### PR TITLE
Android: Playback doesn't pause when app goes to background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - `Player.buffer` to control buffer preferences and to query the current buffer state
 - `DownloadFinishedEvent` to signal when the download of specific content has finished
 
+### Fixed
+
+- Android: Playback doesn't pause when app goes to background
+
 ## [0.13.0] (2023-10-20)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Android: Playback doesn't pause when app goes to background
+- Android: `PlayerView.onDestroy` not being called when the view is detached from the view hierarchy
 
 ## [0.13.0] (2023-10-20)
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -3,7 +3,6 @@ package com.bitmovin.player.reactnative
 import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.graphics.Rect
-import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -98,7 +98,8 @@ private val EVENT_CLASS_TO_REACT_NATIVE_NAME_MAPPING_UI = mapOf<KClass<out Event
 class RNPlayerView(
     private val context: ReactApplicationContext,
 ) : LinearLayout(context), View.OnLayoutChangeListener, RNPictureInPictureDelegate {
-    private val activityLifecycle = (context.currentActivity as ReactActivity).lifecycle
+    private val activityLifecycle = (context.currentActivity as? ReactActivity)?.lifecycle
+        ?: error("Trying to create an instance of ${this::class.simpleName} while not attached to a ReactActivity")
 
     private val activityLifecycleObserver = object : DefaultLifecycleObserver {
         override fun onStart(owner: LifecycleOwner) {


### PR DESCRIPTION
## Description (PRN-81)
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Player doesn't pause as intended when app goes to the background. This was due to `PlayerView.onStop` not being called.

Unfortunately the React Native's LifecycleEventListener doesn't have `onHostStop` and `onHostStart` lifecycle methods, which we need so I migrated to Activity lifecycle observer.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
- Replace `LifecycleEventListener` with `DefaultLifecycleObserver`
- Remove the unneeded PiP handling
- dispose function now also calls `playerView.onDestroy`

## Checklist
- [x] 🗒 `CHANGELOG` entry
