### PR TITLE
Add missing APIs for analytics collector

### DIFF
--- a/android/src/main/java/com/bitmovin/player/reactnative/AnalyticsModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/AnalyticsModule.kt
@@ -129,7 +129,7 @@ class AnalyticsModule(private val context: ReactApplicationContext) : ReactConte
     @ReactMethod
     fun addSourceMetadata(nativeId: NativeId, playerId: NativeId?, json: ReadableMap?) {
         uiManager()?.addUIBlock { _ ->
-            val playerSource = playerModule()?.getPlayer(playerId)?.source ?: return
+            val playerSource = playerModule()?.getPlayer(playerId)?.source ?: return@addUIBlock
             JsonConverter.toAnalyticsSourceMetadata(json)?.let { sourceMetadata ->
                 collectors[nativeId]?.addSourceMetadata(playerSource, sourceMetadata)
             }

--- a/android/src/main/java/com/bitmovin/player/reactnative/AnalyticsModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/AnalyticsModule.kt
@@ -126,6 +126,17 @@ class AnalyticsModule(private val context: ReactApplicationContext) : ReactConte
         }
     }
 
+    @ReactMethod
+    fun addSourceMetadata(nativeId: NativeId, playerId: NativeId?, json: ReadableMap?) {
+        uiManager()?.addUIBlock { _ ->
+            playerModule()?.getPlayer(playerId)?.source?.let { playerSource ->
+                JsonConverter.toAnalyticsSourceMetadata(json)?.let { sourceMetadata ->
+                    collectors[nativeId]?.addSourceMetadata(playerSource, sourceMetadata)
+                }
+            }
+        }
+    }
+
     /**
      * Gets the current user Id for a `BitmovinPlayerCollector` instance.
      * @param nativeId Native Id of the the collector instance.

--- a/android/src/main/java/com/bitmovin/player/reactnative/AnalyticsModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/AnalyticsModule.kt
@@ -129,10 +129,9 @@ class AnalyticsModule(private val context: ReactApplicationContext) : ReactConte
     @ReactMethod
     fun addSourceMetadata(nativeId: NativeId, playerId: NativeId?, json: ReadableMap?) {
         uiManager()?.addUIBlock { _ ->
-            playerModule()?.getPlayer(playerId)?.source?.let { playerSource ->
-                JsonConverter.toAnalyticsSourceMetadata(json)?.let { sourceMetadata ->
-                    collectors[nativeId]?.addSourceMetadata(playerSource, sourceMetadata)
-                }
+            val playerSource = playerModule()?.getPlayer(playerId)?.source ?: return
+            JsonConverter.toAnalyticsSourceMetadata(json)?.let { sourceMetadata ->
+                collectors[nativeId]?.addSourceMetadata(playerSource, sourceMetadata)
             }
         }
     }

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -784,6 +784,9 @@ class JsonConverter {
                     customData.setProperty("customData${n}", customDataN)
                 }
             }
+            it.getString("experimentName")?.let { experimentName ->
+                customData.experimentName = experimentName
+            }
             customData
         }
 
@@ -799,6 +802,9 @@ class JsonConverter {
                 it.getProperty<String>("customData${n}")?.let { customDataN ->
                     json.putString("customData${n}", customDataN)
                 }
+            }
+            it.experimentName?.let { experimentName ->
+                json.putString("experimentName", experimentName)
             }
             json
         }

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -1,6 +1,7 @@
 package com.bitmovin.player.reactnative.converter
 
 import com.bitmovin.analytics.BitmovinAnalyticsConfig
+import com.bitmovin.analytics.config.SourceMetadata
 import com.bitmovin.analytics.data.CustomData
 import com.bitmovin.player.api.DeviceDescription.DeviceName
 import com.bitmovin.player.api.DeviceDescription.ModelName
@@ -807,6 +808,28 @@ class JsonConverter {
                 json.putString("experimentName", experimentName)
             }
             json
+        }
+
+        @JvmStatic
+        fun toAnalyticsSourceMetadata(json: ReadableMap?): SourceMetadata? = json?.let {
+            val sourceMetadata = SourceMetadata(
+                    title = it.getString("title"),
+                    videoId = it.getString("videoId"),
+                    cdnProvider = it.getString("cdnProvider"),
+                    path = it.getString("path"),
+                    isLive = it.getBoolean("isLive")
+            )
+
+            for (n in 1..30) {
+                it.getString("customData${n}")?.let { customDataN ->
+                    sourceMetadata.setProperty("customData${n}", customDataN)
+                }
+            }
+            it.getString("experimentName")?.let { experimentName ->
+                sourceMetadata.experimentName = experimentName
+            }
+
+            sourceMetadata
         }
 
         /**

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -828,7 +828,6 @@ class JsonConverter {
             it.getString("experimentName")?.let { experimentName ->
                 sourceMetadata.experimentName = experimentName
             }
-
             sourceMetadata
         }
 

--- a/ios/AnalyticsModule.m
+++ b/ios/AnalyticsModule.m
@@ -10,5 +10,6 @@ RCT_EXTERN_METHOD(setCustomDataOnce:(NSString *)nativeId json:(nullable id)json)
 RCT_EXTERN_METHOD(setCustomData:(NSString *)nativeId playerId:(nullable NSString *)playerId json:(nullable id)json)
 RCT_EXTERN_METHOD(getCustomData:(NSString *)nativeId playerId:(nullable NSString *)playerId resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(getUserId:(NSString *)nativeId resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(addSourceMetadata:(NSString *)nativeId playerId:(nullable NSString *)playerId json:(nullable id)json)
 
 @end

--- a/ios/AnalyticsModule.swift
+++ b/ios/AnalyticsModule.swift
@@ -191,4 +191,30 @@ class AnalyticsModule: NSObject, RCTBridgeModule {
             resolve(collector.getUserId())
         }
     }
+
+    /**
+     Applies the source metadata for the current source via the `BitmovinPlayerCollector` instance.
+     - Parameter nativeId: Native Id of the collector instance.
+     - Parameter playerId: Native Id of the player instance.
+     - Parameter json: Custom data config json.
+     */
+    @objc(addSourceMetadata:playerId:json:)
+    func addSourceMetadata(
+        _ nativeId: NativeId,
+        playerId: NativeId?,
+        json: Any?
+    ) {
+        bridge.uiManager.addUIBlock { [weak self] _, _ in
+            guard
+                let collector = self?.collectors[nativeId],
+                let sourceMetadata = RCTConvert.analyticsSourceMetadata(json),
+                let playerId = playerId,
+                let player = self?.bridge[PlayerModule.self]?.retrieve(playerId),
+                let source = player.source
+            else {
+                return
+            }
+            collector.apply(sourceMetadata: sourceMetadata, for: source)
+        }
+    }
 }

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -735,6 +735,29 @@ extension RCTConvert {
         json["experimentName"] = analyticsCustomData.experimentName
         return json
     }
