### PR TITLE
Fix Picture in Picture sample screen layout on tvOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Android: `PlayerView` destroys attached `Player` instance on destroy. `Player` lifecycle must be handled on the creation side
+- tvOS: Picture in Picture sample screen has unwanted padding
 
 ## [0.14.0] (2023-11-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@
 
 - Android: `onEvent` callback not being called on `PlayerView`
 - iOS: `onEvent` on iOS has incomplete payload information
+- tvOS: Picture in Picture sample screen has unwanted padding
 
 ## [0.14.1] (2023-11-16)
 
 ### Fixed
 
 - Android: `PlayerView` destroys attached `Player` instance on destroy. `Player` lifecycle must be handled on the creation side
-- tvOS: Picture in Picture sample screen has unwanted padding
 
 ## [0.14.0] (2023-11-14)
 

--- a/example/src/screens/BasicPictureInPicture.tsx
+++ b/example/src/screens/BasicPictureInPicture.tsx
@@ -118,7 +118,7 @@ export default function BasicPictureInPicture({
 
   return (
     <SafeAreaView
-      edges={['bottom', 'left', 'right']}
+      edges={Platform.isTV ? [] : ['bottom', 'left', 'right']}
       style={
         // On Android, we need to remove the padding from the container when in PiP mode.
         Platform.OS === 'android' && isInPictureInPicture
@@ -147,7 +147,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: 'white',
-    padding: 10,
+    padding: Platform.isTV ? 0 : 10,
   },
   player: {
     flex: 1,

--- a/example/src/screens/BasicPictureInPicture.tsx
+++ b/example/src/screens/BasicPictureInPicture.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Button, Platform, StyleSheet } from 'react-native';
+import { Button, Platform, StyleSheet, View, ViewProps } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import {
   Event,
@@ -116,9 +116,9 @@ export default function BasicPictureInPicture({
     []
   );
 
+  const ContainerView = Platform.isTV ? View : SafeAreaContainer;
   return (
-    <SafeAreaView
-      edges={Platform.isTV ? [] : ['bottom', 'left', 'right']}
+    <ContainerView
       style={
         // On Android, we need to remove the padding from the container when in PiP mode.
         Platform.OS === 'android' && isInPictureInPicture
@@ -137,8 +137,12 @@ export default function BasicPictureInPicture({
         onPictureInPictureExit={onPictureInPictureExitEvent}
         onPictureInPictureExited={onEvent}
       />
-    </SafeAreaView>
+    </ContainerView>
   );
+}
+
+function SafeAreaContainer(props: ViewProps): JSX.Element {
+  return <SafeAreaView edges={['bottom', 'left', 'right']} {...props} />;
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Found that on tvOS playback can not be controlled when using the Picture in Picture sample screen.
This is due to the player not taking the whole screen. This is a feature from Apple to not have controls for inline players shown.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Replaced `SafeAreaView` for tvOS with `View` works now.

Note: I tried changing `edges` property to `[]` but that didn't work as expected on tvOS simulator.

|Before|After|
|---|---|
|![Simulator Screenshot - Apple TV 17 0 - 2023-11-24 at 11 03 05](https://github.com/bitmovin/bitmovin-player-react-native/assets/2691371/0166454d-3c6e-469d-8ef2-5c107f4c7965)|![Simulator Screenshot - Apple TV 17 0 - 2023-11-24 at 11 01 08](https://github.com/bitmovin/bitmovin-player-react-native/assets/2691371/dbaa5974-d67d-4509-b0b3-30ebe7a312c3)|

## Checklist
- [x] 🗒 `CHANGELOG` entry
