### PR TITLE
Rename `initializeCasting` to `initializeCastManager` for `BitmovinCastManagerModule`

### DIFF
--- a/ios/BitmovinCastManagerModule.m
+++ b/ios/BitmovinCastManagerModule.m
@@ -6,7 +6,7 @@ RCT_EXTERN_METHOD(
     isInitialized:(RCTPromiseResolveBlock)resolve
     rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(
-    initializeCasting:(nullable id)config
+    initializeCastManager:(nullable id)config
     resolver:(RCTPromiseResolveBlock)resolve
     rejecter:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(sendMessage:(NSString *)message messageNamespace:(nullable NSString *)messageNamespace)

--- a/ios/BitmovinCastManagerModule.swift
+++ b/ios/BitmovinCastManagerModule.swift
@@ -23,8 +23,8 @@ class BitmovinCastManagerModule: NSObject, RCTBridgeModule {
     /**
      Initializes the BitmovinCastManager with the given options or with no options when none given.
      */
-    @objc(initializeCasting:resolver:rejecter:)
-    func initializeCasting(
+    @objc(initializeCastManager:resolver:rejecter:)
+    func initializeCastManager(
         _ config: Any?,
         resolver resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock

--- a/src/bitmovinCastManager.ts
+++ b/src/bitmovinCastManager.ts
@@ -54,7 +54,7 @@ export const BitmovinCastManager = {
     if (Platform.OS === 'ios' && Platform.isTV) {
       return Promise.resolve();
     }
-    return BitmovinCastManagerModule.initializeCasting(options);
+    return BitmovinCastManagerModule.initializeCastManager(options);
   },
 
   /**


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
After some more discussion with @strangesource we decided to use `initializeCastManager` method name on `BitmovinCastManagerModule`

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Renamed `initializeCasting` to `initializeCastManager` in `BitmovinCastManagerModule`

## Checklist
- [ ] 🗒 `CHANGELOG` entry - not applicable
