### PR TITLE
Add casting sample to example  readme

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -14,6 +14,7 @@ inside the [`src/screens/`](https://github.com/bitmovin/bitmovin-player-react-na
 - [Basic Analytics](https://github.com/bitmovin/bitmovin-player-react-native/blob/development/example/src/screens/BasicAnalytics.tsx)
 - [Basic Offline Playback](https://github.com/bitmovin/bitmovin-player-react-native/blob/development/example/src/screens/OfflinePlayback.tsx) (iOS and Android only)
 - [System UI](https://github.com/bitmovin/bitmovin-player-react-native/blob/development/example/src/screens/SystemUi.tsx) (iOS and tvOS only)
+- [Casting](https://github.com/bitmovin/bitmovin-player-react-native/blob/development/example/src/screens/Casting.tsx) (iOS and Android only)
 
 ### Custom asset playback
 


### PR DESCRIPTION
## Description
The casting sample is still missing in the example/README.md

## Changes
Add casting sample to README.md

## Checklist
- [ ] 🗒 `CHANGELOG` entry
