### PR TITLE
Add missing `setMaxSelectableBitrate` API to `Player`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Offline playback support on Android and iOS
 - `SourceConfig.options` to enable configuring stream start position
 - `PlayerConfig.adaptationConfig` to allow configuring the player's adaptation behavior
+- `Player.setMaxSelectableBitrate` to allow setting the maximum selectable bitrate on the `Player`
 
 ## [0.9.2] (2023-08-24)
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
@@ -422,7 +422,7 @@ class PlayerModule(private val context: ReactApplicationContext) : ReactContextB
      * @param maxSelectableBitrate The desired max bitrate limit.
      */
     @ReactMethod
-    fun setMaxSelectableBitrate(nativeId: NativeId, maxSelectableBitrate: Int?) {
+    fun setMaxSelectableBitrate(nativeId: NativeId, maxSelectableBitrate: Int) {
         uiManager()?.addUIBlock {
             players[nativeId]?.setMaxSelectableVideoBitrate(maxSelectableBitrate.takeUnless { it == -1 } ?: Integer.MAX_VALUE)
         }

--- a/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
@@ -417,6 +417,18 @@ class PlayerModule(private val context: ReactApplicationContext) : ReactContextB
     }
 
     /**
+     * Sets the max selectable bitrate for the player.
+     * @param nativeId Target player id.
+     * @param maxSelectableBitrate The desired max bitrate limit.
+     */
+    @ReactMethod
+    fun setMaxSelectableBitrate(nativeId: NativeId, maxSelectableBitrate: Int?) {
+        uiManager()?.addUIBlock {
+            players[nativeId]?.setMaxSelectableVideoBitrate(maxSelectableBitrate.takeUnless { it == -1 } ?: Integer.MAX_VALUE)
+        }
+    }
+
+    /**
      * Helper function that returns the initialized `UIManager` instance.
      */
     private fun uiManager(): UIManagerModule? =

--- a/ios/PlayerModule.m
+++ b/ios/PlayerModule.m
@@ -83,5 +83,6 @@ RCT_EXTERN_METHOD(
     getMaxTimeShift:(NSString *)nativeId
     resolver:(RCTPromiseResolveBlock)resolve
     rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(setMaxSelectableBitrate:(NSString *)nativeId maxSelectableBitrate:(nonnull NSNumber *)maxSelectableBitrate)
 
 @end

--- a/ios/PlayerModule.swift
+++ b/ios/PlayerModule.swift
@@ -517,4 +517,17 @@ class PlayerModule: NSObject, RCTBridgeModule {
             resolve(self?.players[nativeId]?.maxTimeShift)
         }
     }
+
+    /**
+     Sets the max selectable bitrate for the player.
+     - Parameter nativeId: Target player id.
+     - Parameter maxBitrate: The desired max bitrate limit.
+     */
+    @objc(setMaxSelectableBitrate:maxSelectableBitrate:)
+    func setMaxSelectableBitrate(_ nativeId: NativeId, maxSelectableBitrate: NSNumber) {
+        let maxSelectableBitrateValue = maxSelectableBitrate.uintValue
+        bridge.uiManager.addUIBlock { [weak self] _, _ in
+            self?.players[nativeId]?.maxSelectableBitrate = maxSelectableBitrateValue != -1 ? maxSelectableBitrateValue : 0
+        }
+    }
 }

--- a/src/player.ts
+++ b/src/player.ts
@@ -448,4 +448,14 @@ export class Player extends NativeInstance<PlayerConfig> {
   getMaxTimeShift = async (): Promise<number> => {
     return PlayerModule.getMaxTimeShift(this.nativeId);
   };
+
+  /**
+   * Sets the upper bitrate boundary for video qualities. All qualities with a bitrate
+   * that is higher than this threshold will not be eligible for automatic quality selection.
+   *
+   * Can be set to `undefined` for no limitation.
+   */
+  setMaxSelectableBitrate = (bitrate: number | undefined) => {
+    PlayerModule.setMaxSelectableBitrate(this.nativeId, bitrate || -1);
+  };
 }

--- a/src/player.ts
+++ b/src/player.ts
@@ -455,7 +455,7 @@ export class Player extends NativeInstance<PlayerConfig> {
    *
    * Can be set to `undefined` for no limitation.
    */
-  setMaxSelectableBitrate = (bitrate: number | undefined) => {
+  setMaxSelectableBitrate = (bitrate: number | null) => {
     PlayerModule.setMaxSelectableBitrate(this.nativeId, bitrate || -1);
   };
 }


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
This PR compliments #212 by adding `setMaxSelectableBitrate` API to the `Player`.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Added `setMaxSelectableBitrate` to `Player`, with no limit value handling when `undefined` is passed.

## Checklist
- [x] 🗒 `CHANGELOG` entry
