### PR TITLE
Update dependencies

### DIFF
--- a/RNBitmovinPlayer.podspec
+++ b/RNBitmovinPlayer.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "BitmovinPlayer", "3.30.0"
+  s.dependency "BitmovinPlayer", "3.32.0"
   s.dependency "BitmovinAnalyticsCollector/Core", "2.9.4"
   s.dependency "BitmovinAnalyticsCollector/BitmovinPlayer", "2.9.4"
   s.ios.dependency "GoogleAds-IMA-iOS-SDK", "3.17.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,6 +53,6 @@ dependencies {
     implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.26.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
     implementation 'com.bitmovin.analytics:collector-bitmovin-player:2.12.1'
-    implementation 'com.bitmovin.player:player:3.25.2'
+    implementation 'com.bitmovin.player:player:3.26.1'
     implementation 'com.facebook.react:react-native:+'
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - BitmovinAnalyticsCollector/Core
     - BitmovinPlayer (~> 3.0)
   - BitmovinAnalyticsCollector/Core (2.9.4)
-  - BitmovinPlayer (3.30.0)
+  - BitmovinPlayer (3.32.0)
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
@@ -337,7 +337,7 @@ PODS:
   - RNBitmovinPlayer (0.4.0):
     - BitmovinAnalyticsCollector/BitmovinPlayer (= 2.9.4)
     - BitmovinAnalyticsCollector/Core (= 2.9.4)
-    - BitmovinPlayer (= 3.30.0)
+    - BitmovinPlayer (= 3.32.0)
     - GoogleAds-IMA-iOS-SDK (= 3.17.0)
     - GoogleAds-IMA-tvOS-SDK (= 4.6.1)
     - React-Core
@@ -508,7 +508,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   BitmovinAnalyticsCollector: e80b02754019632340556a509fc4268dbad6f219
-  BitmovinPlayer: ae0fa04c43ea513d4fb2ae93fc2d5f2a271d92cc
+  BitmovinPlayer: 7137b245f61da7bbde429a7a0c0075473dc01890
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 1d2f3470dfd56717030d0855f8332361bbd85236
@@ -554,7 +554,7 @@ SPEC CHECKSUMS:
   React-RCTText: 16122ecd9be53be613b2206a13e5cf987835c8cf
   React-runtimeexecutor: 44fe73dca7d31245dfc031971a2ce14085c8d5fe
   ReactCommon: 3f6173ad12133f7e032f4c8d061dba181115c1c0
-  RNBitmovinPlayer: ab80bfc1875d17d754c06e091f61d691752cadbf
+  RNBitmovinPlayer: 90d49a48e2286a095f50340a48f2e2f2d50f95cd
   RNCPicker: 0250e95ad170569a96f5b0555cdd5e65b9084dca
   RNScreens: 4a1af06327774490d97342c00aee0c2bafb497b7
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608


### PR DESCRIPTION
This PR bumps the native player SDKs to v3.25.1 and v3.32.0 for Android and iOS, respectively.