### PR TITLE
Update `RemoteControlConfig`'s `customReceiverConfig` type

### DIFF
--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -126,7 +126,6 @@ class JsonConverter {
             if (json.hasKey("customReceiverConfig")) {
                 customReceiverConfig = json.getMap("customReceiverConfig")
                     ?.toHashMap()
-                    ?.filterValues { entry -> entry is String  }
                     ?.mapValues { entry -> entry.value as String } ?: emptyMap()
             }
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -126,7 +126,8 @@ class JsonConverter {
             if (json.hasKey("customReceiverConfig")) {
                 customReceiverConfig = json.getMap("customReceiverConfig")
                     ?.toHashMap()
-                    ?.mapValues { entry -> entry.value as? String? } ?: emptyMap()
+                    ?.filterValues { entry -> entry is String  }
+                    ?.mapValues { entry -> entry.value as String } ?: emptyMap()
             }
 
             val isCastEnabled = json.getOrDefault(

--- a/src/remoteControlConfig.ts
+++ b/src/remoteControlConfig.ts
@@ -11,7 +11,7 @@ export interface RemoteControlConfig {
    * A Map containing custom configuration values that are sent to the remote control receiver.
    * Default value is an empty map.
    */
-  customReceiverConfig?: Record<string, string | null>;
+  customReceiverConfig?: Record<string, string>;
   /**
    * Whether casting is enabled.
    * Default value is `true`.


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
On iOS it only supports `String` to `String` maps for `RemoteControlConfig. customReceiverConfig`, while in the React Native API we defined `String` to optional `String`.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Changed the public API to reflect our restrictions and modified the Android JSON deserialization to take the right values.

## Checklist
- [ ] 🗒 `CHANGELOG` entry - already exists
