### PR TITLE
Fix silent iOS playback when device is muted while running the example application

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Platform, Button } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { SourceType } from 'bitmovin-player-react-native';
+import { AudioSession, SourceType } from 'bitmovin-player-react-native';
 import ExamplesList from './screens/ExamplesList';
 import BasicAds from './screens/BasicAds';
 import BasicAnalytics from './screens/BasicAnalytics';
@@ -63,6 +63,20 @@ const RootStack = createNativeStackNavigator();
 const isTVOS = Platform.OS === 'ios' && Platform.isTV;
 
 export default function App() {
+  useEffect(() => {
+    // iOS audio session category must be set to `playback` first, otherwise playback
+    // will have no audio when the device is silenced.
+    // This is also required to make Picture in Picture work on iOS.
+    //
+    // Usually it's desireable to set the audio's category only once during your app's main component
+    // initialization. This way you can guarantee that your app's audio category is properly
+    // configured throughout the whole lifecycle of the application.
+    AudioSession.setCategory('playback').catch((error) => {
+      // Handle any native errors that might occur while setting the audio's category.
+      console.log("Failed to set app's audio category to `playback`:\n", error);
+    });
+  });
+
   const stackParams = {
     data: [
       {

--- a/example/src/screens/BasicPictureInPicture.tsx
+++ b/example/src/screens/BasicPictureInPicture.tsx
@@ -6,7 +6,6 @@ import {
   usePlayer,
   PlayerView,
   SourceType,
-  AudioSession,
   PictureInPictureEnterEvent,
   PictureInPictureExitEvent,
   PlayerViewConfig,
@@ -51,19 +50,6 @@ export default function BasicPictureInPicture({
 
   useFocusEffect(
     useCallback(() => {
-      // iOS audio session must be set to `playback` first otherwise PiP mode won't work.
-      //
-      // Usually it's desireable to set the audio's category only once during your app's main component
-      // initialization. This way you can guarantee that your app's audio category is properly
-      // configured throughout the whole lifecycle of the application.
-      AudioSession.setCategory('playback').catch((error) => {
-        // Handle any native errors that might occur while setting the audio's category.
-        console.log(
-          "[BasicPictureInPicture] Failed to set app's audio category to `playback`:\n",
-          error
-        );
-      });
-
       // Load desired source configuration
       player.load({
         url:


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Some developers ran into the issue of having no audio during playback, due to their device being silenced.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Setting audio session category on app level fixes this.

Documentation was updated on the following pages:
- https://developer.bitmovin.com/playback/docs/implementing-a-basic-player
- https://developer.bitmovin.com/playback/docs/react-native-how-to-let-audio-play-when-the-ios-device-is-in-silent-mode

## Checklist
- [x] 🗒 `CHANGELOG` entry - not applicable as no SDK changes were made
