### PR TITLE
Fix incomplete `onEvent` payload on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- iOS: `onEvent` on iOS has partial payload information
+- iOS: `onEvent` on iOS has incomplete payload information
 
 ## [0.14.1] (2023-11-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- iOS: `onEvent` on iOS has partial payload information
+
 ## [0.14.1] (2023-11-16)
 
 ### Fixed

--- a/ios/DefaultJsonConvertibleEvent.swift
+++ b/ios/DefaultJsonConvertibleEvent.swift
@@ -1,0 +1,9 @@
+import BitmovinPlayer
+
+/// Used when the event has no additional data
+internal protocol DefaultJsonConvertibleEvent: JsonConvertible {}
+internal extension DefaultJsonConvertibleEvent where Self: Event {
+    func toJSON() -> [AnyHashable: Any] {
+        toEventJSON { [:] }
+    }
+}

--- a/ios/Event+JSON.swift
+++ b/ios/Event+JSON.swift
@@ -15,47 +15,7 @@ extension Source {
     }
 }
 
-extension SeekEvent {
-    func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "from": [
-                "time": from.time,
-                "source": from.source.toJSON()
-            ],
-            "to": [
-                "time": to.time,
-                "source": to.source.toJSON()
-            ]
-        ]
-    }
-}
-
-extension TimeShiftEvent {
-    func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "position": position,
-            "targetPosition": target
-        ]
-    }
-}
-
-extension TimeChangedEvent {
-    func toJSON() -> [AnyHashable: Any] {
-        ["name": name, "timestamp": timestamp, "currentTime": currentTime]
-    }
-}
-
-extension Event {
-    func toJSON() -> [AnyHashable: Any] {
-        ["name": name, "timestamp": timestamp]
-    }
-}
-
-extension NSError {
+extension NSError: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
         [
             "code": code,
@@ -66,7 +26,7 @@ extension NSError {
     }
 }
 
-extension DeficiencyData {
+extension DeficiencyData: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
         var json: [AnyHashable: Any] = ["code": code, "message": message]
         if let underlyingError {
@@ -76,7 +36,54 @@ extension DeficiencyData {
     }
 }
 
-private protocol ErrorEventType: Event {
+extension Event where Self: JsonConvertible {
+    func toEventJSON(_ eventPayloadBuilder: () -> [AnyHashable: Any]) -> [AnyHashable: Any] {
+        var json: [AnyHashable: Any] = [
+            "name": name,
+            "timestamp": timestamp,
+        ]
+        json.merge(eventPayloadBuilder()) { _, new in new }
+        return json
+    }
+}
+
+extension SeekEvent: JsonConvertible {
+    func toJSON() -> [AnyHashable: Any] {
+        toEventJSON {
+            [
+                "from": [
+                    "time": from.time,
+                    "source": from.source.toJSON()
+                ],
+                "to": [
+                    "time": to.time,
+                    "source": to.source.toJSON()
+                ]
+            ]
+        }
+    }
+}
+
+extension TimeShiftEvent: JsonConvertible {
+    func toJSON() -> [AnyHashable: Any] {
+        toEventJSON {
+            [
+                "position": position,
+                "targetPosition": target
+            ]
+        }
+    }
+}
+
+extension TimeChangedEvent: JsonConvertible {
+    func toJSON() -> [AnyHashable: Any] {
+        toEventJSON {
+            ["currentTime": currentTime]
+        }
+    }
+}
+
+private protocol ErrorEventType: Event, JsonConvertible {
     associatedtype Code
     var code: Code { get }
     var data: DeficiencyData? { get }
@@ -85,16 +92,16 @@ private protocol ErrorEventType: Event {
 
 extension ErrorEventType {
     func toJSON() -> [AnyHashable: Any] {
-        var json: [AnyHashable: Any] = [
-            "name": name,
-            "timestamp": timestamp,
-            "code": code,
-            "message": message
-        ]
-        if let data {
-            json["data"] = data.toJSON()
+        toEventJSON {
+            var json: [AnyHashable: Any] = [
+                "code": code,
+                "message": message
+            ]
+            if let data {
+                json["data"] = data.toJSON()
+            }
+            return json
         }
-        return json
     }
 }
 
@@ -114,13 +121,15 @@ extension SourceWarningEvent: ErrorEventType {
     typealias Code = SourceWarning.Code
 }
 
-private protocol SourceEventType: Event {
+private protocol SourceEventType: Event, JsonConvertible {
     var source: Source { get }
 }
 
 extension SourceEventType {
     func toJSON() -> [AnyHashable: Any] {
-        ["name": name, "timestamp": timestamp, "source": source.toJSON()]
+        toEventJSON {
+            ["source": source.toJSON()]
+        }
     }
 }
 
@@ -128,13 +137,15 @@ extension SourceLoadEvent: SourceEventType {}
 extension SourceLoadedEvent: SourceEventType {}
 extension SourceUnloadedEvent: SourceEventType {}
 
-private protocol TimedEventType: Event {
+private protocol TimedEventType: Event, JsonConvertible {
     var time: TimeInterval { get }
 }
 
 extension TimedEventType {
     func toJSON() -> [AnyHashable: Any] {
-        ["name": name, "timestamp": timestamp, "time": time]
+        toEventJSON {
+            ["time": time]
+        }
     }
 }
 
@@ -142,263 +153,289 @@ extension PlayEvent: TimedEventType {}
 extension PausedEvent: TimedEventType {}
 extension PlayingEvent: TimedEventType {}
 
-extension AudioAddedEvent {
+extension AudioAddedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "audioTrack": RCTConvert.audioTrackJson(audioTrack),
-            "time": time
-        ]
+        toEventJSON {
+            [
+                "audioTrack": RCTConvert.audioTrackJson(audioTrack),
+                "time": time
+            ]
+        }
     }
 }
 
-extension AudioRemovedEvent {
+extension AudioRemovedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "audioTrack": RCTConvert.audioTrackJson(audioTrack),
-            "time": time
-        ]
+        toEventJSON {
+            [
+                "audioTrack": RCTConvert.audioTrackJson(audioTrack),
+                "time": time
+            ]
+        }
     }
 }
 
-extension AudioChangedEvent {
+extension AudioChangedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "oldAudioTrack": RCTConvert.audioTrackJson(audioTrackOld),
-            "newAudioTrack": RCTConvert.audioTrackJson(audioTrackNew)
-        ]
+        toEventJSON {
+            [
+                "oldAudioTrack": RCTConvert.audioTrackJson(audioTrackOld),
+                "newAudioTrack": RCTConvert.audioTrackJson(audioTrackNew)
+            ]
+        }
     }
 }
 
-extension SubtitleAddedEvent {
+extension SubtitleAddedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "subtitleTrack": RCTConvert.subtitleTrackJson(subtitleTrack)
-        ]
+        toEventJSON {
+            [
+                "subtitleTrack": RCTConvert.subtitleTrackJson(subtitleTrack)
+            ]
+        }
     }
 }
 
