### PR TITLE
Replace GH token for update PR creation workflow

### DIFF
--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -19,7 +19,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Replace the used GH token, so the CI is triggered by the automatic updates.