### PR TITLE
Fix package installation due to husky setup error

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -356,7 +356,7 @@ PODS:
     - React-jsi (= 0.69.1)
     - React-logger (= 0.69.1)
     - React-perflogger (= 0.69.1)
-  - RNBitmovinPlayer (0.1.0):
+  - RNBitmovinPlayer (0.2.1):
     - BitmovinPlayer (= 3.23.0)
     - React-Core
   - RNCPicker (2.4.2):
@@ -572,7 +572,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: e8b7dd6635cc95689b5db643b5a3848f1e05b30b
   React-runtimeexecutor: 27f468c5576eaf05ffb7a907528e44c75a3fcbae
   ReactCommon: e30ec17dfb1d4c4f3419eac254350d6abca6d5a2
-  RNBitmovinPlayer: fa9321844db8490b4406397e8270f225005d2cee
+  RNBitmovinPlayer: b12b6bc48fb8a6afe2249c2343ccf1dc9f5901be
   RNCPicker: 0250e95ad170569a96f5b0555cdd5e65b9084dca
   RNScreens: 4a1af06327774490d97342c00aee0c2bafb497b7
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",
     "bootstrap": "yarn && yarn example && yarn pods",
-    "postinstall": "husky install"
+    "prepare": "husky install"
   },
   "keywords": [
     "react-native",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmovin-player-react-native",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Official React Native bindings for Bitmovin's mobile Player SDKs.",
   "main": "lib/index.js",
   "module": "lib/index.mjs",


### PR DESCRIPTION
This PR is related to #17 

It moves husky setup from `postinstall` to `prepare` to avoid installation errors. You can read more about this issue [here](https://github.com/typicode/husky/issues/884) and [here](https://sonspring.com/journal/husky-v5-and-npm-prepare).