### PR TITLE
Enable casting different source on iOS

### DIFF
--- a/android/src/main/java/com/bitmovin/player/reactnative/SourceModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/SourceModule.kt
@@ -46,7 +46,7 @@ class SourceModule(private val context: ReactApplicationContext) : ReactContextB
      * @param nativeId ID to be associated with the `Source` instance.
      * @param drmNativeId ID of the DRM config to use.
      * @param config `SourceConfig` object received from JS.
-     * @param sourceRemoteControlConfig `SourceRemoteControlConfig` object received from JS.
+     * @param sourceRemoteControlConfig `SourceRemoteControlConfig` object received from JS. Not supported on Android.
      * @param analyticsSourceMetadata `SourceMetadata` object received from JS.
      */
     @ReactMethod
@@ -71,7 +71,7 @@ class SourceModule(private val context: ReactApplicationContext) : ReactContextB
      * @param nativeId ID to be associated with the `Source` instance.
      * @param drmNativeId ID of the DRM config to use.
      * @param config `SourceConfig` object received from JS.
-     * @param sourceRemoteControlConfig `SourceRemoteControlConfig` object received from JS.
+     * @param sourceRemoteControlConfig `SourceRemoteControlConfig` object received from JS. Not supported on Android.
      */
     @ReactMethod
     fun initWithConfig(

--- a/android/src/main/java/com/bitmovin/player/reactnative/SourceModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/SourceModule.kt
@@ -53,7 +53,7 @@ class SourceModule(private val context: ReactApplicationContext) : ReactContextB
         nativeId: NativeId,
         drmNativeId: NativeId?,
         config: ReadableMap?,
-        remotePlaybackJson: ReadableMap?,
+        sourceRemotePlaybackConfig: ReadableMap?,
         analyticsSourceMetadata: ReadableMap?
     ) {
         uiManager()?.addUIBlock {
@@ -76,7 +76,7 @@ class SourceModule(private val context: ReactApplicationContext) : ReactContextB
         nativeId: NativeId,
         drmNativeId: NativeId?,
         config: ReadableMap?,
-        remotePlaybackJson: ReadableMap?
+        sourceRemotePlaybackConfig: ReadableMap?
     ) {
         uiManager()?.addUIBlock {
             initializeSource(nativeId, drmNativeId, config) { sourceConfig ->

--- a/android/src/main/java/com/bitmovin/player/reactnative/SourceModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/SourceModule.kt
@@ -46,6 +46,7 @@ class SourceModule(private val context: ReactApplicationContext) : ReactContextB
      * @param nativeId ID to be associated with the `Source` instance.
      * @param drmNativeId ID of the DRM config to use.
      * @param config `SourceConfig` object received from JS.
+     * @param sourceRemoteControlConfig `SourceRemoteControlConfig` object received from JS.
      * @param analyticsSourceMetadata `SourceMetadata` object received from JS.
      */
     @ReactMethod
@@ -53,7 +54,7 @@ class SourceModule(private val context: ReactApplicationContext) : ReactContextB
         nativeId: NativeId,
         drmNativeId: NativeId?,
         config: ReadableMap?,
-        sourceRemotePlaybackConfig: ReadableMap?,
+        sourceRemoteControlConfig: ReadableMap?,
         analyticsSourceMetadata: ReadableMap?
     ) {
         uiManager()?.addUIBlock {
@@ -70,13 +71,14 @@ class SourceModule(private val context: ReactApplicationContext) : ReactContextB
      * @param nativeId ID to be associated with the `Source` instance.
      * @param drmNativeId ID of the DRM config to use.
      * @param config `SourceConfig` object received from JS.
+     * @param sourceRemoteControlConfig `SourceRemoteControlConfig` object received from JS.
      */
     @ReactMethod
     fun initWithConfig(
         nativeId: NativeId,
         drmNativeId: NativeId?,
         config: ReadableMap?,
-        sourceRemotePlaybackConfig: ReadableMap?
+        sourceRemoteControlConfig: ReadableMap?
     ) {
         uiManager()?.addUIBlock {
             initializeSource(nativeId, drmNativeId, config) { sourceConfig ->

--- a/android/src/main/java/com/bitmovin/player/reactnative/SourceModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/SourceModule.kt
@@ -53,6 +53,7 @@ class SourceModule(private val context: ReactApplicationContext) : ReactContextB
         nativeId: NativeId,
         drmNativeId: NativeId?,
         config: ReadableMap?,
+        remotePlaybackJson: ReadableMap?,
         analyticsSourceMetadata: ReadableMap?
     ) {
         uiManager()?.addUIBlock {
@@ -75,6 +76,7 @@ class SourceModule(private val context: ReactApplicationContext) : ReactContextB
         nativeId: NativeId,
         drmNativeId: NativeId?,
         config: ReadableMap?,
+        remotePlaybackJson: ReadableMap?
     ) {
         uiManager()?.addUIBlock {
             initializeSource(nativeId, drmNativeId, config) { sourceConfig ->

--- a/example/src/screens/Casting.tsx
+++ b/example/src/screens/Casting.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Platform } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import {
   Event,
@@ -7,6 +7,7 @@ import {
   PlayerView,
   SourceType,
   BitmovinCastManager,
+  Source,
 } from 'bitmovin-player-react-native';
 
 function prettyPrint(header: string, obj: any) {
@@ -20,11 +21,29 @@ export default function Casting() {
 
   useFocusEffect(
     useCallback(() => {
-      player.load({
-        url: 'https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_4x3/bipbop_4x3_variant.m3u8',
-        type: SourceType.HLS,
-        title: 'BipBop - Apple sample stream',
+      const source = new Source({
+        url:
+          Platform.OS === 'ios'
+            ? 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
+            : 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+        type: Platform.OS === 'ios' ? SourceType.HLS : SourceType.DASH,
+        title: 'Art of Motion',
+        poster:
+          'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/poster.jpg',
+        thumbnailTrack:
+          'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/thumbnails/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.vtt',
+        metadata: { platform: Platform.OS },
       });
+
+      // Configure playing DASH source on Chromecast, even when casting from iOS.
+      source.remotePlayback = {
+        castSourceConfig: {
+          url: 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+          type: SourceType.DASH,
+          title: 'Art of Motion',
+        },
+      };
+      player.loadSource(source);
       return () => {
         player.destroy();
       };

--- a/ios/PlayerModule.swift
+++ b/ios/PlayerModule.swift
@@ -45,7 +45,18 @@ class PlayerModule: NSObject, RCTBridgeModule {
             else {
                 return
             }
-            self?.players[nativeId] = PlayerFactory.create(playerConfig: playerConfig)
+            let player = PlayerFactory.create(playerConfig: playerConfig)
+            self?.players[nativeId] = player
+
+            playerConfig.remoteControlConfig.prepareSource = { [weak self] type, sourceConfig in
+                guard let sourceModule = self?.bridge[SourceModule.self],
+                      let sourceNativeId = sourceModule.nativeId(where: { $0.sourceConfig === sourceConfig }),
+                      let castSourceConfig = sourceModule.retrieveCastSourceConfig(sourceNativeId) else {
+                    return nil
+                }
+
+                return castSourceConfig
+            }
         }
     }
     
@@ -65,12 +76,24 @@ class PlayerModule: NSObject, RCTBridgeModule {
             else {
                 return
             }
+
             let defaultMetadata = RCTConvert.analyticsDefaultMetadataFromAnalyticsConfig(analyticsConfigJson)
-            self?.players[nativeId] = PlayerFactory.create(
+            let player = PlayerFactory.create(
                 playerConfig: playerConfig,
                 analyticsConfig: analyticsConfig,
                 defaultMetadata: defaultMetadata ?? DefaultMetadata()
             )
+            self?.players[nativeId] = player
+
+            playerConfig.remoteControlConfig.prepareSource = { [weak self] type, sourceConfig in
+                guard let sourceModule = self?.bridge[SourceModule.self],
+                      let sourceNativeId = sourceModule.nativeId(where: { $0.sourceConfig === sourceConfig }),
+                      let castSourceConfig = sourceModule.retrieveCastSourceConfig(sourceNativeId) else {
+                    return nil
+                }
+
+                return castSourceConfig
+            }
         }
     }
 

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -983,6 +983,11 @@ extension RCTConvert {
         ]
     }
 
+    /**
+     Utility method to instantiate a `SourceRemotePlaybackConfig` from a JS object.
+     - Parameter json: JS object
+     - Returns: The produced `SourceRemotePlaybackConfig` object
+     */
     static func sourceRemotePlaybackConfig(_ json: Any?) -> SourceRemotePlaybackConfig? {
         guard let json = json as? [String: Any?] else {
             return nil

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -984,16 +984,16 @@ extension RCTConvert {
     }
 
     /**
-     Utility method to instantiate a `SourceRemotePlaybackConfig` from a JS object.
+     Utility method to instantiate a `SourceRemoteControlConfig` from a JS object.
      - Parameter json: JS object
-     - Returns: The produced `SourceRemotePlaybackConfig` object
+     - Returns: The produced `SourceRemoteControlConfig` object
      */
-    static func sourceRemotePlaybackConfig(_ json: Any?) -> SourceRemotePlaybackConfig? {
+    static func sourceRemoteControlConfig(_ json: Any?) -> SourceRemoteControlConfig? {
         guard let json = json as? [String: Any?] else {
             return nil
         }
 
-        return SourceRemotePlaybackConfig(
+        return SourceRemoteControlConfig(
             castSourceConfig: RCTConvert.sourceConfig(json["castSourceConfig"])
         )
     }

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -982,4 +982,14 @@ extension RCTConvert {
             "type": castPayload.type,
         ]
     }
+
+    static func sourceRemotePlaybackConfig(_ json: Any?) -> SourceRemotePlaybackConfig? {
+        guard let json = json as? [String: Any?] else {
+            return nil
+        }
+
+        return SourceRemotePlaybackConfig(
+            castSourceConfig: RCTConvert.sourceConfig(json["castSourceConfig"])
+        )
+    }
 }

--- a/ios/SourceModule.m
+++ b/ios/SourceModule.m
@@ -2,8 +2,15 @@
 
 @interface RCT_EXTERN_REMAP_MODULE(SourceModule, SourceModule, NSObject)
 
-RCT_EXTERN_METHOD(initWithConfig:(NSString *)nativeId drmNativeId:(NSString *)drmNativeId config:(nullable id)config)
-RCT_EXTERN_METHOD(initWithAnalyticsConfig:(NSString *)nativeId drmNativeId:(NSString *)drmNativeId config:(nullable id)config analyticsSourceMetadata:(nullable id)analyticsSourceMetadata)
+RCT_EXTERN_METHOD(initWithConfig:(NSString *)nativeId
+                  drmNativeId:(NSString *)drmNativeId
+                  config:(nullable id)config
+                  sourceRemotePlaybackConfig:(id)remotePlayback)
+RCT_EXTERN_METHOD(initWithAnalyticsConfig:(NSString *)nativeId
+                  drmNativeId:(NSString *)drmNativeId
+                  config:(nullable id)config
+                  sourceRemotePlaybackConfig:(id)remotePlayback
+                  analyticsSourceMetadata:(nullable id)analyticsSourceMetadata)
 RCT_EXTERN_METHOD(destroy:(NSString *)nativeId)
 RCT_EXTERN_METHOD(
     isAttachedToPlayer:(NSString *)nativeId

--- a/ios/SourceModule.m
+++ b/ios/SourceModule.m
@@ -3,14 +3,14 @@
 @interface RCT_EXTERN_REMAP_MODULE(SourceModule, SourceModule, NSObject)
 
 RCT_EXTERN_METHOD(initWithConfig:(NSString *)nativeId
-                  drmNativeId:(NSString *)drmNativeId
-                  config:(nullable id)config
-                  sourceRemoteControlConfig:(id)remotePlayback)
+    drmNativeId:(NSString *)drmNativeId
+    config:(nullable id)config
+    sourceRemoteControlConfig:(id)remotePlayback)
 RCT_EXTERN_METHOD(initWithAnalyticsConfig:(NSString *)nativeId
-                  drmNativeId:(NSString *)drmNativeId
-                  config:(nullable id)config
-                  sourceRemoteControlConfig:(id)remotePlayback
-                  analyticsSourceMetadata:(nullable id)analyticsSourceMetadata)
+    drmNativeId:(NSString *)drmNativeId
+    config:(nullable id)config
+    sourceRemoteControlConfig:(id)remotePlayback
+    analyticsSourceMetadata:(nullable id)analyticsSourceMetadata)
 RCT_EXTERN_METHOD(destroy:(NSString *)nativeId)
 RCT_EXTERN_METHOD(
     isAttachedToPlayer:(NSString *)nativeId

--- a/ios/SourceModule.m
+++ b/ios/SourceModule.m
@@ -5,11 +5,11 @@
 RCT_EXTERN_METHOD(initWithConfig:(NSString *)nativeId
                   drmNativeId:(NSString *)drmNativeId
                   config:(nullable id)config
-                  sourceRemotePlaybackConfig:(id)remotePlayback)
+                  sourceRemoteControlConfig:(id)remotePlayback)
 RCT_EXTERN_METHOD(initWithAnalyticsConfig:(NSString *)nativeId
                   drmNativeId:(NSString *)drmNativeId
                   config:(nullable id)config
-                  sourceRemotePlaybackConfig:(id)remotePlayback
+                  sourceRemoteControlConfig:(id)remotePlayback
                   analyticsSourceMetadata:(nullable id)analyticsSourceMetadata)
 RCT_EXTERN_METHOD(destroy:(NSString *)nativeId)
 RCT_EXTERN_METHOD(

--- a/ios/SourceModule.swift
+++ b/ios/SourceModule.swift
@@ -77,8 +77,7 @@ class SourceModule: NSObject, RCTBridgeModule {
             else {
                 return
             }
-            let source = SourceFactory.create(from: sourceConfig, sourceMetadata: sourceMetadata)
-            self?.sources[nativeId] = source
+            self?.sources[nativeId] = SourceFactory.create(from: sourceConfig, sourceMetadata: sourceMetadata)
             if let remoteConfig = RCTConvert.sourceRemotePlaybackConfig(sourceRemotePlaybackConfig){
                 self?.castSourceConfigs[nativeId] = remoteConfig.castSourceConfig
             }
@@ -112,8 +111,7 @@ class SourceModule: NSObject, RCTBridgeModule {
             else {
                 return
             }
-            let source = SourceFactory.create(from: sourceConfig)
-            self?.sources[nativeId] = source
+            self?.sources[nativeId] = SourceFactory.create(from: sourceConfig)
             if let remoteConfig = RCTConvert.sourceRemotePlaybackConfig(sourceRemotePlaybackConfig) {
                 self?.castSourceConfigs[nativeId] = remoteConfig.castSourceConfig
             }

--- a/ios/SourceModule.swift
+++ b/ios/SourceModule.swift
@@ -35,12 +35,14 @@ class SourceModule: NSObject, RCTBridgeModule {
         sources[nativeId]
     }
 
+    // Finds `NativeId` based on predicate ran on `Source` instances
     func nativeId(where predicate: (Source) -> Bool) -> NativeId? {
         sources.first { _, value in
             predicate(value)
         }?.key
     }
 
+    // Fetches cast-specific `SourceConfig` by `NativeId` if exists
     func retrieveCastSourceConfig(_ nativeId: NativeId) -> SourceConfig? {
         castSourceConfigs[nativeId]
     }

--- a/ios/SourceModule.swift
+++ b/ios/SourceModule.swift
@@ -53,6 +53,7 @@ class SourceModule: NSObject, RCTBridgeModule {
      - Parameter drmNativeId: ID of the DRM config object to use.
      - Parameter config: `SourceConfig` object received from JS.
      - Parameter analyticsSourceMetadata: `SourceMetadata` object received from JS.
+     - Parameter sourceRemoteControlConfig: `SourceRemoteControlConfig` object received from JS.
      */
     @objc(initWithAnalyticsConfig:drmNativeId:config:sourceRemoteControlConfig:analyticsSourceMetadata:)
     func initWithAnalyticsConfig(
@@ -89,6 +90,7 @@ class SourceModule: NSObject, RCTBridgeModule {
      - Parameter nativeId: ID to be associated with the `Source` instance.
      - Parameter drmNativeId: ID of the DRM config object to use.
      - Parameter config: `SourceConfig` object received from JS.
+     - Parameter sourceRemoteControlConfig: `SourceRemoteControlConfig` object received from JS.
      */
     @objc(initWithConfig:drmNativeId:config:sourceRemoteControlConfig:)
     func initWithConfig(

--- a/ios/SourceModule.swift
+++ b/ios/SourceModule.swift
@@ -54,12 +54,12 @@ class SourceModule: NSObject, RCTBridgeModule {
      - Parameter config: `SourceConfig` object received from JS.
      - Parameter analyticsSourceMetadata: `SourceMetadata` object received from JS.
      */
-    @objc(initWithAnalyticsConfig:drmNativeId:config:sourceRemotePlaybackConfig:analyticsSourceMetadata:)
+    @objc(initWithAnalyticsConfig:drmNativeId:config:sourceRemoteControlConfig:analyticsSourceMetadata:)
     func initWithAnalyticsConfig(
         _ nativeId: NativeId,
         drmNativeId: NativeId?,
         config: Any?,
-        sourceRemotePlaybackConfig: Any,
+        sourceRemoteControlConfig: Any,
         analyticsSourceMetadata: Any?
     ) {
         bridge.uiManager.addUIBlock { [weak self] _, _ in
@@ -78,7 +78,7 @@ class SourceModule: NSObject, RCTBridgeModule {
                 return
             }
             self?.sources[nativeId] = SourceFactory.create(from: sourceConfig, sourceMetadata: sourceMetadata)
-            if let remoteConfig = RCTConvert.sourceRemotePlaybackConfig(sourceRemotePlaybackConfig){
+            if let remoteConfig = RCTConvert.sourceRemoteControlConfig(sourceRemoteControlConfig){
                 self?.castSourceConfigs[nativeId] = remoteConfig.castSourceConfig
             }
         }
@@ -90,12 +90,12 @@ class SourceModule: NSObject, RCTBridgeModule {
      - Parameter drmNativeId: ID of the DRM config object to use.
      - Parameter config: `SourceConfig` object received from JS.
      */
-    @objc(initWithConfig:drmNativeId:config:sourceRemotePlaybackConfig:)
+    @objc(initWithConfig:drmNativeId:config:sourceRemoteControlConfig:)
     func initWithConfig(
         _ nativeId: NativeId,
         drmNativeId: NativeId?,
         config: Any?,
-        sourceRemotePlaybackConfig: Any
+        sourceRemoteControlConfig: Any
     ) {
         bridge.uiManager.addUIBlock { [weak self] _, _ in
             let fairplayConfig: FairplayConfig?
@@ -112,7 +112,7 @@ class SourceModule: NSObject, RCTBridgeModule {
                 return
             }
             self?.sources[nativeId] = SourceFactory.create(from: sourceConfig)
-            if let remoteConfig = RCTConvert.sourceRemotePlaybackConfig(sourceRemotePlaybackConfig) {
+            if let remoteConfig = RCTConvert.sourceRemoteControlConfig(sourceRemoteControlConfig) {
                 self?.castSourceConfigs[nativeId] = remoteConfig.castSourceConfig
             }
         }
@@ -253,6 +253,6 @@ class SourceModule: NSObject, RCTBridgeModule {
     }
 }
 
-internal struct SourceRemotePlaybackConfig {
+internal struct SourceRemoteControlConfig {
     let castSourceConfig: SourceConfig?
 }

--- a/ios/SourceModule.swift
+++ b/ios/SourceModule.swift
@@ -36,11 +36,9 @@ class SourceModule: NSObject, RCTBridgeModule {
     }
 
     func nativeId(where predicate: (Source) -> Bool) -> NativeId? {
-        sources
-            .first { key, value in
-                predicate(value)
-            }?
-            .key
+        sources.first { _, value in
+            predicate(value)
+        }?.key
     }
 
     func retrieveCastSourceConfig(_ nativeId: NativeId) -> SourceConfig? {

--- a/ios/SourceModule.swift
+++ b/ios/SourceModule.swift
@@ -59,7 +59,7 @@ class SourceModule: NSObject, RCTBridgeModule {
         _ nativeId: NativeId,
         drmNativeId: NativeId?,
         config: Any?,
-        sourceRemoteControlConfig: Any,
+        sourceRemoteControlConfig: Any?,
         analyticsSourceMetadata: Any?
     ) {
         bridge.uiManager.addUIBlock { [weak self] _, _ in
@@ -95,7 +95,7 @@ class SourceModule: NSObject, RCTBridgeModule {
         _ nativeId: NativeId,
         drmNativeId: NativeId?,
         config: Any?,
-        sourceRemoteControlConfig: Any
+        sourceRemoteControlConfig: Any?
     ) {
         bridge.uiManager.addUIBlock { [weak self] _, _ in
             let fairplayConfig: FairplayConfig?

--- a/src/source.ts
+++ b/src/source.ts
@@ -137,7 +137,7 @@ export interface SourceConfig extends NativeInstanceConfig {
 }
 
 /**
- * The remote playback config for a source.
+ * The remote control config for a source.
  * @platform iOS
  */
 export interface SourceRemoteControlConfig {
@@ -160,7 +160,7 @@ export class Source extends NativeInstance<SourceConfig> {
    */
   drm?: Drm;
   /**
-   * The remote playback config for this source.
+   * The remote control config for this source.
    * This is only supported on iOS.
    *
    * @platform iOS

--- a/src/source.ts
+++ b/src/source.ts
@@ -137,6 +137,21 @@ export interface SourceConfig extends NativeInstanceConfig {
 }
 
 /**
+ * The remote playback config for a source.
+ * @platform iOS
+ */
+export interface SourceRemotePlaybackConfig {
+  /**
+   * The `SourceConfig` for casting.
+   * Enables to play different content when casting.
+   * This can be useful when the remote playback device supports different streaming formats,
+   * DRM systems, etc. than the local device.
+   * If not set, the local source config will be used for casting.
+   */
+  castSourceConfig?: SourceConfig | null;
+}
+
+/**
  * Represents audio and video content that can be loaded into a player.
  */
 export class Source extends NativeInstance<SourceConfig> {
@@ -144,6 +159,13 @@ export class Source extends NativeInstance<SourceConfig> {
    * The native DRM config reference of this source.
    */
   drm?: Drm;
+  /**
+   * The remote playback config for this source.
+   * This is only used on iOS.
+   *
+   * @platform iOS
+   */
+  remotePlayback: SourceRemotePlaybackConfig | null = null;
   /**
    * Whether the native `Source` object has been created.
    */
@@ -168,13 +190,15 @@ export class Source extends NativeInstance<SourceConfig> {
           this.nativeId,
           this.drm?.nativeId,
           this.config,
+          this.remotePlayback,
           sourceMetadata
         );
       } else {
         SourceModule.initWithConfig(
           this.nativeId,
           this.drm?.nativeId,
-          this.config
+          this.config,
+          this.remotePlayback
         );
       }
       this.isInitialized = true;

--- a/src/source.ts
+++ b/src/source.ts
@@ -165,7 +165,7 @@ export class Source extends NativeInstance<SourceConfig> {
    *
    * @platform iOS
    */
-  remotePlayback: SourceRemoteControlConfig | null = null;
+  remoteControl: SourceRemoteControlConfig | null = null;
   /**
    * Whether the native `Source` object has been created.
    */
@@ -190,7 +190,7 @@ export class Source extends NativeInstance<SourceConfig> {
           this.nativeId,
           this.drm?.nativeId,
           this.config,
-          this.remotePlayback,
+          this.remoteControl,
           sourceMetadata
         );
       } else {
@@ -198,7 +198,7 @@ export class Source extends NativeInstance<SourceConfig> {
           this.nativeId,
           this.drm?.nativeId,
           this.config,
-          this.remotePlayback
+          this.remoteControl
         );
       }
       this.isInitialized = true;

--- a/src/source.ts
+++ b/src/source.ts
@@ -161,7 +161,7 @@ export class Source extends NativeInstance<SourceConfig> {
   drm?: Drm;
   /**
    * The remote playback config for this source.
-   * This is only used on iOS.
+   * This is only supported on iOS.
    *
    * @platform iOS
    */

--- a/src/source.ts
+++ b/src/source.ts
@@ -140,7 +140,7 @@ export interface SourceConfig extends NativeInstanceConfig {
  * The remote playback config for a source.
  * @platform iOS
  */
-export interface SourceRemotePlaybackConfig {
+export interface SourceRemoteControlConfig {
   /**
    * The `SourceConfig` for casting.
    * Enables to play different content when casting.
@@ -165,7 +165,7 @@ export class Source extends NativeInstance<SourceConfig> {
    *
    * @platform iOS
    */
-  remotePlayback: SourceRemotePlaybackConfig | null = null;
+  remotePlayback: SourceRemoteControlConfig | null = null;
   /**
    * Whether the native `Source` object has been created.
    */


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
On the iOS SDK we support casting a different source config when casting, this is not yet available for the React Native SDK.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Added support to configure a cast-specific `SourceConfig` for casting, via adding a new namespace, `remotePlayback` to `Source`.

## Checklist
- [ ] 🗒 `CHANGELOG` entry - already exists
