### PR TITLE
State that isBackgroundPlaybackEnabled flag is available on iOS only

### DIFF
--- a/src/playbackConfig.ts
+++ b/src/playbackConfig.ts
@@ -39,8 +39,6 @@ export interface PlaybackConfig {
    */
   isTimeShiftEnabled?: boolean;
   /**
-   * @platform iOS, tvOS
-   *
    * Whether background playback is enabled or not.
    * Default is `false`.
    *
@@ -61,6 +59,7 @@ export interface PlaybackConfig {
    *   }
    * })
    * ```
+   * @platform iOS, tvOS
    */
   isBackgroundPlaybackEnabled?: boolean;
   /**

--- a/src/playbackConfig.ts
+++ b/src/playbackConfig.ts
@@ -39,7 +39,7 @@ export interface PlaybackConfig {
    */
   isTimeShiftEnabled?: boolean;
   /**
-   * iOS only.
+   * @platform iOS, tvOS
    *
    * Whether background playback is enabled or not.
    * Default is `false`.

--- a/src/playbackConfig.ts
+++ b/src/playbackConfig.ts
@@ -39,6 +39,8 @@ export interface PlaybackConfig {
    */
   isTimeShiftEnabled?: boolean;
   /**
+   * iOS only.
+   *
    * Whether background playback is enabled or not.
    * Default is `false`.
    *


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
`isBackgroundPlaybackEnabled` configuration is available only on iOS, but this is not stated in the documentation.

## Checklist
- [ ] 🗒 `CHANGELOG` entry
