### PR TITLE
Fix `FullscreenHandler` interface visibility

### DIFF
--- a/example/src/screens/BasicFullscreenHandling.tsx
+++ b/example/src/screens/BasicFullscreenHandling.tsx
@@ -7,9 +7,9 @@ import {
   PlayerView,
   SourceType,
   AudioSession,
+  FullscreenHandler,
 } from 'bitmovin-player-react-native';
 import { useTVGestures } from '../hooks';
-import { FullscreenHandler } from '../../../src/ui/fullscreenhandler';
 
 function prettyPrint(header: string, obj: any) {
   console.log(header, JSON.stringify(obj, null, 2));

--- a/src/components/PlayerView/index.tsx
+++ b/src/components/PlayerView/index.tsx
@@ -11,7 +11,7 @@ import { PlayerViewEvents } from './events';
 import { NativePlayerView } from './native';
 import { Player } from '../../player';
 import { useProxy } from '../../hooks/useProxy';
-import { FullscreenHandler } from '../../ui/fullscreenhandler';
+import { FullscreenHandler } from '../../ui';
 import { FullscreenHandlerBridge } from '../../ui/fullscreenhandlerbridge';
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export * from './player';
 export * from './source';
 export * from './subtitleTrack';
 export * from './styleConfig';
+export * from './ui';

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,1 @@
+export * from './fullscreenhandler';


### PR DESCRIPTION
This PR fixes the missing `export` for `FullscreenHandler`.

Closes #75