### PR TITLE
Fix passing of props to the BasicFullscreenHandling

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Platform } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { SourceType } from 'bitmovin-player-react-native';
 import Button from './components/Button';
 import ExamplesList from './screens/ExamplesList';
@@ -29,7 +30,9 @@ export type RootStackParamsList = {
   BasicPlayback: undefined;
   BasicDrmPlayback: undefined;
   BasicPictureInPicture: undefined;
-  BasicFullscreenHandling: undefined;
+  BasicFullscreenHandling: {
+    navigation: NativeStackNavigationProp<RootStackParamsList>;
+  };
   SubtitlePlayback: undefined;
   CustomPlaybackForm: undefined;
   CustomPlayback: {

--- a/example/src/screens/BasicFullscreenHandling.tsx
+++ b/example/src/screens/BasicFullscreenHandling.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { View, Platform, StyleSheet, StatusBar } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useFocusEffect } from '@react-navigation/native';
 import {
   Event,
@@ -10,6 +11,12 @@ import {
   FullscreenHandler,
 } from 'bitmovin-player-react-native';
 import { useTVGestures } from '../hooks';
+import { RootStackParamsList } from '../App';
+
+type BasicFullscreenHandlingProps = NativeStackScreenProps<
+  RootStackParamsList,
+  'BasicFullscreenHandling'
+>;
 
 function prettyPrint(header: string, obj: any) {
   console.log(header, JSON.stringify(obj, null, 2));
@@ -41,7 +48,9 @@ class SampleFullscreenHandler implements FullscreenHandler {
     console.log('exit fullscreen');
   }
 }
-export default function BasicFullscreenHandling({ navigation }) {
+export default function BasicFullscreenHandling({
+  navigation,
+}: BasicFullscreenHandlingProps) {
   useTVGestures();
 
   const player = usePlayer();


### PR DESCRIPTION
There is a typescript error in the `BasicFullscreenHandling` screen, because of missing type information on the props.