### PR TITLE
Fix cast issues on Android

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -255,6 +255,10 @@ dependencies {
     // Only needed if the offline feature is used
     implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.1.0"
 
+    // only needed if the casting feature is used
+    implementation("com.google.android.gms:play-services-cast-framework:21.3.0")
+    implementation("androidx.mediarouter:mediarouter:1.3.1")
+
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
     debugImplementation("com.facebook.flipper:flipper:$FLIPPER_VERSION") {
@@ -268,9 +272,6 @@ dependencies {
         exclude group:'com.facebook.flipper'
     }
     implementation project(':bitmovin-player-react-native')
-
-    implementation("com.google.android.gms:play-services-cast-framework:21.3.0")
-    implementation("androidx.mediarouter:mediarouter:1.3.1")
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -30,19 +30,20 @@
         </intent-filter>
       </activity>
 
-        <activity
-            android:name="com.bitmovin.player.casting.ExpandedControllerActivity"
-            android:exported="true"
-            android:label="@string/app_name"
-            android:launchMode="singleTask"
-            android:screenOrientation="portrait">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-            </intent-filter>
-            <meta-data
-                android:name="android.support.PARENT_ACTIVITY"
-                android:value="com.bitmovin.player.reactnative.example.MainActivity" />
-        </activity>
+    <!-- Following lines are needed for the usage of cast -->
+    <activity
+        android:name="com.bitmovin.player.casting.ExpandedControllerActivity"
+        android:exported="true"
+        android:label="@string/app_name"
+        android:launchMode="singleTask"
+        android:screenOrientation="portrait">
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+        </intent-filter>
+        <meta-data
+            android:name="android.support.PARENT_ACTIVITY"
+            android:value="com.bitmovin.player.reactnative.example.MainActivity" />
+    </activity>
 
       <meta-data
             android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,20 @@
         </intent-filter>
       </activity>
 
+        <activity
+            android:name="com.bitmovin.player.casting.ExpandedControllerActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:launchMode="singleTask"
+            android:screenOrientation="portrait">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+            </intent-filter>
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.bitmovin.player.reactnative.example.MainActivity" />
+        </activity>
+
       <meta-data
             android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
             android:value="com.bitmovin.player.casting.BitmovinCastOptionsProvider" />

--- a/example/android/app/src/main/java/com/bitmovin/player/reactnative/example/MainActivity.java
+++ b/example/android/app/src/main/java/com/bitmovin/player/reactnative/example/MainActivity.java
@@ -5,11 +5,19 @@ import androidx.annotation.Nullable;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
+import com.google.android.gms.cast.framework.CastContext;
 
 public class MainActivity extends ReactActivity {
   @Override
   public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(null);
+    try {
+      // Load Google Cast context eagerly in order to ensure that
+      // the cast state is updated correctly.
+      CastContext.getSharedInstance(this, Runnable::run);
+    } catch (Exception e) {
+      // cast framework not supported
+    }
   }
 
   /**

--- a/example/src/screens/Casting.tsx
+++ b/example/src/screens/Casting.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Platform } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import {
   Event,
@@ -15,6 +15,11 @@ function prettyPrint(header: string, obj: any) {
 
 export default function Casting() {
   BitmovinCastManager.initialize();
+
+  if (Platform.OS === 'android') {
+    // Must be called in every activity on Android
+    BitmovinCastManager.updateContext();
+  }
 
   const player = usePlayer();
 


### PR DESCRIPTION
## Description
Casting was not yet properly working as 
- the `ExpandedControllerActivity` was not declared in the manifest yet
- the cast context needs to be initialized in the `onCreate` of the activity (see [here](https://github.com/react-native-google-cast/react-native-google-cast/blob/4a2a129761acf13bfcf4fb0835d37ee0d5c74ff0/docs/getting-started/setup.md#android) and [here](https://stackoverflow.com/questions/58884569/chromecast-button-only-appears-after-backgrounding-the-app)
- `updateContext` was not yet called on Android

## Changes
- feat(casting): move dependencies to a more sensible location
- feat(casting): add expanded controller activity to manifest
- feat(casting): eagerly initialize cast context
- feat(casting): call `updateContext` on Android


## Checklist
- [ ] 🗒 `CHANGELOG` entry
