### PR TITLE
Don't force react native version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,5 +55,6 @@ dependencies {
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
     implementation 'com.bitmovin.analytics:collector-bitmovin-player:2.12.1'
     implementation 'com.bitmovin.player:player:3.39.0'
-    implementation 'com.facebook.react:react-native:0.69.10'
+    //noinspection GradleDynamicVersion
+    implementation 'com.facebook.react:react-native:+' // From node_modules
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@types/lodash.omit": "4.5.0",
     "@types/react": "18.0.15",
     "@types/react-native": "0.69.7",
+    "react-native": "0.69.7",
     "babel-plugin-module-resolver": "4.1.0",
     "commitlint": "17.1.2",
     "eslint": "8.24.0",
@@ -69,9 +70,7 @@
     "typescript": "4.8.4"
   },
   "dependencies": {
-    "lodash.omit": "4.5.0",
-    "react-native": "0.69.10",
-    "react": "18.0.0"
+    "lodash.omit": "4.5.0"
   },
   "peerDependencies": {
     "react": ">=17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7520,10 +7520,10 @@ react-native-gradle-plugin@^0.0.7:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz#96602f909745239deab7b589443f14fce5da2056"
   integrity sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g==
 
-react-native@0.69.10:
-  version "0.69.10"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.69.10.tgz#5111f5e103eedde95e77f4d0ba0c9864f7a149d4"
-  integrity sha512-zBsJmFsjyx9zC0JDRH6F6hib3BWbIu65EYPsJBQMDHMSGJ9fL7C6ZV49O7Abockn/dbCHhIWpiSyCuda/bhV8g==
+react-native@0.69.7:
+  version "0.69.7"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.69.7.tgz#891ba4ed7722f1ab570099ce097c355bef8ceb05"
+  integrity sha512-T3z2utgRcE/+mMML3Wg4vvpnFoGWJcqWskq+8vdFS4ASM1zYg5Hab5vPlKZp9uncD8weYiGsYwkWXzrvZrsayQ==
   dependencies:
     "@jest/create-cache-key-function" "^27.0.1"
     "@react-native-community/cli" "^8.0.4"
@@ -7571,13 +7571,6 @@ react-shallow-renderer@16.15.0:
   dependencies:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
-
-react@18.0.0:
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.0.0.tgz#b468736d1f4a5891f38585ba8e8fb29f91c3cb96"
-  integrity sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==
-  dependencies:
-    loose-envify "^1.1.0"
 
 read-pkg-up@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
## Problem
Our project specified a `react-native` version in dependencies, making it not compatible for apps based on other react-native versions. 
Instead, a react-native version should be specified in devDependencies.

## Changes
- Remove `react-native` and `react` form dependencies
- Add `react-native` to devDependencies
