### PR TITLE
docs: added hint if default iOS simulator can not be found

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -77,6 +77,12 @@ yarn example ios # Run examples on iOS
 yarn example android # Run examples on Android
 ```
 
+Hint: You can provide a specific simulator by name when using `--simulator` flag. `xcrun simctl list devices available` provides you with a list of available devices in your environment.
+
+```sh
+yarn example ios --simulator="iPhone 14 Pro"
+```
+
 **IDE**
 
 You can also open the iOS project using Xcode by typing `xed example/ios/` on terminal, or `studio example/android/` to open the android project in Android Studio (make sure to setup its binaries first).


### PR DESCRIPTION
## Description
When running `yarn example ios` I found myself in the situation where I got the following console log: `error No simulator available with name "iPhone 13"` My environment doesn't come with that simulator.

```
yarn example ios --verbose
yarn run v1.22.19
warning ../../../package.json: No license field
$ yarn --cwd example ios --verbose
warning ../../../../package.json: No license field
$ react-native run-ios --verbose
info Found Xcode workspace "BitmovinPlayerReactNativeExample.xcworkspace"
error No simulator available with name "iPhone 13"
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->

## Changes
Added a hint describing how to select a specific simulator on your environment when running an example.

## Checklist
- [ ] 🗒 `CHANGELOG` entry
