### PR TITLE
Fix non-DRM playback on iOS

### DIFF
--- a/ios/SourceModule.swift
+++ b/ios/SourceModule.swift
@@ -42,8 +42,13 @@ class SourceModule: NSObject, RCTBridgeModule {
     @objc(initWithAnalyticsConfig:drmNativeId:config:analyticsSourceMetadata:)
     func initWithAnalyticsConfig(_ nativeId: NativeId, drmNativeId: NativeId?, config: Any?, analyticsSourceMetadata: Any?) {
         bridge.uiManager.addUIBlock { [weak self] _, _ in
-            let fairplayConfig = drmNativeId != nil ? self?.getDrmModule()?.retrieve(drmNativeId!) : nil
-            
+            let fairplayConfig: FairplayConfig?
+            if let drmNativeId = drmNativeId {
+                fairplayConfig = self?.getDrmModule()?.retrieve(drmNativeId)
+            } else {
+                fairplayConfig = nil
+            }
+
             guard
                 self?.sources[nativeId] == nil,
                 let sourceConfig = RCTConvert.sourceConfig(config, drmConfig: fairplayConfig),
@@ -64,9 +69,15 @@ class SourceModule: NSObject, RCTBridgeModule {
     @objc(initWithConfig:drmNativeId:config:)
     func initWithConfig(_ nativeId: NativeId, drmNativeId: NativeId?, config: Any?) {
         bridge.uiManager.addUIBlock { [weak self] _, _ in
+            let fairplayConfig: FairplayConfig?
+            if let drmNativeId = drmNativeId {
+                fairplayConfig = self?.getDrmModule()?.retrieve(drmNativeId)
+            } else {
+                fairplayConfig = nil
+            }
+
             guard
                 self?.sources[nativeId] == nil,
-                let fairplayConfig = drmNativeId != nil ? self?.getDrmModule()?.retrieve(drmNativeId!) : nil,
                 let sourceConfig = RCTConvert.sourceConfig(config, drmConfig: fairplayConfig)
             else {
                 return


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Found that in #236 we accidentally broke non-DRM playback when Analytics is not enabled.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Fixed the `Source` config parsing and `Source` creation.

## Checklist
- [ ] 🗒 `CHANGELOG` entry