+
+    /**
+     Utility method to get an analytics `SourceMetadata` value from a JS object.
+     - Parameter json: JS object.
+     - Returns: The associated `SourceMetadata` value or nil.
+     */
+    static func analyticsSourceMetadata(_ json: Any?) -> SourceMetadata? {
+        guard let json = json as? [String: Any?] else {
+            return nil
+        }
+
+        let customData = analyticsCustomData(json)
+
+        return SourceMetadata(
+            videoId: json["videoId"] as? String,
+            title: json["title"] as? String,
+            path: json["path"] as? String,
+            isLive: json["isLive"] as? Bool,
+            cdnProvider: json["cdnProvider"] as? String,
+            customData: customData ?? CustomData()
+        )
+    }
+
     /**
      Utility method to compute a JS value from a `VideoQuality` object.
      - Parameter videoQuality `VideoQuality` object to be converted.

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -644,6 +644,7 @@ extension RCTConvert {
         config.customData28 = json["customData28"] as? String
         config.customData29 = json["customData29"] as? String
         config.customData30 = json["customData30"] as? String
+        config.experimentName = json["experimentName"] as? String
         return config
     }
 
@@ -686,7 +687,8 @@ extension RCTConvert {
             customData27: json["customData27"] as? String,
             customData28: json["customData28"] as? String,
             customData29: json["customData29"] as? String,
-            customData30: json["customData30"] as? String
+            customData30: json["customData30"] as? String,
+            experimentName: json["experimentName"] as? String
         )
     }
 
@@ -730,6 +732,7 @@ extension RCTConvert {
         json["customData28"] = analyticsCustomData.customData28
         json["customData29"] = analyticsCustomData.customData29
         json["customData30"] = analyticsCustomData.customData30
+        json["experimentName"] = analyticsCustomData.experimentName
         return json
     }
     /**

--- a/src/analytics/collector.ts
+++ b/src/analytics/collector.ts
@@ -1,6 +1,6 @@
 import { NativeModules } from 'react-native';
 import NativeInstance from '../nativeInstance';
-import { AnalyticsConfig, CustomDataConfig } from './config';
+import { AnalyticsConfig, CustomDataConfig, SourceMetadata } from './config';
 
 const AnalyticsModule = NativeModules.AnalyticsModule;
 
@@ -101,5 +101,19 @@ export class AnalyticsCollector extends NativeInstance<AnalyticsConfig> {
    */
   getUserId = async (): Promise<string> => {
     return AnalyticsModule.getUserId(this.nativeId);
+  };
+
+  /**
+   * Adds source metadata for the current source loaded into the player.
+   * This method should be called every time a new source is loaded into the player to ensure
+   * that the analytics data is correct.
+   * @param sourceMetadata - Source metadata to set.
+   */
+  addSourceMetadata = (sourceMetadata: SourceMetadata) => {
+    return AnalyticsModule.addSourceMetadata(
+      this.nativeId,
+      this.playerId,
+      sourceMetadata
+    );
   };
 }

