### PR TITLE
Update android player to 3.42.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,8 +53,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
-    implementation 'com.bitmovin.analytics:collector-bitmovin-player:2.12.1'
-    implementation 'com.bitmovin.player:player:3.40.0'
+    implementation 'com.bitmovin.player:player:3.42.0'
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+' // From node_modules
 }

--- a/android/src/main/java/com/bitmovin/player/reactnative/AnalyticsModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/AnalyticsModule.kt
@@ -1,6 +1,7 @@
 package com.bitmovin.player.reactnative
 
-import com.bitmovin.analytics.bitmovin.player.BitmovinPlayerCollector
+import android.util.Log
+import com.bitmovin.analytics.bitmovin.player.api.IBitmovinPlayerCollector
 import com.bitmovin.player.reactnative.converter.JsonConverter
 import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
@@ -13,7 +14,7 @@ class AnalyticsModule(private val context: ReactApplicationContext) : ReactConte
     /**
      * In-memory mapping from `nativeId`s to `BitmovinPlayerCollector` instances.
      */
-    private val collectors: Registry<BitmovinPlayerCollector> = mutableMapOf()
+    private val collectors: Registry<IBitmovinPlayerCollector> = mutableMapOf()
 
     /**
      * JS exported module name.
@@ -25,7 +26,7 @@ class AnalyticsModule(private val context: ReactApplicationContext) : ReactConte
      * @param nativeId `BitmovinPlayerCollector` instance ID.
      * @return The associated `BitmovinPlayerCollector` instance or `null`.
      */
