### PR TITLE
Decouple player view and player lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Android: `PlayerView` destroys attached `Player` instance on destroy. `Player` life cycle must be handled on the creation side
+- Android: `PlayerView` destroys attached `Player` instance on destroy. `Player` lifecycle must be handled on the creation side
 
 ## [0.14.0] (2023-11-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Android: `PlayerView` destroys attached `Player` instance on destroy. `Player` life cycle must be handled on the creation side
+
 ## [0.14.0] (2023-11-14)
 
 ### Added

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -149,6 +149,7 @@ class RNPlayerView(
 
     private var _playerView: PlayerView? = null
         set(value) {
+            field?.removeOnLayoutChangeListener(this)
             field = value
             viewEventRelay.eventEmitter = field
             playerEventRelay.eventEmitter = field?.player
@@ -193,7 +194,6 @@ class RNPlayerView(
         // As a different component is creating the player instance, the other component
         // is responsible for destroying the player in the end.
         playerView.player = null
-        playerView.removeOnLayoutChangeListener(this)
         playerView.onDestroy()
     }
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -157,8 +157,7 @@ class RNPlayerView(
     /**
      * Associated Bitmovin's `PlayerView`.
      */
-    val playerView: PlayerView?
-        get() = _playerView
+    val playerView: PlayerView? get() = _playerView
 
     private var subtitleView: SubtitleView? = null
 
@@ -186,16 +185,16 @@ class RNPlayerView(
      * Cleans up the resources and listeners produced by this view.
      */
     fun dispose() {
-        _playerView?.run {
-            removeOnLayoutChangeListener(this@RNPlayerView)
-            // The `RNPlayerView` should not take care of the player lifecycle.
-            // As a different component is creating the player instance, the other component
-            // is responsible for destroying the player in the end.
-            player = null
-            onDestroy()
-        }
-        _playerView = null
         activityLifecycle.removeObserver(activityLifecycleObserver)
+
+        val playerView = _playerView ?: return
+        _playerView = null
+        // The `RNPlayerView` should not take care of the player lifecycle.
+        // As a different component is creating the player instance, the other component
+        // is responsible for destroying the player in the end.
+        playerView.player = null
+        playerView.removeOnLayoutChangeListener(this)
+        playerView.onDestroy()
     }
 
     /**

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -186,10 +186,15 @@ class RNPlayerView(
      * Cleans up the resources and listeners produced by this view.
      */
     fun dispose() {
-        viewEventRelay.eventEmitter = null
-        playerEventRelay.eventEmitter = null
-        playerView?.removeOnLayoutChangeListener(this)
-        playerView?.onDestroy()
+        _playerView?.run {
+            removeOnLayoutChangeListener(this@RNPlayerView)
+            // The `RNPlayerView` should not take care of the player lifecycle.
+            // As a different component is creating the player instance, the other component
+            // is responsible for destroying the player in the end.
+            player = null
+            onDestroy()
+        }
+        _playerView = null
         activityLifecycle.removeObserver(activityLifecycleObserver)
     }
 


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
The `RNPlayerView` takes charge of the `Player` life cycle. As the `Player` is created independently of the `PlayerView` (and then the player is explicitly attached to the view), it is unexpected that the `PlayerView` destroys the `Player` once itself is destroyed.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Detach the `Player` from the `RNPlayerView`/`PlayerView` internally, when the `RNPlayerView` is disposed and before the `PlayerView` is destroyed.

## Checklist
- [x] 🗒 `CHANGELOG` entry
