### PR TITLE
Add support for `AdaptationConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Offline playback support on Android and iOS
+- `PlayerConfig.adaptationConfig` to allow configuring the player's adaptation behavior
 
 ## [0.9.2] (2023-08-24)
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -13,6 +13,7 @@ import com.bitmovin.player.api.drm.WidevineConfig
 import com.bitmovin.player.api.event.PlayerEvent
 import com.bitmovin.player.api.event.SourceEvent
 import com.bitmovin.player.api.event.data.SeekPosition
+import com.bitmovin.player.api.media.AdaptationConfig
 import com.bitmovin.player.api.media.audio.AudioTrack
 import com.bitmovin.player.api.media.subtitle.SubtitleTrack
 import com.bitmovin.player.api.media.thumbnail.ThumbnailTrack
@@ -73,7 +74,26 @@ class JsonConverter {
                     playerConfig.advertisingConfig = it
                 }
             }
+            if (json.hasKey("adaptationConfig")) {
+                toAdaptationConfig(json.getMap("adaptationConfig"))?.let {
+                    playerConfig.adaptationConfig = it
+                }
+            }
             return playerConfig
+        }
+
+        /**
+         * Converts an arbitrary `json` to `AdaptationConfig`.
+         * @param json JS object representing the `AdaptationConfig`.
+         * @return The generated `AdaptationConfig` if successful, `null` otherwise.
+         */
+        private fun toAdaptationConfig(json: ReadableMap?): AdaptationConfig? {
+            if (json == null) return null
+            val adaptationConfig = AdaptationConfig()
+            if (json.hasKey("maxSelectableBitrate")) {
+                adaptationConfig.maxSelectableVideoBitrate = json.getInt("maxSelectableBitrate")
+            }
+            return adaptationConfig
         }
 
         /**

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -28,6 +28,9 @@ extension RCTConvert {
         if let advertisingConfig = RCTConvert.advertisingConfig(json["advertisingConfig"]) {
             playerConfig.advertisingConfig = advertisingConfig
         }
+        if let adaptationConfig = RCTConvert.adaptationConfig(json["adaptationConfig"]) {
+            playerConfig.adaptationConfig = adaptationConfig
+        }
         return playerConfig
     }
 
@@ -878,4 +881,21 @@ extension RCTConvert {
         ]
     }
 #endif
+
+    /**
+     Utility method to instantiate a `AdaptationConfig` from a JS object.
+     - Parameter json: JS object
+     - Returns: The produced `AdaptationConfig` object
+     */
+    static func adaptationConfig(_ json: Any?) -> AdaptationConfig? {
+        guard let json = json as? [String: Any?] else {
+            return nil
+        }
+        let adaptationConfig = AdaptationConfig()
+        if let maxSelectableBitrate = json["maxSelectableBitrate"] as? NSNumber {
+            adaptationConfig.maxSelectableBitrate = maxSelectableBitrate.uintValue
+        }
+
+        return adaptationConfig
+    }
 }

--- a/src/adaptationConfig.ts
+++ b/src/adaptationConfig.ts
@@ -1,0 +1,10 @@
+/**
+ * Configures the adaptation logic.
+ */
+export interface AdaptationConfig {
+  /**
+   * The upper bitrate boundary in bits per second for network bandwidth consumption of the played source.
+   * Can be set to `undefined` for no limitation.
+   */
+  maxSelectableBitrate?: number;
+}

--- a/src/adaptationConfig.ts
+++ b/src/adaptationConfig.ts
@@ -3,7 +3,7 @@
  */
 export interface AdaptationConfig {
   /**
-   * The upper bitrate boundary in bits per second for network bandwidth consumption of the played source.
+   * The upper bitrate boundary in bits per second for approximate network bandwidth consumption of the played source.
    * Can be set to `undefined` for no limitation.
    */
   maxSelectableBitrate?: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './adaptationConfig';
 export * from './advertising';
 export * from './analytics';
 export * from './audioSession';

--- a/src/player.ts
+++ b/src/player.ts
@@ -8,6 +8,7 @@ import { SubtitleTrack } from './subtitleTrack';
 import { StyleConfig } from './styleConfig';
 import { TweaksConfig } from './tweaksConfig';
 import { OfflineContentManager, OfflineSourceOptions } from './offline';
+import { AdaptationConfig } from './adaptationConfig';
 
 const PlayerModule = NativeModules.PlayerModule;
 
@@ -54,6 +55,10 @@ export interface PlayerConfig extends NativeInstanceConfig {
    * Configures analytics functionality.
    */
   analyticsConfig?: AnalyticsConfig;
+  /**
+   * Configures adaptation logic.
+   */
+  adaptationConfig?: AdaptationConfig;
 }
 
 /**

--- a/src/player.ts
+++ b/src/player.ts
@@ -7,8 +7,8 @@ import { AudioTrack } from './audioTrack';
 import { SubtitleTrack } from './subtitleTrack';
 import { StyleConfig } from './styleConfig';
 import { TweaksConfig } from './tweaksConfig';
-import { OfflineContentManager, OfflineSourceOptions } from './offline';
 import { AdaptationConfig } from './adaptationConfig';
+import { OfflineContentManager, OfflineSourceOptions } from './offline';
 
 const PlayerModule = NativeModules.PlayerModule;
 


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
This PR adds support for configuring adaptation for the player via `PlayerConfig.adaptationConfig`.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Introduced `AdaptationConfig` type and `PlayerConfig.adaptationConfig` property.
For now only the `maxSelectableBitrate` property is supported.

To test this in the Example app, replace:
```ts
const player = usePlayer();
```
with
```ts
const player = usePlayer({
  adaptationConfig: {
    maxSelectableBitrate: 700000,
  },
});
```

and see that the content is limited to lower resolution.

## Checklist
- [x] 🗒 `CHANGELOG` entry
