### PR TITLE
Implement `BitmovinCastManagerModule` on Android

### DIFF
--- a/android/src/main/java/com/bitmovin/player/reactnative/BitmovinCastManagerModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/BitmovinCastManagerModule.kt
@@ -22,7 +22,9 @@ class BitmovinCastManagerModule(
      * Returns whether the [BitmovinCastManager] is initialized.
      */
     @ReactMethod
-    fun isInitialized() = BitmovinCastManager.isInitialized()
+    fun isInitialized(promise: Promise) = uiManager?.addUIBlock {
+        promise.resolve(BitmovinCastManager.isInitialized())
+    }
 
     /**
      * Initializes the [BitmovinCastManager] with the given options.

--- a/android/src/main/java/com/bitmovin/player/reactnative/BitmovinCastManagerModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/BitmovinCastManagerModule.kt
@@ -1,0 +1,74 @@
+package com.bitmovin.player.reactnative
+
+import com.bitmovin.player.casting.BitmovinCastManager
+import com.bitmovin.player.reactnative.converter.JsonConverter
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.UIManagerModule
+
+private const val MODULE_NAME = "BitmovinCastManagerModule"
+
+@ReactModule(name = MODULE_NAME)
+class BitmovinCastManagerModule(
+    private val context: ReactApplicationContext,
+) : ReactContextBaseJavaModule(context) {
+    override fun getName() = MODULE_NAME
+
+    /**
+     * Returns whether the [BitmovinCastManager] is initialized.
+     */
+    @ReactMethod
+    fun isInitialized() = BitmovinCastManager.isInitialized()
+
+    /**
+     * Initializes the [BitmovinCastManager] with the given options.
+     */
+    @ReactMethod
+    fun initializeCastManager(options: ReadableMap?, promise: Promise) {
+        val castOptions = JsonConverter.toCastOptions(options)
+        uiManager?.addUIBlock {
+            BitmovinCastManager.initialize(
+                castOptions?.applicationId,
+                castOptions?.messageNamespace
+            )
+            promise.resolve(null)
+        }
+    }
+
+    /**
+     * Sends a message to the receiver.
+     */
+    @ReactMethod
+    fun sendMessage(message: String, messageNamespace: String?, promise: Promise) {
+        uiManager?.addUIBlock {
+            BitmovinCastManager.getInstance().sendMessage(message, messageNamespace)
+            promise.resolve(null)
+        }
+    }
+
+    /**
+     * Updates the context of the [BitmovinCastManager] to the current activity.
+     */
+    @ReactMethod
+    fun updateContext(promise: Promise) {
+        uiManager?.addUIBlock {
+            BitmovinCastManager.getInstance().updateContext(currentActivity)
+            promise.resolve(null)
+        }
+    }
+
+    private val uiManager: UIManagerModule?
+        get() = context.getNativeModule(UIManagerModule::class.java)
+}
+
+/**
+ * Represents configuration options for the [BitmovinCastManager].
+ */
+data class BitmovinCastManagerOptions(
+    val applicationId: String? = null,
+    val messageNamespace: String? = null,
+)

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewPackage.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewPackage.kt
@@ -27,7 +27,8 @@ class RNPlayerViewPackage : ReactPackage {
             PlayerAnalyticsModule(reactContext),
             RNPlayerViewManager(reactContext),
             FullscreenHandlerModule(reactContext),
-            CustomMessageHandlerModule(reactContext)
+            CustomMessageHandlerModule(reactContext),
+            BitmovinCastManagerModule(reactContext),
         )
     }
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -39,6 +39,7 @@ import com.bitmovin.player.api.source.SourceType
 import com.bitmovin.player.api.source.TimelineReferencePoint
 import com.bitmovin.player.api.ui.ScalingMode
 import com.bitmovin.player.api.ui.StyleConfig
+import com.bitmovin.player.reactnative.BitmovinCastManagerOptions
 import com.bitmovin.player.reactnative.extensions.getBooleanOrNull
 import com.bitmovin.player.reactnative.extensions.getName
 import com.bitmovin.player.reactnative.extensions.getOrDefault
@@ -184,7 +185,7 @@ class JsonConverter {
             "end" -> TimelineReferencePoint.End
             else -> null
         }
-        
+
         /**
          * Converts an arbitrary `json` to `AdaptationConfig`.
          * @param json JS object representing the `AdaptationConfig`.
@@ -638,6 +639,19 @@ class JsonConverter {
                 }
             }
             return json
+        }
+
+        /**
+         * Converts an arbitrary `json` into [BitmovinCastManagerOptions].
+         * @param json JS object representing the [BitmovinCastManagerOptions].
+         * @return The generated [BitmovinCastManagerOptions] if successful, `null` otherwise.
+         */
+        fun toCastOptions(json: ReadableMap?): BitmovinCastManagerOptions? {
+            if (json == null) return null
+            return BitmovinCastManagerOptions(
+                json.getOrDefault("applicationId", null),
+                json.getOrDefault("messageNamespace", null)
+            )
         }
 
         /**

--- a/src/bitmovinCastManager.ts
+++ b/src/bitmovinCastManager.ts
@@ -58,6 +58,20 @@ export const BitmovinCastManager = {
   },
 
   /**
+   * Must be called in every Android Activity to update the context to the current one.
+   * Make sure to call this method on every Android Activity switch.
+   *
+   * @returns A promise that resolves when the context was updated successfully
+   * @platform Android
+   */
+  updateContext: async (): Promise<void> => {
+    if (Platform.OS === 'ios') {
+      return Promise.resolve();
+    }
+    return BitmovinCastManagerModule.updateContext();
+  },
+
+  /**
    * Sends the given message to the cast receiver.
    *
    * @param message The message to be sent


### PR DESCRIPTION
## Description
`BitmovinCastManagerModule` does not yet have an Android implementation. In addition, Android requires an additional `updateContext` function to pass the current context into the manager.

## Changes
Implement `BitmovinCastManagerModule` and add `updateContext` function to the public API for Android only.

## Checklist
- [x] 🗒 `CHANGELOG` entry
