### PR TITLE
Use jason build of the android player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Use `jason` build of Bitmovin's native Android SDK
+
+## [Unreleased]
+
 ### Added
 
 - `Player.getAudioTrack` and `Player.getSubtitleTrack` APIs to get currently selected audio and subtitle tracks

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
-    implementation 'com.bitmovin.player:player:3.43.0'
+    implementation 'com.bitmovin.player:player:3.43.0+jason'
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+' // From node_modules
 }


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
The `jason` build allows the usage of other exoplayer based players, besides the bitmovin player

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Change the build variant of the bitmovin android player to `jason`.

## Checklist
- [x] 🗒 `CHANGELOG` entry
