### PR TITLE
Widevine DRM support for casting on iOS

### DIFF
--- a/ios/DrmModule.swift
+++ b/ios/DrmModule.swift
@@ -6,7 +6,7 @@ class DrmModule: NSObject, RCTBridgeModule {
     @objc var bridge: RCTBridge!
 
     /// In-memory mapping from `nativeId`s to `FairplayConfig` instances.
-    private var drmConfigs: Registry<DrmConfig> = [:]
+    private var drmConfigs: Registry<FairplayConfig> = [:]
 
     /// JS module name.
     static func moduleName() -> String! {
@@ -28,7 +28,7 @@ class DrmModule: NSObject, RCTBridgeModule {
      - Parameter nativeId: ID to associate with the `FairplayConfig` instance.
      - Returns: The associated `FairplayConfig` instance or `nil`.
      */
-    @objc func retrieve(_ nativeId: NativeId) -> DrmConfig? {
+    @objc func retrieve(_ nativeId: NativeId) -> FairplayConfig? {
         drmConfigs[nativeId]
     }
 
@@ -42,11 +42,11 @@ class DrmModule: NSObject, RCTBridgeModule {
         bridge.uiManager.addUIBlock { [weak self] _, _ in
             guard
                 self?.drmConfigs[nativeId] == nil,
-                let drmConfig = RCTConvert.drmConfig(config)
+                let fairplayConfig = RCTConvert.drmConfig(config).fairplay
             else {
                 return
             }
-            self?.drmConfigs[nativeId] = drmConfig
+            self?.drmConfigs[nativeId] = fairplayConfig
             self?.initConfigBlocks(nativeId, config)
         }
     }
@@ -181,12 +181,12 @@ class DrmModule: NSObject, RCTBridgeModule {
      */
     private func initConfigBlocks(_ nativeId: NativeId, _ config: Any?) {
         if let json = config as? [String: Any], let fairplayJson = json["fairplay"] as? [String: Any] {
-            initFairplayPrepareCertificate(nativeId, fairplayJson: fairplayJson)
-            initFairplayPrepareMessage(nativeId, fairplayJson: fairplayJson)
-            initFairplayPrepareSyncMessage(nativeId, fairplayJson: fairplayJson)
-            initFairplayPrepareLicense(nativeId, fairplayJson: fairplayJson)
-            initFairplayPrepareLicenseServerUrl(nativeId, fairplayJson: fairplayJson)
-            initFairplayPrepareContentId(nativeId, fairplayJson: fairplayJson)
+            initPrepareCertificate(nativeId, fairplayJson: fairplayJson)
+            initPrepareMessage(nativeId, fairplayJson: fairplayJson)
+            initPrepareSyncMessage(nativeId, fairplayJson: fairplayJson)
+            initPrepareLicense(nativeId, fairplayJson: fairplayJson)
+            initPrepareLicenseServerUrl(nativeId, fairplayJson: fairplayJson)
+            initPrepareContentId(nativeId, fairplayJson: fairplayJson)
         }
     }
     
@@ -196,8 +196,8 @@ class DrmModule: NSObject, RCTBridgeModule {
      - Parameter nativeId - Instance nativeId.
      - Parameter config: FairPlay config object sent from JS.
      */
-    private func initFairplayPrepareCertificate(_ nativeId: NativeId, fairplayJson: [String: Any]) {
-        guard let fairplayConfig = drmConfigs[nativeId] as? FairplayConfig else {
+    private func initPrepareCertificate(_ nativeId: NativeId, fairplayJson: [String: Any]) {
+        guard let fairplayConfig = drmConfigs[nativeId] else {
             return
         }
         if fairplayJson["prepareCertificate"] != nil {
@@ -213,8 +213,8 @@ class DrmModule: NSObject, RCTBridgeModule {
      - Parameter nativeId - Instance nativeId.
      - Parameter config: FairPlay config object sent from JS.
      */
-    private func initFairplayPrepareMessage(_ nativeId: NativeId, fairplayJson: [String: Any]) {
-        guard let fairplayConfig = drmConfigs[nativeId] as? FairplayConfig else {
+    private func initPrepareMessage(_ nativeId: NativeId, fairplayJson: [String: Any]) {
+        guard let fairplayConfig = drmConfigs[nativeId] else {
             return
         }
         if fairplayJson["prepareMessage"] != nil {
@@ -230,8 +230,8 @@ class DrmModule: NSObject, RCTBridgeModule {
      - Parameter nativeId - Instance nativeId.
      - Parameter config: FairPlay config object sent from JS.
      */
-    private func initFairplayPrepareSyncMessage(_ nativeId: NativeId, fairplayJson: [String: Any]) {
-        guard let fairplayConfig = drmConfigs[nativeId] as? FairplayConfig else {
+    private func initPrepareSyncMessage(_ nativeId: NativeId, fairplayJson: [String: Any]) {
+        guard let fairplayConfig = drmConfigs[nativeId] else {
             return
         }
         if fairplayJson["prepareSyncMessage"] != nil {
@@ -247,8 +247,8 @@ class DrmModule: NSObject, RCTBridgeModule {
      - Parameter nativeId - Instance nativeId.
      - Parameter config: FairPlay config object sent from JS.
      */
-    private func initFairplayPrepareLicense(_ nativeId: NativeId, fairplayJson: [String: Any]) {
-        guard let fairplayConfig = drmConfigs[nativeId] as? FairplayConfig else {
+    private func initPrepareLicense(_ nativeId: NativeId, fairplayJson: [String: Any]) {
+        guard let fairplayConfig = drmConfigs[nativeId] else {
             return
         }
         if fairplayJson["prepareLicense"] != nil {
@@ -264,8 +264,8 @@ class DrmModule: NSObject, RCTBridgeModule {
      - Parameter nativeId - Instance nativeId.
      - Parameter config: FairPlay config object sent from JS.
      */
-    private func initFairplayPrepareLicenseServerUrl(_ nativeId: NativeId, fairplayJson: [String: Any]) {
-        guard let fairplayConfig = drmConfigs[nativeId] as? FairplayConfig else {
+    private func initPrepareLicenseServerUrl(_ nativeId: NativeId, fairplayJson: [String: Any]) {
+        guard let fairplayConfig = drmConfigs[nativeId] else {
             return
         }
         if fairplayJson["prepareLicenseServerUrl"] != nil {
@@ -281,8 +281,8 @@ class DrmModule: NSObject, RCTBridgeModule {
      - Parameter nativeId - Instance nativeId.
      - Parameter config: FairPlay config object sent from JS.
      */
-    private func initFairplayPrepareContentId(_ nativeId: NativeId, fairplayJson: [String: Any]) {
-        guard let fairplayConfig = drmConfigs[nativeId] as? FairplayConfig else {
+    private func initPrepareContentId(_ nativeId: NativeId, fairplayJson: [String: Any]) {
+        guard let fairplayConfig = drmConfigs[nativeId] else {
             return
         }
         if fairplayJson["prepareContentId"] != nil {

--- a/ios/DrmModule.swift
+++ b/ios/DrmModule.swift
@@ -6,7 +6,7 @@ class DrmModule: NSObject, RCTBridgeModule {
     @objc var bridge: RCTBridge!
 
     /// In-memory mapping from `nativeId`s to `FairplayConfig` instances.
-    private var drmConfigs: Registry<FairplayConfig> = [:]
+    private var drmConfigs: Registry<DrmConfig> = [:]
 
     /// JS module name.
     static func moduleName() -> String! {
@@ -28,7 +28,7 @@ class DrmModule: NSObject, RCTBridgeModule {
      - Parameter nativeId: ID to associate with the `FairplayConfig` instance.
      - Returns: The associated `FairplayConfig` instance or `nil`.
      */
-    @objc func retrieve(_ nativeId: NativeId) -> FairplayConfig? {
+    @objc func retrieve(_ nativeId: NativeId) -> DrmConfig? {
         drmConfigs[nativeId]
     }
 
@@ -42,11 +42,11 @@ class DrmModule: NSObject, RCTBridgeModule {
         bridge.uiManager.addUIBlock { [weak self] _, _ in
             guard
                 self?.drmConfigs[nativeId] == nil,
-                let fairplayConfig = RCTConvert.fairplayConfig(config)
+                let drmConfig = RCTConvert.drmConfig(config)
             else {
                 return
             }
-            self?.drmConfigs[nativeId] = fairplayConfig
+            self?.drmConfigs[nativeId] = drmConfig
             self?.initConfigBlocks(nativeId, config)
         }
     }
@@ -181,12 +181,12 @@ class DrmModule: NSObject, RCTBridgeModule {
      */
     private func initConfigBlocks(_ nativeId: NativeId, _ config: Any?) {
         if let json = config as? [String: Any], let fairplayJson = json["fairplay"] as? [String: Any] {
-            initPrepareCertificate(nativeId, fairplayJson: fairplayJson)
-            initPrepareMessage(nativeId, fairplayJson: fairplayJson)
-            initPrepareSyncMessage(nativeId, fairplayJson: fairplayJson)
-            initPrepareLicense(nativeId, fairplayJson: fairplayJson)
-            initPrepareLicenseServerUrl(nativeId, fairplayJson: fairplayJson)
-            initPrepareContentId(nativeId, fairplayJson: fairplayJson)
+            initFairplayPrepareCertificate(nativeId, fairplayJson: fairplayJson)
+            initFairplayPrepareMessage(nativeId, fairplayJson: fairplayJson)
+            initFairplayPrepareSyncMessage(nativeId, fairplayJson: fairplayJson)
+            initFairplayPrepareLicense(nativeId, fairplayJson: fairplayJson)
+            initFairplayPrepareLicenseServerUrl(nativeId, fairplayJson: fairplayJson)
+            initFairplayPrepareContentId(nativeId, fairplayJson: fairplayJson)
         }
     }
     
@@ -196,8 +196,8 @@ class DrmModule: NSObject, RCTBridgeModule {
      - Parameter nativeId - Instance nativeId.
      - Parameter config: FairPlay config object sent from JS.
      */
-    private func initPrepareCertificate(_ nativeId: NativeId, fairplayJson: [String: Any]) {
-        guard let fairplayConfig = drmConfigs[nativeId] else {
+    private func initFairplayPrepareCertificate(_ nativeId: NativeId, fairplayJson: [String: Any]) {
+        guard let fairplayConfig = drmConfigs[nativeId] as? FairplayConfig else {
             return
         }
         if fairplayJson["prepareCertificate"] != nil {
@@ -213,8 +213,8 @@ class DrmModule: NSObject, RCTBridgeModule {
      - Parameter nativeId - Instance nativeId.
      - Parameter config: FairPlay config object sent from JS.
      */
-    private func initPrepareMessage(_ nativeId: NativeId, fairplayJson: [String: Any]) {
-        guard let fairplayConfig = drmConfigs[nativeId] else {
+    private func initFairplayPrepareMessage(_ nativeId: NativeId, fairplayJson: [String: Any]) {
+        guard let fairplayConfig = drmConfigs[nativeId] as? FairplayConfig else {
             return
         }
         if fairplayJson["prepareMessage"] != nil {
@@ -230,8 +230,8 @@ class DrmModule: NSObject, RCTBridgeModule {
      - Parameter nativeId - Instance nativeId.
      - Parameter config: FairPlay config object sent from JS.
      */
-    private func initPrepareSyncMessage(_ nativeId: NativeId, fairplayJson: [String: Any]) {
-        guard let fairplayConfig = drmConfigs[nativeId] else {
+    private func initFairplayPrepareSyncMessage(_ nativeId: NativeId, fairplayJson: [String: Any]) {
+        guard let fairplayConfig = drmConfigs[nativeId] as? FairplayConfig else {
             return
         }
         if fairplayJson["prepareSyncMessage"] != nil {
@@ -247,8 +247,8 @@ class DrmModule: NSObject, RCTBridgeModule {
      - Parameter nativeId - Instance nativeId.
      - Parameter config: FairPlay config object sent from JS.
      */
-    private func initPrepareLicense(_ nativeId: NativeId, fairplayJson: [String: Any]) {
-        guard let fairplayConfig = drmConfigs[nativeId] else {
+    private func initFairplayPrepareLicense(_ nativeId: NativeId, fairplayJson: [String: Any]) {
+        guard let fairplayConfig = drmConfigs[nativeId] as? FairplayConfig else {
             return
         }
         if fairplayJson["prepareLicense"] != nil {
@@ -264,8 +264,8 @@ class DrmModule: NSObject, RCTBridgeModule {
      - Parameter nativeId - Instance nativeId.
      - Parameter config: FairPlay config object sent from JS.
      */
-    private func initPrepareLicenseServerUrl(_ nativeId: NativeId, fairplayJson: [String: Any]) {
-        guard let fairplayConfig = drmConfigs[nativeId] else {
+    private func initFairplayPrepareLicenseServerUrl(_ nativeId: NativeId, fairplayJson: [String: Any]) {
+        guard let fairplayConfig = drmConfigs[nativeId] as? FairplayConfig else {
             return
         }
         if fairplayJson["prepareLicenseServerUrl"] != nil {
@@ -281,8 +281,8 @@ class DrmModule: NSObject, RCTBridgeModule {
      - Parameter nativeId - Instance nativeId.
      - Parameter config: FairPlay config object sent from JS.
      */
-    private func initPrepareContentId(_ nativeId: NativeId, fairplayJson: [String: Any]) {
-        guard let fairplayConfig = drmConfigs[nativeId] else {
+    private func initFairplayPrepareContentId(_ nativeId: NativeId, fairplayJson: [String: Any]) {
+        guard let fairplayConfig = drmConfigs[nativeId] as? FairplayConfig else {
             return
         }
         if fairplayJson["prepareContentId"] != nil {

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -228,7 +228,7 @@ extension RCTConvert {
      - Parameter json: JS object
      - Returns: The produced `SourceConfig` object
      */
-    static func sourceConfig(_ json: Any?, drmConfig: FairplayConfig? = nil) -> SourceConfig? {
+    static func sourceConfig(_ json: Any?, drmConfig: DrmConfig? = nil) -> SourceConfig? {
         guard let json = json as? [String: Any?] else {
             return nil
         }
@@ -336,30 +336,62 @@ extension RCTConvert {
     }
 
     /**
+     Utility method to get a `DrmConfig` from a JS object.
+     - Parameter json: JS object
+     - Returns: The generated `DrmConfig` object
+     */
+    static func drmConfig(_ json: Any?) -> DrmConfig? {
+        guard let json = json as? [String: Any?] else {
+            return nil
+        }
+        if  let fairplayConfig = RCTConvert.fairplayConfig(json["fairplay"]) {
+            return fairplayConfig
+        }
+        if let widevineConfig = RCTConvert.widevineConfig(json["widevine"]) {
+            return widevineConfig
+        }
+        return nil
+    }
+
+    /**
      Utility method to get a `FairplayConfig` from a JS object.
      - Parameter json: JS object
      - Returns: The generated `FairplayConfig` object
      */
     static func fairplayConfig(_ json: Any?) -> FairplayConfig? {
-        guard
-            let json = json as? [String: Any?],
-            let fairplayJson = json["fairplay"] as? [String: Any?],
-            let licenseURL = fairplayJson["licenseUrl"] as? String,
-            let certificateURL = fairplayJson["certificateUrl"] as? String
-        else {
+        guard let json = json as? [String: Any?],
+            let licenseURL = json["licenseUrl"] as? String,
+            let certificateURL = json["certificateUrl"] as? String else {
             return nil
         }
         let fairplayConfig = FairplayConfig(
             license: URL(string: licenseURL),
             certificateURL: URL(string: certificateURL)!
         )
-        if let licenseRequestHeaders = fairplayJson["licenseRequestHeaders"] as? [String: String] {
+        if let licenseRequestHeaders = json["licenseRequestHeaders"] as? [String: String] {
             fairplayConfig.licenseRequestHeaders = licenseRequestHeaders
         }
-        if let certificateRequestHeaders = fairplayJson["certificateRequestHeaders"] as? [String: String] {
+        if let certificateRequestHeaders = json["certificateRequestHeaders"] as? [String: String] {
             fairplayConfig.certificateRequestHeaders = certificateRequestHeaders
         }
         return fairplayConfig
+    }
+
+    /**
+     Utility method to get a `WidevineConfig` from a JS object.
+     - Parameter json: JS object
+     - Returns: The generated `WidevineConfig` object
+     */
+    static func widevineConfig(_ json: Any?) -> WidevineConfig? {
+        guard let json = json as? [String: Any?],
+            let licenseURL = json["licenseUrl"] as? String else {
+            return nil
+        }
+        let widevineConfig = WidevineConfig(license: URL(string: licenseURL))
+        if let licenseRequestHeaders = json["httpHeaders"] as? [String: String] {
+            widevineConfig.licenseRequestHeaders = licenseRequestHeaders
+        }
+        return widevineConfig
     }
 
     /**
@@ -988,8 +1020,13 @@ extension RCTConvert {
             return nil
         }
 
+        let castSourceConfig = RCTConvert.sourceConfig(json["castSourceConfig"])
+        if let castSourceConfigJson = json["castSourceConfig"] as? [String: Any?],
+           let drmConfig = RCTConvert.drmConfig(castSourceConfigJson["drmConfig"]) {
+            castSourceConfig?.drmConfig = drmConfig
+        }
         return SourceRemotePlaybackConfig(
-            castSourceConfig: RCTConvert.sourceConfig(json["castSourceConfig"])
+            castSourceConfig: castSourceConfig
         )
     }
 }

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -340,17 +340,14 @@ extension RCTConvert {
      - Parameter json: JS object
      - Returns: The generated `DrmConfig` object
      */
-    static func drmConfig(_ json: Any?) -> DrmConfig? {
+    static func drmConfig(_ json: Any?) -> (fairplay: FairplayConfig?, widevine: WidevineConfig?) {
         guard let json = json as? [String: Any?] else {
-            return nil
+            return (nil, nil)
         }
-        if  let fairplayConfig = RCTConvert.fairplayConfig(json["fairplay"]) {
-            return fairplayConfig
-        }
-        if let widevineConfig = RCTConvert.widevineConfig(json["widevine"]) {
-            return widevineConfig
-        }
-        return nil
+        return (
+            fairplay: RCTConvert.fairplayConfig(json["fairplay"]),
+            widevine: RCTConvert.widevineConfig(json["widevine"])
+        )
     }
 
     /**
@@ -1022,11 +1019,14 @@ extension RCTConvert {
      */
     static func sourceRemoteControlConfig(_ json: Any?) -> SourceRemoteControlConfig? {
         guard let json = json as? [String: Any?],
-              let castSourceConfigJson = json["castSourceConfig"] as? [String: Any?],
-              let castSourceConfig = RCTConvert.sourceConfig(json["castSourceConfig"]) else {
+              let castSourceConfigJson = json["castSourceConfig"] as? [String: Any?] else {
             return nil
         }
-        castSourceConfig.drmConfig = RCTConvert.drmConfig(castSourceConfigJson["drmConfig"])
-        return SourceRemoteControlConfig(castSourceConfig: castSourceConfig)
+        return SourceRemoteControlConfig(
+            castSourceConfig: RCTConvert.sourceConfig(
+                json["castSourceConfig"],
+                drmConfig: RCTConvert.drmConfig(castSourceConfigJson["drmConfig"]).widevine
+            )
+        )
     }
 }

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -1016,17 +1016,12 @@ extension RCTConvert {
     }
 
     static func sourceRemotePlaybackConfig(_ json: Any?) -> SourceRemotePlaybackConfig? {
-        guard let json = json as? [String: Any?] else {
+        guard let json = json as? [String: Any?],
+              let castSourceConfigJson = json["castSourceConfig"] as? [String: Any?],
+              let castSourceConfig = RCTConvert.sourceConfig(json["castSourceConfig"]) else {
             return nil
         }
-
-        let castSourceConfig = RCTConvert.sourceConfig(json["castSourceConfig"])
-        if let castSourceConfigJson = json["castSourceConfig"] as? [String: Any?],
-           let drmConfig = RCTConvert.drmConfig(castSourceConfigJson["drmConfig"]) {
-            castSourceConfig?.drmConfig = drmConfig
-        }
-        return SourceRemotePlaybackConfig(
-            castSourceConfig: castSourceConfig
-        )
+        castSourceConfig.drmConfig = RCTConvert.drmConfig(castSourceConfigJson["drmConfig"])
+        return SourceRemotePlaybackConfig(castSourceConfig: castSourceConfig)
     }
 }

--- a/ios/SourceModule.swift
+++ b/ios/SourceModule.swift
@@ -63,16 +63,16 @@ class SourceModule: NSObject, RCTBridgeModule {
         analyticsSourceMetadata: Any?
     ) {
         bridge.uiManager.addUIBlock { [weak self] _, _ in
-            let fairplayConfig: FairplayConfig?
+            let drmConfig: DrmConfig?
             if let drmNativeId = drmNativeId {
-                fairplayConfig = self?.getDrmModule()?.retrieve(drmNativeId)
+                drmConfig = self?.getDrmModule()?.retrieve(drmNativeId)
             } else {
-                fairplayConfig = nil
+                drmConfig = nil
             }
 
             guard
                 self?.sources[nativeId] == nil,
-                let sourceConfig = RCTConvert.sourceConfig(config, drmConfig: fairplayConfig),
+                let sourceConfig = RCTConvert.sourceConfig(config, drmConfig: drmConfig),
                 let sourceMetadata = RCTConvert.analyticsSourceMetadata(analyticsSourceMetadata)
             else {
                 return
@@ -98,16 +98,16 @@ class SourceModule: NSObject, RCTBridgeModule {
         sourceRemotePlaybackConfig: Any
     ) {
         bridge.uiManager.addUIBlock { [weak self] _, _ in
-            let fairplayConfig: FairplayConfig?
+            let drmConfig: DrmConfig?
             if let drmNativeId = drmNativeId {
-                fairplayConfig = self?.getDrmModule()?.retrieve(drmNativeId)
+                drmConfig = self?.getDrmModule()?.retrieve(drmNativeId)
             } else {
-                fairplayConfig = nil
+                drmConfig = nil
             }
 
             guard
                 self?.sources[nativeId] == nil,
-                let sourceConfig = RCTConvert.sourceConfig(config, drmConfig: fairplayConfig)
+                let sourceConfig = RCTConvert.sourceConfig(config, drmConfig: drmConfig)
             else {
                 return
             }

--- a/src/drm/index.ts
+++ b/src/drm/index.ts
@@ -14,11 +14,15 @@ const DrmModule = NativeModules.DrmModule;
  */
 export interface DrmConfig extends NativeInstanceConfig {
   /**
-   * FairPlay specific configuration. Only applicable for iOS.
+   * FairPlay specific configuration.
+   *
+   * @platform iOS
    */
   fairplay?: FairplayConfig;
   /**
-   * Widevine specific configuration. Only applicable for Android.
+   * Widevine specific configuration.
+   *
+   * @platform Android, iOS (only for casting).
    */
   widevine?: WidevineConfig;
 }

--- a/src/drm/widevineConfig.ts
+++ b/src/drm/widevineConfig.ts
@@ -10,7 +10,7 @@ export interface WidevineConfig {
   /**
    * A map containing the HTTP request headers, or null.
    */
-  httpHeaders: Record<string, string>;
+  httpHeaders?: Record<string, string>;
   /**
    * A block to prepare the data which is sent as the body of the POST license request.
    * As many DRM providers expect different, vendor-specific messages, this can be done using
@@ -45,5 +45,5 @@ export interface WidevineConfig {
    * as the same DRM scheme information.
    * Default: `false`
    */
-  shouldKeepDrmSessionsAlive: boolean;
+  shouldKeepDrmSessionsAlive?: boolean;
 }

--- a/src/drm/widevineConfig.ts
+++ b/src/drm/widevineConfig.ts
@@ -1,6 +1,6 @@
 /**
  * Represents a Widevine Streaming DRM config.
- * Android only.
+ * @platform Android, iOS (only for casting).
  */
 export interface WidevineConfig {
   /**
@@ -19,6 +19,8 @@ export interface WidevineConfig {
    * Note that both the passed `message` data and this block return value should be a Base64 string.
    * So use whatever solution suits you best to handle Base64 in React Native.
    *
+   * @platform Android
+   *
    * @param message - Base64 encoded message data.
    * @returns The processed Base64 encoded message.
    */
@@ -31,12 +33,16 @@ export interface WidevineConfig {
    * Note that both the passed `license` data and this block return value should be a Base64 string.
    * So use whatever solution suits you best to handle Base64 in React Native.
    *
+   * @platform Android
+   *
    * @param license - Base64 encoded license data.
    * @returns The processed Base64 encoded license.
    */
   prepareLicense?: (license: string) => string;
   /**
    * Set widevine's preferred security level.
+   *
+   * @platform Android
    */
   preferredSecurityLevel?: string;
   /**
@@ -44,6 +50,8 @@ export interface WidevineConfig {
    * This allows DRM sessions to be reused over several different source items with the same DRM configuration as well
    * as the same DRM scheme information.
    * Default: `false`
+   *
+   * @platform Android
    */
   shouldKeepDrmSessionsAlive?: boolean;
 }


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
We don't support DRM-protected playback for casting.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Added `WidevineConfig` parsing to iOS and use it for remote playback.

## Checklist
- [ ] 🗒 `CHANGELOG` entry - not applicable
