### PR TITLE
Replace deprecated/removed Platform.isTVOS API usage

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -44,6 +44,8 @@ export type RootStackParamsList = {
 
 const RootStack = createNativeStackNavigator();
 
+const isTVOS = Platform.OS === 'ios' && Platform.isTV;
+
 export default function App() {
   var stackParams = {
     data: [
@@ -74,7 +76,7 @@ export default function App() {
     ],
   };
 
-  if (!Platform.isTVOS) {
+  if (!isTVOS) {
     stackParams.data.push({
       title: 'Custom HTML UI',
       routeName: 'CustomHtmlUI',
@@ -153,7 +155,7 @@ export default function App() {
           component={BasicPictureInPicture}
           options={{ title: 'Basic Picture in Picture' }}
         />
-        {!Platform.isTVOS && (
+        {!isTVOS && (
           <RootStack.Screen
             name="CustomHtmlUI"
             component={CustomHtmlUI}


### PR DESCRIPTION
`Platform.isTVOS` is deprecated API and in newer versions of RN even already removed.
The usage is replaced by an equivalent i.e. if the current OS is iOS and a TV 