-extension SubtitleRemovedEvent {
+extension SubtitleRemovedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "subtitleTrack": RCTConvert.subtitleTrackJson(subtitleTrack)
-        ]
+        toEventJSON {
+            [
+                "subtitleTrack": RCTConvert.subtitleTrackJson(subtitleTrack)
+            ]
+        }
     }
 }
 
-extension SubtitleChangedEvent {
+extension SubtitleChangedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "oldSubtitleTrack": RCTConvert.subtitleTrackJson(subtitleTrackOld),
-            "newSubtitleTrack": RCTConvert.subtitleTrackJson(subtitleTrackNew)
-        ]
+        toEventJSON {
+            [
+                "oldSubtitleTrack": RCTConvert.subtitleTrackJson(subtitleTrackOld),
+                "newSubtitleTrack": RCTConvert.subtitleTrackJson(subtitleTrackNew)
+            ]
+        }
     }
 }
 
-extension AdBreakFinishedEvent {
+extension AdBreakFinishedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "adBreak": RCTConvert.toJson(adBreak: adBreak)
-        ]
+        toEventJSON {
+            [
+                "adBreak": RCTConvert.toJson(adBreak: adBreak)
+            ]
+        }
     }
 }
 
-extension AdBreakStartedEvent {
+extension AdBreakStartedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "adBreak": RCTConvert.toJson(adBreak: adBreak)
-        ]
+        toEventJSON {
+            [
+                "adBreak": RCTConvert.toJson(adBreak: adBreak)
+            ]
+        }
     }
 }
 
