### PR TITLE
Expose SourceConfig metadata api

### DIFF
--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -29,6 +29,7 @@ import com.bitmovin.player.reactnative.extensions.toReadableArray
 import com.bitmovin.player.reactnative.extensions.getProperty
 import com.bitmovin.player.reactnative.extensions.setProperty
 import com.facebook.react.bridge.*
+import com.bitmovin.player.reactnative.extensions.toReadableMap
 import java.util.UUID
 
 /**
@@ -302,7 +303,7 @@ class JsonConverter {
             json.putBoolean("isActive", source.isActive)
             json.putBoolean("isAttachedToPlayer", source.isAttachedToPlayer)
             json.putInt("loadingState", source.loadingState.ordinal)
-            json.putNull("metadata")
+            json.putMap("metadata", source.config.metadata?.toReadableMap())
             return json
         }
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -265,6 +265,11 @@ class JsonConverter {
             if (json.hasKey("thumbnailTrack")) {
                 config.thumbnailTrack = toThumbnailTrack(json.getString("thumbnailTrack"))
             }
+            if (json.hasKey("metadata")) {
+                config.metadata = json.getMap("metadata")
+                    ?.toHashMap()
+                    ?.mapValues { entry -> entry.value as String }
+            }
             return config
         }
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/extensions/ReadableMap.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/extensions/ReadableMap.kt
@@ -1,0 +1,19 @@
+package com.bitmovin.player.reactnative.extensions
+
+import com.facebook.react.bridge.*
+
+inline fun <reified T> Map<String, T>.toReadableMap(): ReadableMap = Arguments.createMap().apply {
+    forEach {
+        when (T::class) {
+            Boolean::class -> putBoolean(it.key, it.value as Boolean)
+            String::class -> putString(it.key, it.value as String)
+            Double::class -> putDouble(it.key, it.value as Double)
+            Int::class -> putInt(it.key, it.value as Int)
+            ReadableArray::class -> putArray(it.key, it.value as ReadableArray)
+            ReadableMap::class -> putMap(it.key, it.value as ReadableMap)
+            WritableArray::class -> putArray(it.key, it.value as ReadableArray)
+            WritableMap::class -> putMap(it.key, it.value as ReadableMap)
+            else -> putNull(it.key)
+        }
+    }
+}

--- a/example/src/screens/BasicPlayback.tsx
+++ b/example/src/screens/BasicPlayback.tsx
@@ -31,6 +31,7 @@ export default function BasicPlayback() {
           'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/poster.jpg',
         thumbnailTrack:
           'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/thumbnails/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.vtt',
+        metadata: { platform: Platform.OS },
       });
       return () => {
         player.destroy();

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -249,6 +249,9 @@ extension RCTConvert {
         if let thumbnailTrack = json["thumbnailTrack"] as? String {
             sourceConfig.thumbnailTrack = RCTConvert.thumbnailTrack(thumbnailTrack)
         }
+        if let metadata = json["metadata"] as? [String: String] {
+            sourceConfig.metadata = metadata
+        }
         return sourceConfig
     }
 

--- a/src/source.ts
+++ b/src/source.ts
@@ -83,7 +83,7 @@ export interface SourceConfig extends NativeInstanceConfig {
    */
   thumbnailTrack?: string;
   /**
-   * The optional custom metadata. Also sent to the cast receiver when loading the [Source].
+   * The optional custom metadata. Also sent to the cast receiver when loading the Source.
    */
   metadata?: Record<string, string>;
 }

--- a/src/source.ts
+++ b/src/source.ts
@@ -82,6 +82,10 @@ export interface SourceConfig extends NativeInstanceConfig {
    * External thumbnails to be added into the player.
    */
   thumbnailTrack?: string;
+  /**
+   * The optional custom metadata. Also sent to the cast receiver when loading the [Source].
+   */
+  metadata?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
## Problem
React Native SDK doesn't expose `SourceConfig`'s metadata API yet.

## Changes
- Expose `SourceConfig`'s metadata API
- Create `toReadableMap` extension function (based on the existing `toReadableArray`)