### PR TITLE
Implement `LiveConfig`: `minTimeshiftBufferDepth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `LiveConfig.minTimeshiftBufferDepth` to control the minimum buffer depth of a stream needed to enable time shifting.
+
 ## [0.13.0] (2023-10-20)
 
 ### Added

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -26,6 +26,7 @@ import com.bitmovin.player.api.event.PlayerEvent
 import com.bitmovin.player.api.event.SourceEvent
 import com.bitmovin.player.api.event.data.CastPayload
 import com.bitmovin.player.api.event.data.SeekPosition
+import com.bitmovin.player.api.live.LiveConfig
 import com.bitmovin.player.api.media.AdaptationConfig
 import com.bitmovin.player.api.media.audio.AudioTrack
 import com.bitmovin.player.api.media.subtitle.SubtitleTrack
@@ -114,6 +115,11 @@ class JsonConverter {
             if (json.hasKey("bufferConfig")) {
                 toBufferConfig(json.getMap("bufferConfig"))?.let {
                     playerConfig.bufferConfig = it
+                }
+            }
+            if (json.hasKey("liveConfig")) {
+                toLiveConfig(json.getMap("liveConfig"))?.let {
+                    playerConfig.liveConfig = it
                 }
             }
             return playerConfig
@@ -1169,6 +1175,23 @@ class JsonConverter {
             playerViewConfig = toPlayerViewConfig(json),
             pictureInPictureConfig = toPictureInPictureConfig(json.getMap("pictureInPictureConfig")),
         )
+
+        /**
+         * Converts any JS object into a [LiveConfig] object.
+         * @param json JS object representing the [LiveConfig].
+         * @return The generated [LiveConfig] if successful, `null` otherwise.
+         */
+        @JvmStatic
+        fun toLiveConfig(json: ReadableMap?): LiveConfig? {
+            if (json == null) {
+                return null
+            }
+            val liveConfig = LiveConfig()
+            if (json.hasKey("minTimeshiftBufferDepth")) {
+                liveConfig.minTimeShiftBufferDepth = json.getDouble("minTimeshiftBufferDepth")
+            }
+            return liveConfig
+        }
     }
 }
 

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -36,6 +36,9 @@ extension RCTConvert {
         if let bufferConfig = RCTConvert.bufferConfig(json["bufferConfig"]) {
             playerConfig.bufferConfig = bufferConfig
         }
+        if let liveConfig = RCTConvert.liveConfig(json["liveConfig"]) {
+            playerConfig.liveConfig = liveConfig
+        }
 #if os(iOS)
         if let remoteControlConfig = RCTConvert.remoteControlConfig(json["remoteControlConfig"]) {
             playerConfig.remoteControlConfig = remoteControlConfig
@@ -189,6 +192,22 @@ extension RCTConvert {
             bufferConfig.audioAndVideo = bufferMediaTypeConfig
         }
         return bufferConfig
+    }
+
+    /**
+     Utility method to instantiate a `LiveConfig` from a JS object.
+     - Parameter json: JS object.
+     - Returns: The produced `LiveConfig` object, or `nil` if `json` is not valid.
+     */
+    static func liveConfig(_ json: Any?) -> LiveConfig? {
+        guard let json = json as? [String: Any?] else {
+            return nil
+        }
+        let liveConfig = LiveConfig()
+        if let minTimeshiftBufferDepth = json["minTimeshiftBufferDepth"] as? NSNumber {
+            liveConfig.minTimeshiftBufferDepth = minTimeshiftBufferDepth.doubleValue
+        }
+        return liveConfig
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,3 +21,4 @@ export * from './tweaksConfig';
 export * from './bufferConfig';
 export * from './playbackConfig';
 export * from './playerConfig';
+export * from './liveConfig';

--- a/src/liveConfig.ts
+++ b/src/liveConfig.ts
@@ -1,0 +1,12 @@
+/**
+ * Contains config values regarding the behaviour when playing live streams.
+ */
+export interface LiveConfig {
+  /**
+   * The minimum buffer depth of a stream needed to enable time shifting.
+   * When the internal value for the maximal possible timeshift is lower than this value,
+   * timeshifting should be disabled. That means `Player.maxTimeShift` returns `0` in that case.
+   * This value should always be non-positive value, default value is `-40`.
+   */
+  minTimeshiftBufferDepth?: number;
+}

--- a/src/playerConfig.ts
+++ b/src/playerConfig.ts
@@ -7,6 +7,7 @@ import { RemoteControlConfig } from './remoteControlConfig';
 import { BufferConfig } from './bufferConfig';
 import { NativeInstanceConfig } from './nativeInstance';
 import { PlaybackConfig } from './playbackConfig';
+import { LiveConfig } from './liveConfig';
 
 /**
  * Object used to configure a new `Player` instance.
@@ -63,4 +64,8 @@ export interface PlayerConfig extends NativeInstanceConfig {
    * Configures buffer settings. A default {@link BufferConfig} is set initially.
    */
   bufferConfig?: BufferConfig;
+  /**
+   * Configures behaviour when playing live content. A default {@link LiveConfig} is set initially.
+   */
+  liveConfig?: LiveConfig;
 }


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Add `LiveConfig` and its `minTimeshiftBufferDepth` property to control the minimum buffer depth of a stream needed to enable time shifting.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
- Add `LiveConfig`
- Add `minTimeshiftBufferDepth` property to `LiveConfig`

## Testing

Apply this patch, open **Basic Playback**, and look at the logs on Metro
[patch.diff.txt](https://github.com/bitmovin/bitmovin-player-react-native/files/13072168/patch.diff.txt)

Checks:
- `minTimeshiftBufferDepth` should be set to `-11.2`

## Checklist
- [x] 🗒 `CHANGELOG` entry
