### PR TITLE
Fix unsafe config property access

### DIFF
--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewManager.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewManager.kt
@@ -143,7 +143,6 @@ class RNPlayerViewManager(private val context: ReactApplicationContext) : Simple
                 Commands.ATTACH_FULLSCREEN_BRIDGE.ordinal -> args?.getString(1)?.let { fullscreenBridgeId ->
                     attachFullscreenBridge(view, fullscreenBridgeId)
                 }
-
                 else -> {}
             }
         }
@@ -165,7 +164,8 @@ class RNPlayerViewManager(private val context: ReactApplicationContext) : Simple
     private fun attachPlayer(view: RNPlayerView, playerId: NativeId?, playerConfig: ReadableMap?) {
         Handler(Looper.getMainLooper()).post {
             val player = getPlayerModule()?.getPlayer(playerId)
-            playerConfig?.getMap("playbackConfig")
+            playerConfig
+                ?.getMap("playbackConfig")
                 ?.getBooleanOrNull("isPictureInPictureEnabled")
                 ?.let {
                     pictureInPictureHandler.isPictureInPictureEnabled = it

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewManager.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewManager.kt
@@ -4,6 +4,7 @@ import android.os.Handler
 import android.os.Looper
 import android.view.ViewGroup.LayoutParams
 import com.bitmovin.player.PlayerView
+import com.bitmovin.player.reactnative.extensions.getBooleanOrNull
 import com.bitmovin.player.reactnative.extensions.getModule
 import com.bitmovin.player.reactnative.ui.FullscreenHandlerBridge
 import com.bitmovin.player.reactnative.ui.FullscreenHandlerModule
@@ -142,6 +143,7 @@ class RNPlayerViewManager(private val context: ReactApplicationContext) : Simple
                 Commands.ATTACH_FULLSCREEN_BRIDGE.ordinal -> args?.getString(1)?.let { fullscreenBridgeId ->
                     attachFullscreenBridge(view, fullscreenBridgeId)
                 }
+
                 else -> {}
             }
         }
@@ -163,10 +165,12 @@ class RNPlayerViewManager(private val context: ReactApplicationContext) : Simple
     private fun attachPlayer(view: RNPlayerView, playerId: NativeId?, playerConfig: ReadableMap?) {
         Handler(Looper.getMainLooper()).post {
             val player = getPlayerModule()?.getPlayer(playerId)
-            playerConfig?.getMap("playbackConfig")?.getBoolean("isPictureInPictureEnabled")?.let {
-                pictureInPictureHandler.isPictureInPictureEnabled = it
-                view.pictureInPictureHandler = pictureInPictureHandler
-            }
+            playerConfig?.getMap("playbackConfig")
+                ?.getBooleanOrNull("isPictureInPictureEnabled")
+                ?.let {
+                    pictureInPictureHandler.isPictureInPictureEnabled = it
+                    view.pictureInPictureHandler = pictureInPictureHandler
+                }
             if (view.playerView != null) {
                 view.player = player
             } else {

--- a/android/src/main/java/com/bitmovin/player/reactnative/extensions/ReadableMapExtension.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/extensions/ReadableMapExtension.kt
@@ -4,5 +4,4 @@ import com.facebook.react.bridge.ReadableMap
 
 fun ReadableMap.getBooleanOrNull(
     key: String
-): Boolean? = takeIf { hasKey(key) }
-    ?.getBoolean(key)
+): Boolean? = takeIf { hasKey(key) }?.getBoolean(key)

--- a/android/src/main/java/com/bitmovin/player/reactnative/extensions/ReadableMapExtension.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/extensions/ReadableMapExtension.kt
@@ -1,0 +1,8 @@
+package com.bitmovin.player.reactnative.extensions
+
+import com.facebook.react.bridge.ReadableMap
+
+fun ReadableMap.getBooleanOrNull(
+    key: String
+): Boolean? = takeIf { hasKey(key) }
+    ?.getBoolean(key)


### PR DESCRIPTION
If the `isPictureInPictureEnabled` property is not defined in the config, the access fails because of the missing check on the presents of the property.

This PR:
- Introduces an extension function for save boolean property access
- Fixes the bug where `isPictureInPictureEnabled` is not access safely