### PR TITLE
fix: workaround React native command not sent

### DIFF
--- a/src/components/PlayerView/index.tsx
+++ b/src/components/PlayerView/index.tsx
@@ -57,7 +57,6 @@ function dispatch(command: string, node: NodeHandle, ...args: any[]) {
     Platform.OS === 'android'
       ? (UIManager as any).NativePlayerView.Commands[command].toString()
       : UIManager.getViewManagerConfig('NativePlayerView').Commands[command];
-  //console.log("dispatching command %s", command)
   UIManager.dispatchViewManagerCommand(
     node,
     commandId,
@@ -76,7 +75,6 @@ export function PlayerView({
   customMessageHandler,
   ...props
 }: PlayerViewProps) {
-  // Native view reference.
   const fakeStateUpdater = useState(1)[1];
   const workaroundViewManagerCommandNotSent = useCallback(() => {
     setTimeout(


### PR DESCRIPTION
React Native's `UIManager.dispatchViewManagerCommand` sometimes (~3/4 times on emulator, very rarely on recent devices) doesn't sent native commands. They get stuck until the next UI refresh.

This issue should be fixed in the latest React Native release but our SDK needs significant work to update to this version.

Until the React Native version is updated, force UI redraws after dispatching commands to force them to be received by the native side.

Player issue: https://github.com/bitmovin/bitmovin-player-react-native/issues/163
RN issue: https://github.com/microsoft/react-native-windows/issues/7543