### PR TITLE
Attach cast events to Android player

### DIFF
--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -62,6 +62,18 @@ private val EVENT_CLASS_TO_REACT_NATIVE_NAME_MAPPING = mapOf(
     PlayerEvent.AdSkipped::class to "adSkipped",
     PlayerEvent.AdStarted::class to "adStarted",
     PlayerEvent.VideoPlaybackQualityChanged::class to "videoPlaybackQualityChanged",
+    PlayerEvent.CastStart::class to "castStart",
+    @Suppress("DEPRECATION")
+    PlayerEvent.CastPlaybackFinished::class to "castPlaybackFinished",
+    @Suppress("DEPRECATION")
+    PlayerEvent.CastPaused::class to "castPaused",
+    @Suppress("DEPRECATION")
+    PlayerEvent.CastPlaying::class to "castPlaying",
+    PlayerEvent.CastStarted::class to "castStarted",
+    PlayerEvent.CastAvailable::class to "castAvailable",
+    PlayerEvent.CastStopped::class to "castStopped",
+    PlayerEvent.CastWaitingForDevice::class to "castWaitingForDevice",
+    PlayerEvent.CastTimeUpdated::class to "castTimeUpdated",
 )
 
 private val EVENT_CLASS_TO_REACT_NATIVE_NAME_MAPPING_UI = mapOf<KClass<out Event>, String>(

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewManager.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewManager.kt
@@ -113,6 +113,15 @@ class RNPlayerViewManager(private val context: ReactApplicationContext) : Simple
         "fullscreenDisabled" to "onFullscreenDisabled",
         "fullscreenEnter" to "onFullscreenEnter",
         "fullscreenExit" to "onFullscreenExit",
+        "castStart" to "onCastStart",
+        "castPlaybackFinished" to "onCastPlaybackFinished",
+        "castPaused" to "onCastPaused",
+        "castPlaying" to "onCastPlaying",
+        "castStarted" to "onCastStarted",
+        "castAvailable" to "onCastAvailable",
+        "castStopped" to "onCastStopped",
+        "castWaitingForDevice" to "onCastWaitingForDevice",
+        "castTimeUpdated" to "onCastTimeUpdated",
     )
 
     /**


### PR DESCRIPTION
## Description
The cast events are not yet attached on the Android side.

## Changes
Attach cast events to the Android player and relay them to the React Native view.

## Checklist
- [ ] 🗒 `CHANGELOG` entry
