### PR TITLE
Hide home indicator on iOS when entering fullscreen mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Android: `onEvent` callback not being called on `PlayerView`
 - iOS: `onEvent` on iOS has incomplete payload information
+- iOS: hide home indicator when entering fullscreen mode in the example application
 
 ## [0.14.1] (2023-11-16)
 

--- a/example/src/screens/BasicFullscreenHandling.tsx
+++ b/example/src/screens/BasicFullscreenHandling.tsx
@@ -78,6 +78,7 @@ export default function BasicFullscreenHandling({
       setFullscreenMode(isFullscreen);
       navigation.setOptions({
         headerShown: !isFullscreen, // show/hide top bar
+        autoHideHomeIndicator: isFullscreen, // show/hide home indicator on iOS
       });
     })
   ).current;

--- a/example/src/screens/LandscapeFullscreenHandling.tsx
+++ b/example/src/screens/LandscapeFullscreenHandling.tsx
@@ -84,7 +84,10 @@ export default function LandscapeFullscreenHandling({
     new SampleFullscreenHandler(fullscreenMode, (isFullscreen: boolean) => {
       console.log('on fullscreen change');
       setFullscreenMode(isFullscreen);
-      navigation.setOptions({ headerShown: !isFullscreen });
+      navigation.setOptions({
+        headerShown: !isFullscreen, // show/hide top bar
+        autoHideHomeIndicator: isFullscreen, // show/hide home indicator on iOS
+      });
     })
   ).current;
   useFocusEffect(


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
When entering fullscreen on your iOS device, the home indicator stays on-screen.
Usually, video players hide it, once they present fullscreen.

This was raised in a community post here: https://community.bitmovin.com/t/cannot-hide-ios-home-indicator-in-fullscreen/2449

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Showcasing how to hide the home indicator from React Native by using [`autohidehomeindicator`](https://reactnavigation.org/docs/native-stack-navigator/#autohidehomeindicator) property.

## Checklist
- [x] 🗒 `CHANGELOG` entry
