### PR TITLE
Enable running CI workflow on all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - '*.md'
 
   push:
+    branches: [development]
     paths-ignore:
       - '*.md'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,10 @@ name: CI
 
 on:
   pull_request:
-    branches: [development]
     paths-ignore:
       - '*.md'
 
   push:
-    branches: [development]
     paths-ignore:
       - '*.md'
 


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
When opening a PR that is targeting other than the `development` branch we don't run the CI workflow right now.
This is problematic when working on a bigger feature with a chain of PRs open.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Enabled running the CI workflow on all PRs.

## Checklist
- [ ] 🗒 `CHANGELOG` entry - not applicable
