### PR TITLE
Add missing native id in `isCastAvailable`

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -504,7 +504,7 @@ export class Player extends NativeInstance<PlayerConfig> {
    * @platform iOS, Android
    */
   isCastAvailable = async (): Promise<boolean> => {
-    return PlayerModule.isCastAvailable();
+    return PlayerModule.isCastAvailable(this.nativeId);
   };
 
   /**


### PR DESCRIPTION
## Description
The native id is missing in the `isCastAvailable` call

## Changes
Add missing native id

## Checklist
- [ ] 🗒 `CHANGELOG` entry
