### PR TITLE
`onPictureInPictureAvailabilityChanged` event support on iOS and tvOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - API Reference now can be found [here](https://cdn.bitmovin.com/player/reactnative/0/docs/index.html)
 - `PictureInPictureConfig` to `PlayerView` to allow configuring the Picture in Picture behavior
+- `onPictureInPictureAvailabilityChanged` event is now emitted on iOS and tvOS in addition to Android
 
 ### Changed
 
@@ -15,7 +16,6 @@
 ### Deprecated
 
 - `PlaybackConfig.isPictureInPictureEnabled` in favor of `PictureInPictureConfig.isEnabled`
-
 
 ## [0.12.0] (2023-09-25)
 

--- a/ios/RNPlayerView.swift
+++ b/ios/RNPlayerView.swift
@@ -62,6 +62,7 @@ class RNPlayerView: UIView {
     @objc var onCastStopped: RCTBubblingEventBlock?
     @objc var onCastTimeUpdated: RCTBubblingEventBlock?
     @objc var onCastWaitingForDevice: RCTBubblingEventBlock?
+    @objc var onPictureInPictureAvailabilityChanged: RCTBubblingEventBlock?
     @objc var pictureInPictureConfig: [String: Any]?
 
     /// The `PlayerView` subview.

--- a/ios/RNPlayerViewManager.m
+++ b/ios/RNPlayerViewManager.m
@@ -61,6 +61,7 @@ RCT_EXPORT_VIEW_PROPERTY(onCastStart, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onCastStopped, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onCastTimeUpdated, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onCastWaitingForDevice, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onPictureInPictureAvailabilityChanged, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(pictureInPictureConfig, NSDictionary)
 
 RCT_EXTERN_METHOD(attachPlayer:(nonnull NSNumber *)viewId playerId:(NSString *)playerId playerConfig:(nullable NSDictionary *)playerConfig)

--- a/ios/RNPlayerViewManager.swift
+++ b/ios/RNPlayerViewManager.swift
@@ -40,7 +40,7 @@ class RNPlayerViewManager: RCTViewManager {
             }
 #endif
 
-            var previousPictureInPictureAvailableValue = false
+            let previousPictureInPictureAvailableValue: Bool
             if let playerView = view.playerView {
                 playerView.player = player
                 previousPictureInPictureAvailableValue = playerView.isPictureInPictureAvailable
@@ -54,6 +54,7 @@ class RNPlayerViewManager: RCTViewManager {
                     frame: view.bounds,
                     playerViewConfig: playerViewConfig
                 )
+                previousPictureInPictureAvailableValue = false
             }
             player.add(listener: view)
             view.playerView?.add(listener: view)

--- a/ios/RNPlayerViewManager.swift
+++ b/ios/RNPlayerViewManager.swift
@@ -58,7 +58,7 @@ class RNPlayerViewManager: RCTViewManager {
             player.add(listener: view)
             view.playerView?.add(listener: view)
 
-            maybeEmitPictureInPictureAvailabilityEvent(for: view, previousState: previousPictureInPictureAvailableValue)
+            self.maybeEmitPictureInPictureAvailabilityEvent(for: view, previousState: previousPictureInPictureAvailableValue)
         }
     }
 

--- a/ios/RNPlayerViewManager.swift
+++ b/ios/RNPlayerViewManager.swift
@@ -40,8 +40,10 @@ class RNPlayerViewManager: RCTViewManager {
             }
 #endif
 
+            var previousPictureInPictureAvailableValue = false
             if let playerView = view.playerView {
                 playerView.player = player
+                previousPictureInPictureAvailableValue = playerView.isPictureInPictureAvailable
             } else {
                 let playerViewConfig = PlayerViewConfig()
                 if let pictureInPictureConfig = RCTConvert.pictureInPictureConfig(view.pictureInPictureConfig) {
@@ -55,6 +57,8 @@ class RNPlayerViewManager: RCTViewManager {
             }
             player.add(listener: view)
             view.playerView?.add(listener: view)
+
+            maybeEmitPictureInPictureAvailabilityEvent(for: view, previousState: previousPictureInPictureAvailableValue)
         }
     }
 
@@ -109,4 +113,18 @@ class RNPlayerViewManager: RCTViewManager {
     private func getFullscreenHandlerModule() -> FullscreenHandlerModule? {
         bridge.module(for: FullscreenHandlerModule.self) as? FullscreenHandlerModule
     }
+
+    private func maybeEmitPictureInPictureAvailabilityEvent(for view: RNPlayerView, previousState: Bool) {
+        guard let playerView = view.playerView,
+              playerView.isPictureInPictureAvailable != previousState else {
+            return
+        }
+        let event: [AnyHashable: Any] = [
+            "isPictureInPictureAvailable": playerView.isPictureInPictureAvailable,
+            "name": "onPictureInPictureAvailabilityChanged",
+            "timestamp": Date().timeIntervalSince1970
+        ]
+        view.onPictureInPictureAvailabilityChanged?(event)
+    }
+
 }

--- a/ios/RNPlayerViewManager.swift
+++ b/ios/RNPlayerViewManager.swift
@@ -83,27 +83,27 @@ class RNPlayerViewManager: RCTViewManager {
         self.customMessageHandlerBridgeId = customMessageHandlerBridgeId
     }
 
-     @objc func setFullscreen(_ viewId: NSNumber, isFullscreen: Bool) {
-         bridge.uiManager.addUIBlock { [weak self] _, views in
-             guard
-                 let self,
-                 let view = views?[viewId] as? RNPlayerView
-             else {
-                 return
-             }
-             guard let playerView = view.playerView else {
-                 return
-             }
-             guard playerView.isFullscreen != isFullscreen else {
-                 return
-             }
-             if isFullscreen {
-                 playerView.enterFullscreen()
-             } else {
-                 playerView.exitFullscreen()
-             }
-         }
-     }
+    @objc func setFullscreen(_ viewId: NSNumber, isFullscreen: Bool) {
+        bridge.uiManager.addUIBlock { [weak self] _, views in
+            guard
+                let self,
+                let view = views?[viewId] as? RNPlayerView
+            else {
+                return
+            }
+            guard let playerView = view.playerView else {
+                return
+            }
+            guard playerView.isFullscreen != isFullscreen else {
+                return
+            }
+            if isFullscreen {
+                playerView.enterFullscreen()
+            } else {
+                playerView.exitFullscreen()
+            }
+        }
+    }
 
     /// Fetches the initialized `PlayerModule` instance on RN's bridge object.
     private func getPlayerModule() -> PlayerModule? {

--- a/ios/RNPlayerViewManager.swift
+++ b/ios/RNPlayerViewManager.swift
@@ -127,5 +127,4 @@ class RNPlayerViewManager: RCTViewManager {
         ]
         view.onPictureInPictureAvailabilityChanged?(event)
     }
-
 }

--- a/src/components/PlayerView/events.ts
+++ b/src/components/PlayerView/events.ts
@@ -208,7 +208,6 @@ interface EventProps {
   onPaused: PausedEvent;
   /**
    * Event mitted when the availability of the Picture in Picture mode changed.
-   * @platform Android
    */
   onPictureInPictureAvailabilityChanged: PictureInPictureAvailabilityChangedEvent;
   /**


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
We don't support `onPictureInPictureAvailabilityChanged` on iOS and this way it is not possible to tell if PiP is available.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Emitting `onPictureInPictureAvailabilityChanged` on iOS and tvOS to allow detection of PiP availability.

## Checklist
- [x] 🗒 `CHANGELOG` entry