-extension AdClickedEvent {
+extension AdClickedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "clickThroughUrl": clickThroughUrl
-        ]
+        toEventJSON {
+            [
+                "clickThroughUrl": clickThroughUrl
+            ]
+        }
     }
 }
 
-extension AdErrorEvent {
+extension AdErrorEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "adConfig": RCTConvert.toJson(adConfig: adConfig),
-            "adItem": RCTConvert.toJson(adItem: adItem),
-            "code": code,
-            "message": message
-        ]
+        toEventJSON {
+            [
+                "adConfig": RCTConvert.toJson(adConfig: adConfig),
+                "adItem": RCTConvert.toJson(adItem: adItem),
+                "code": code,
+                "message": message
+            ]
+        }
     }
 }
 
-extension AdFinishedEvent {
+extension AdFinishedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "ad": RCTConvert.toJson(ad: ad)
-        ]
+        toEventJSON {
+            [
+                "ad": RCTConvert.toJson(ad: ad)
+            ]
+        }
     }
 }
 
-extension AdManifestLoadEvent {
+extension AdManifestLoadEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "adBreak": RCTConvert.toJson(adBreak: adBreak),
-            "adConfig": RCTConvert.toJson(adConfig: adConfig)
-        ]
+        toEventJSON {
+            [
+                "adBreak": RCTConvert.toJson(adBreak: adBreak),
+                "adConfig": RCTConvert.toJson(adConfig: adConfig)
+            ]
+        }
     }
 }
 
-extension AdManifestLoadedEvent {
+extension AdManifestLoadedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "adBreak": RCTConvert.toJson(adBreak: adBreak),
-            "adConfig": RCTConvert.toJson(adConfig: adConfig),
-            "downloadTime": downloadTime
-        ]
+        toEventJSON {
+            [
+                "adBreak": RCTConvert.toJson(adBreak: adBreak),
+                "adConfig": RCTConvert.toJson(adConfig: adConfig),
+                "downloadTime": downloadTime
+            ]
+        }
     }
 }
 
-extension AdQuartileEvent {
+extension AdQuartileEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "quartile": RCTConvert.toJson(adQuartile: adQuartile)
-        ]
+        toEventJSON {
+            [
+                "quartile": RCTConvert.toJson(adQuartile: adQuartile)
+            ]
+        }
     }
 }
 
-extension AdScheduledEvent {
+extension AdScheduledEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "numberOfAds": numberOfAds
-        ]
+        toEventJSON {
+            [
+                "numberOfAds": numberOfAds
+            ]
+        }
     }
 }
 
-extension AdSkippedEvent {
+extension AdSkippedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "ad": RCTConvert.toJson(ad: ad)
-        ]
+        toEventJSON {
+            [
+                "ad": RCTConvert.toJson(ad: ad)
+            ]
+        }
     }
 }
 