-    fun getCollector(nativeId: NativeId?): BitmovinPlayerCollector? {
+    fun getCollector(nativeId: NativeId?): IBitmovinPlayerCollector? {
         if (nativeId == null) {
             return null
         }
@@ -40,7 +41,7 @@ class AnalyticsModule(private val context: ReactApplicationContext) : ReactConte
     fun initWithConfig(nativeId: NativeId, config: ReadableMap?) {
         uiManager()?.addUIBlock { _ ->
             JsonConverter.toAnalyticsConfig(config)?.let {
-                collectors[nativeId] = BitmovinPlayerCollector(it, context)
+                collectors[nativeId] = IBitmovinPlayerCollector.create(it, context)
             }
         }
     }
@@ -106,8 +107,20 @@ class AnalyticsModule(private val context: ReactApplicationContext) : ReactConte
     @ReactMethod
     fun setCustomData(nativeId: NativeId, playerId: NativeId?, json: ReadableMap?) {
         uiManager()?.addUIBlock { _ ->
-            JsonConverter.toAnalyticsCustomData(json)?.let {
-                collectors[nativeId]?.customData = it
+            val source = playerModule()?.getPlayer(playerId)?.source
+            val collector = collectors[nativeId]
+            val customData = JsonConverter.toAnalyticsCustomData(json)
+            when {
+                source == null -> Log.d(
+                    "[AnalyticsModule]", "Could not find source for player ($playerId)"
+                )
+                collector == null -> Log.d(
+                    "[AnalyticsModule]", "Could not find analytics collector ($nativeId)"
+                )
+                customData == null -> Log.d(
+                    "[AnalyticsModule]", "Could not convert custom data, thus they are not applied to the active source for the player ($playerId) with the collector ($nativeId)"
+                )
+                else -> collector.setCustomData(source,  customData)
             }
         }
     }
@@ -120,8 +133,16 @@ class AnalyticsModule(private val context: ReactApplicationContext) : ReactConte
     @ReactMethod
     fun getCustomData(nativeId: NativeId, playerId: NativeId?, promise: Promise) {
         uiManager()?.addUIBlock { _ ->
-            collectors[nativeId]?.let {
-                promise.resolve(JsonConverter.fromAnalyticsCustomData(it.customData))
+            val source = playerModule()?.getPlayer(playerId)?.source
+            val collector = collectors[nativeId]
+            when {
+                source == null -> promise.reject(
+                    "[AnalyticsModule]", "Could not find source for player ($playerId)"
+                )
+                collector == null -> promise.reject(
+                    "[AnalyticsModule]", "Could not find analytics collector ($nativeId)"
+                )
+                else -> promise.resolve(JsonConverter.fromAnalyticsCustomData(collector.getCustomData(source)))
             }
         }
     }
@@ -129,9 +150,20 @@ class AnalyticsModule(private val context: ReactApplicationContext) : ReactConte
     @ReactMethod
     fun addSourceMetadata(nativeId: NativeId, playerId: NativeId?, json: ReadableMap?) {
         uiManager()?.addUIBlock { _ ->
-            val playerSource = playerModule()?.getPlayer(playerId)?.source ?: return@addUIBlock
-            JsonConverter.toAnalyticsSourceMetadata(json)?.let { sourceMetadata ->
-                collectors[nativeId]?.addSourceMetadata(playerSource, sourceMetadata)
+            val source = playerModule()?.getPlayer(playerId)?.source
+            val collector = collectors[nativeId]
+            val sourceMetadata = JsonConverter.toAnalyticsSourceMetadata(json)
+            when {
+                source == null -> Log.d(
+                    "[AnalyticsModule]", "Could not find source for player with ID ($playerId)"
+                )
+                collector == null -> Log.d(
+                    "[AnalyticsModule]", "Could not find analytics collector with ID ($nativeId)"
+                )
+                sourceMetadata == null -> Log.d(
+                    "[AnalyticsModule]", "Could not convert source metadata, thus they are not applied to the collector with ID ($nativeId)"
+                )
+                else -> collector.addSourceMetadata(source,  sourceMetadata)
             }
         }
     }

--- a/android/src/main/java/com/bitmovin/player/reactnative/AnalyticsModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/AnalyticsModule.kt
@@ -155,13 +155,13 @@ class AnalyticsModule(private val context: ReactApplicationContext) : ReactConte
             val sourceMetadata = JsonConverter.toAnalyticsSourceMetadata(json)
             when {
                 source == null -> Log.d(
-                    "[AnalyticsModule]", "Could not find source for player with ID ($playerId)"
+                    "[AnalyticsModule]", "Could not find source for player ($playerId)"
                 )
                 collector == null -> Log.d(
-                    "[AnalyticsModule]", "Could not find analytics collector with ID ($nativeId)"
+                    "[AnalyticsModule]", "Could not find analytics collector ($nativeId)"
                 )
                 sourceMetadata == null -> Log.d(
-                    "[AnalyticsModule]", "Could not convert source metadata, thus they are not applied to the collector with ID ($nativeId)"
+                    "[AnalyticsModule]", "Could not convert source metadata, thus they are not applied to the collector ($nativeId)"
                 )
                 else -> collector.addSourceMetadata(source,  sourceMetadata)
             }

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -1,14 +1,22 @@
 package com.bitmovin.player.reactnative.converter
 
 import com.bitmovin.analytics.BitmovinAnalyticsConfig
-import com.bitmovin.analytics.config.SourceMetadata
-import com.bitmovin.analytics.data.CustomData
+import com.bitmovin.analytics.api.CustomData
+import com.bitmovin.analytics.api.SourceMetadata
 import com.bitmovin.player.api.DeviceDescription.DeviceName
 import com.bitmovin.player.api.DeviceDescription.ModelName
 import com.bitmovin.player.api.PlaybackConfig
 import com.bitmovin.player.api.PlayerConfig
 import com.bitmovin.player.api.TweaksConfig
-import com.bitmovin.player.api.advertising.*
+import com.bitmovin.player.api.advertising.Ad
+import com.bitmovin.player.api.advertising.AdBreak
+import com.bitmovin.player.api.advertising.AdConfig
+import com.bitmovin.player.api.advertising.AdData
+import com.bitmovin.player.api.advertising.AdItem
+import com.bitmovin.player.api.advertising.AdQuartile
+import com.bitmovin.player.api.advertising.AdSource
+import com.bitmovin.player.api.advertising.AdSourceType
+import com.bitmovin.player.api.advertising.AdvertisingConfig
 import com.bitmovin.player.api.drm.WidevineConfig
 import com.bitmovin.player.api.event.PlayerEvent
 import com.bitmovin.player.api.event.SourceEvent
@@ -23,14 +31,17 @@ import com.bitmovin.player.api.source.SourceType
 import com.bitmovin.player.api.ui.ScalingMode
 import com.bitmovin.player.api.ui.StyleConfig
 import com.bitmovin.player.reactnative.extensions.getName
-import com.bitmovin.player.reactnative.extensions.putInt
+import com.bitmovin.player.reactnative.extensions.getProperty
 import com.bitmovin.player.reactnative.extensions.putDouble
+import com.bitmovin.player.reactnative.extensions.putInt
+import com.bitmovin.player.reactnative.extensions.setProperty
 import com.bitmovin.player.reactnative.extensions.toList
 import com.bitmovin.player.reactnative.extensions.toReadableArray
-import com.bitmovin.player.reactnative.extensions.getProperty
-import com.bitmovin.player.reactnative.extensions.setProperty
-import com.facebook.react.bridge.*
 import com.bitmovin.player.reactnative.extensions.toReadableMap
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableMap
 import java.util.UUID
 
 /**
@@ -213,7 +224,7 @@ class JsonConverter {
                 ?.mapNotNull(::toAdSource)
                 ?.toTypedArray()
                 ?: return null
-            return AdItem(sources, json?.getString("position") ?: "pre")
+            return AdItem(sources, json.getString("position") ?: "pre")
         }
 
         /**
@@ -545,7 +556,7 @@ class JsonConverter {
                 false
             }
             val format = json.getString("format")
-            if (format != null && format.isNotBlank()) {
+            if (!format.isNullOrBlank()) {
                 return SubtitleTrack(
                     url = url,
                     label = label,
@@ -778,17 +789,20 @@ class JsonConverter {
          * @return The produced `CustomData` or null.
          */
         @JvmStatic
-        fun toAnalyticsCustomData(json: ReadableMap?): CustomData? = json?.let {
-            val customData = CustomData()
-            for (n in 1..30) {
-                it.getString("customData${n}")?.let { customDataN ->
-                    customData.setProperty("customData${n}", customDataN)
+        fun toAnalyticsCustomData(json: ReadableMap?): CustomData? {
+            if (json == null) return null
+
+            return CustomData.Builder().apply {
+                for (n in 1..30) {
+                    setProperty(
+                        "customData${n}",
+                        json.getString("customData${n}") ?: continue
+                    )
                 }
-            }
-            it.getString("experimentName")?.let { experimentName ->
-                customData.experimentName = experimentName
-            }
-            customData
+                json.getString("experimentName")?.let {
+                    setExperimentName(it)
+                }
+            }.build()
         }
 
         /**
@@ -812,23 +826,15 @@ class JsonConverter {
 
         @JvmStatic
         fun toAnalyticsSourceMetadata(json: ReadableMap?): SourceMetadata? = json?.let {
-            val sourceMetadata = SourceMetadata(
-                    title = it.getString("title"),
-                    videoId = it.getString("videoId"),
-                    cdnProvider = it.getString("cdnProvider"),
-                    path = it.getString("path"),
-                    isLive = it.getBoolean("isLive")
+            val sourceCustomData = toAnalyticsCustomData(json) ?: CustomData()
+            SourceMetadata(
+                title = it.getString("title"),
+                videoId = it.getString("videoId"),
+                cdnProvider = it.getString("cdnProvider"),
+                path = it.getString("path"),
+                isLive = it.getBoolean("isLive"),
+                customData = sourceCustomData
             )
-
-            for (n in 1..30) {
-                it.getString("customData${n}")?.let { customDataN ->
-                    sourceMetadata.setProperty("customData${n}", customDataN)
-                }
-            }
-            it.getString("experimentName")?.let { experimentName ->
-                sourceMetadata.experimentName = experimentName
-            }
-            sourceMetadata
         }
 
         /**


### PR DESCRIPTION
Android player version update to 3.42.0

The update also required to update the analytics usage. This PR does not change the usage of the integrated analytics setup i.e. some now deprecated analytics configs and APIs are used.
In a future PR the API should be adjusted to reflect the bundling and benefit the API exposed to react.