### PR TITLE
Player sometimes plays sound but no video

### DIFF
--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -82,6 +82,16 @@ private val EVENT_CLASS_TO_REACT_NATIVE_NAME_MAPPING_UI = mapOf<KClass<out Event
 @SuppressLint("ViewConstructor")
 class RNPlayerView(val context: ReactApplicationContext) : LinearLayout(context),
     LifecycleEventListener, View.OnLayoutChangeListener, RNPictureInPictureDelegate {
+
+    init {
+        // React Native has a bug that dynamically added views sometimes aren't laid out again properly.
+        // Since we dynamically add and remove SurfaceView under the hood this caused the player
+        // to suddenly not show the video anymore because SurfaceView was not laid out properly.
+        // Bitmovin player issue: https://github.com/bitmovin/bitmovin-player-react-native/issues/180
+        // React Native layout issue: https://github.com/facebook/react-native/issues/17968
+        getViewTreeObserver().addOnGlobalLayoutListener { requestLayout() }
+    }
+
     /**
      * Relays the provided set of events, emitted by the player, together with the associated name
      * to the `eventOutput` callback.


### PR DESCRIPTION
## Problem (PRN-26)
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
_Sometimes video suddenly doesn't play anymore, but audio continues to play._
Issue: https://github.com/bitmovin/bitmovin-player-react-native/issues/180

Turns out that this was influenced by a React Native issue, reported here: https://github.com/facebook/react-native/issues/17968

In our case the native `PlayerView` adds and removes `SurfaceView` under the hood. After screen rotation newly added SurfaceView's size wasn't calculated properly, which caused no video to be displayed.

## Changes
- Add a [workaround](https://github.com/facebook/react-native/issues/17968#issuecomment-549780002) that triggers a new layout measurement