-extension AdStartedEvent {
+extension AdStartedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "ad": RCTConvert.toJson(ad: ad),
-            "clickThroughUrl": clickThroughUrl?.absoluteString,
-            "clientType": RCTConvert.toJson(adSourceType: clientType),
-            "duration": duration,
-            "indexInQueue": indexInQueue,
-            "position": position,
-            "skipOffset": skipOffset,
-            "timeOffset": timeOffset
-        ]
+        toEventJSON {
+            [
+                "ad": RCTConvert.toJson(ad: ad),
+                "clickThroughUrl": clickThroughUrl?.absoluteString,
+                "clientType": RCTConvert.toJson(adSourceType: clientType),
+                "duration": duration,
+                "indexInQueue": indexInQueue,
+                "position": position,
+                "skipOffset": skipOffset,
+                "timeOffset": timeOffset
+            ]
+        }
     }
 }
 
-extension VideoDownloadQualityChangedEvent {
+extension VideoDownloadQualityChangedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "newVideoQuality": RCTConvert.toJson(videoQuality: videoQualityNew),
-            "oldVideoQuality": RCTConvert.toJson(videoQuality: videoQualityOld),
-            "name": name,
-            "timestamp": timestamp
-        ]
+        toEventJSON {
+            [
+                "newVideoQuality": RCTConvert.toJson(videoQuality: videoQualityNew),
+                "oldVideoQuality": RCTConvert.toJson(videoQuality: videoQualityOld),
+            ]
+        }
     }
 }
 
-extension VideoPlaybackQualityChangedEvent {
+extension VideoPlaybackQualityChangedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "newVideoQuality": RCTConvert.toJson(videoQuality: videoQualityNew),
-            "oldVideoQuality": RCTConvert.toJson(videoQuality: videoQualityOld),
-            "name": name,
-            "timestamp": timestamp
-        ]
+        toEventJSON {
+            [
+                "newVideoQuality": RCTConvert.toJson(videoQuality: videoQualityNew),
+                "oldVideoQuality": RCTConvert.toJson(videoQuality: videoQualityOld),
+            ]
+        }
     }
 }
 
-extension CastStartedEvent {
+extension CastStartedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "deviceName": deviceName
-        ]
+        toEventJSON {
+            [
+                "deviceName": deviceName
+            ]
+        }
     }
 }
 
 #if os(iOS)
-extension CastWaitingForDeviceEvent {
+extension CastWaitingForDeviceEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "castPayload": RCTConvert.toJson(castPayload: castPayload)
-        ]
+        toEventJSON {
+            [
+                "castPayload": RCTConvert.toJson(castPayload: castPayload)
+            ]
+        }
     }
 }
 #endif
 
-extension DownloadFinishedEvent {
+extension DownloadFinishedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        var json: [AnyHashable: Any] = [
-            "name": name,
-            "timestamp": timestamp,
-            "downloadTime": downloadTime,
-            "requestType": requestType.rawValue,
-            "httpStatus": httpStatus,
-            "isSuccess": successful,
-            "size": size,
-            "url": url.absoluteString
-        ]
-        if let lastRedirectLocation {
-            json["lastRedirectLocation"] = lastRedirectLocation.absoluteString
+        toEventJSON {
+            var json: [AnyHashable: Any] = [
+                "downloadTime": downloadTime,
+                "requestType": requestType.rawValue,
+                "httpStatus": httpStatus,
+                "isSuccess": successful,
+                "size": size,
+                "url": url.absoluteString
+            ]
+            if let lastRedirectLocation {
+                json["lastRedirectLocation"] = lastRedirectLocation.absoluteString
+            }
+            return json
         }
-        return json
     }
 }
 
-extension PlaybackSpeedChangedEvent {
+extension PlaybackSpeedChangedEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
-        [
-            "name": name,
-            "timestamp": timestamp,
-            "from": from,
-            "to": to,
-        ]
+        toEventJSON {
+            [
+                "from": from,
+                "to": to,
+            ]
+        }
     }
 }