--- a/src/analytics/config.ts
+++ b/src/analytics/config.ts
@@ -240,7 +240,7 @@ export interface SourceMetadata extends CustomDataConfig {
   isLive?: boolean;
 
   /**
-   * CDN Provide that the video playback session is using
+   * CDN Provider that the video playback session is using
    */
   cdnProvider?: String;
 }

--- a/src/analytics/config.ts
+++ b/src/analytics/config.ts
@@ -215,4 +215,9 @@ export interface CustomDataConfig {
    * Optional free-form custom data
    */
   customData30?: string;
+
+  /**
+   * Optional free-form label
+   */
+  experimentName?: string;
 }

--- a/src/analytics/config.ts
+++ b/src/analytics/config.ts
@@ -28,10 +28,6 @@ export interface AnalyticsConfig
    */
   customUserId?: string;
   /**
-   * Experiment name needed for A/B testing.
-   */
-  experimentName?: string;
-  /**
    * ID of the video in the CMS system.
    */
   videoId?: string;
@@ -217,7 +213,34 @@ export interface CustomDataConfig {
   customData30?: string;
 
   /**
-   * Optional free-form label
+   * Experiment name needed for A/B testing.
    */
   experimentName?: string;
+}
+
+export interface SourceMetadata extends CustomDataConfig {
+  /**
+   * ID of the video in the CMS system
+   */
+  videoId?: String;
+
+  /**
+   * Human readable title of the video asset currently playing
+   */
+  title?: String;
+
+  /**
+   * Breadcrumb path to show where in the app the user is
+   */
+  path?: String;
+
+  /**
+   * Flag to see if stream is live before stream metadata is available
+   */
+  isLive?: boolean;
+
+  /**
+   * CDN Provide that the video playback session is using
+   */
+  cdnProvider?: String;
 }


### PR DESCRIPTION
This PR adds missing API for the analytics integration:
- `CustomData.experimentName` property
- `Player.analyticsCollector.addSourceMetadata` API and related `SourceMetadata` type