### PR TITLE
Update android player to 3.37.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,6 +53,6 @@ dependencies {
     implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.26.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
     implementation 'com.bitmovin.analytics:collector-bitmovin-player:2.12.1'
-    implementation 'com.bitmovin.player:player:3.36.0'
+    implementation 'com.bitmovin.player:player:3.37.0'
     implementation 'com.facebook.react:react-native:+'
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         buildToolsVersion = "31.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 33
+        targetSdkVersion = 33
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
             ndkVersion = "24.0.8215888"


### PR DESCRIPTION
Automated android player version update to 3.37.0

EDIT: The update includes dependency[ requirements](https://developer.android.com/build/publish-library/prep-lib-release#choose-mincompilesdk) for a higher compile SDK version. The library is already on API level 33, but the sample app was not and thus had to be updated.