### PR TITLE
Use specific flipper version

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -253,14 +253,14 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
-    debugImplementation("com.facebook.flipper:flipper:+") {
+    debugImplementation("com.facebook.flipper:flipper:$FLIPPER_VERSION") {
         exclude group:'com.facebook.fbjni'
     }
-    debugImplementation("com.facebook.flipper:flipper-network-plugin:+") {
+    debugImplementation("com.facebook.flipper:flipper-network-plugin:$FLIPPER_VERSION") {
         exclude group:'com.facebook.flipper'
         exclude group:'com.squareup.okhttp3', module:'okhttp'
     }
-    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:+") {
+    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:0.182.0") {
         exclude group:'com.facebook.flipper'
     }
     implementation project(':bitmovin-player-react-native')

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
 
 android.useAndroidX=true
 android.enableJetifier=true
-FLIPPER_VERSION=0.125.0
+FLIPPER_VERSION=0.191.0
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64


### PR DESCRIPTION
## Problem
Flipper version was unspecified, which caused example project to suddenly not be buildable. There seems to be a problem with the latest version, so I specified the latest version that is working.

Interestingly the flipper changelog currently doesn't include the latest 2 releases ([0.191.1](https://github.com/facebook/flipper/releases/tag/v0.191.1) and [0.192.0](https://github.com/facebook/flipper/releases/tag/v0.192.0))

## Changes 
- Specify the flipper version
- Specify  `flipper-fresco-plugin`