### PR TITLE
chore: upgrade GitHub Actions checkout step to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node and npm registry
         uses: actions/setup-node@v3
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node and npm registry
         uses: actions/setup-node@v3
@@ -79,7 +79,7 @@ jobs:
     runs-on: macOS-12
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node and npm registry
         uses: actions/setup-node@v3
@@ -141,7 +141,7 @@ jobs:
     runs-on: macOS-12
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node and npm registry
         uses: actions/setup-node@v3

--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -23,7 +23,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup git user
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node and npm registry
         uses: actions/setup-node@v3


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
This PR upgrades GitHub actions checkout step to v4 to fix current issues with v3.
Official issue: https://github.com/actions/checkout/issues/1448

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Upgraded `actions/checkout` to `v4`

## Checklist
- [ ] 🗒 `CHANGELOG` entry - not needed