+
+extension PlayerActiveEvent: DefaultJsonConvertibleEvent {}
+extension DestroyEvent: DefaultJsonConvertibleEvent {}
+extension MutedEvent: DefaultJsonConvertibleEvent {}
+extension UnmutedEvent: DefaultJsonConvertibleEvent {}
+extension ReadyEvent: DefaultJsonConvertibleEvent {}
+extension PlaybackFinishedEvent: DefaultJsonConvertibleEvent {}
+extension SeekedEvent: DefaultJsonConvertibleEvent {}
+extension TimeShiftedEvent: DefaultJsonConvertibleEvent {}
+extension StallStartedEvent: DefaultJsonConvertibleEvent {}
+extension StallEndedEvent: DefaultJsonConvertibleEvent {}
+extension CastAvailableEvent: DefaultJsonConvertibleEvent {}
+extension CastPausedEvent: DefaultJsonConvertibleEvent {}
+extension CastPlaybackFinishedEvent: DefaultJsonConvertibleEvent {}
+extension CastPlayingEvent: DefaultJsonConvertibleEvent {}
+extension CastStartEvent: DefaultJsonConvertibleEvent {}
+extension CastStoppedEvent: DefaultJsonConvertibleEvent {}
+extension CastTimeUpdatedEvent: DefaultJsonConvertibleEvent {}
+extension PictureInPictureEnterEvent: DefaultJsonConvertibleEvent {}
+extension PictureInPictureEnteredEvent: DefaultJsonConvertibleEvent {}
+extension PictureInPictureExitEvent: DefaultJsonConvertibleEvent {}
+extension PictureInPictureExitedEvent: DefaultJsonConvertibleEvent {}
+extension FullscreenEnterEvent: DefaultJsonConvertibleEvent {}
+extension FullscreenExitEvent: DefaultJsonConvertibleEvent {}
+extension FullscreenEnabledEvent: DefaultJsonConvertibleEvent {}
+extension FullscreenDisabledEvent: DefaultJsonConvertibleEvent {}

--- a/ios/JsonConvertible.swift
+++ b/ios/JsonConvertible.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+internal protocol JsonConvertible {
+    func toJSON() -> [AnyHashable: Any]
+}

--- a/ios/OfflineContentManagerBridge.swift
+++ b/ios/OfflineContentManagerBridge.swift
@@ -158,7 +158,7 @@ internal class OfflineContentManagerBridge: NSObject, OfflineContentManagerListe
             "state": RCTConvert.toJson(offlineState: offlineContentManager.offlineState)
         ]
 
-        var eventBody = baseEvent.merging(body) { current, _ in current }
+        let eventBody = baseEvent.merging(body) { current, _ in current }
 
         do {
             try eventEmitter?.sendEvent(withName: "BitmovinOfflineEvent", body: eventBody)

--- a/ios/RNPlayerView+PlayerListener.swift
+++ b/ios/RNPlayerView+PlayerListener.swift
@@ -2,7 +2,8 @@ import BitmovinPlayer
 
 extension RNPlayerView: PlayerListener {
     public func onEvent(_ event: Event, player: Player) {
-        onEvent?(event.toJSON())
+        guard let jsonConvertibleEvent = event as? JsonConvertible else { return }
+        onEvent?(jsonConvertibleEvent.toJSON())
     }
 
     public func onPlayerActive(_ event: PlayerActiveEvent, player: Player) {


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
`onEvent` listener receives only `name` and `timestamp` properties as its payload, regardless of the actual event.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
The problem is that functions declared in extensions in Swift don't support runtime polymorphism, therefore when calling `event.toJSON()` when `event` has type `Event`, it will invoke the one from `extension Event`, not the actual type's implementation.

To address this I made the JSON serialization protocol-based, thus enabling runtime dynamic dispatch for method calls, resulting in runtime polymorphism.

At I implemented the same approach as we have for Android, with `JSONConverter`, but that way we would lose the ability to detect missing event serialization during compilation when new events are introduced.

## Checklist
- [x] 🗒 `CHANGELOG` entry
