### PR TITLE
Fix `loadingState` missing in source events on iOS and tvOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - iOS: `onEvent` on iOS has incomplete payload information
 - tvOS: Picture in Picture sample screen has unwanted padding
 - iOS: hide home indicator when entering fullscreen mode in the example application
+- iOS: invalid `loadingState` value in `SeekEvent`, `SourceLoadEvent`, `SourceLoadedEvent` and in `SourceUnloadedEvent`
 
 ## [0.14.1] (2023-11-16)
 

--- a/ios/Event+JSON.swift
+++ b/ios/Event+JSON.swift
@@ -5,7 +5,7 @@ extension Source {
         var json: [AnyHashable: Any] = [
             "duration": duration,
             "isActive": isActive,
-            "loadingState": loadingState,
+            "loadingState": loadingState.rawValue,
             "isAttachedToPlayer": isAttachedToPlayer
         ]
         if let metadata {

--- a/src/events.ts
+++ b/src/events.ts
@@ -9,6 +9,7 @@ import {
 import { SubtitleTrack } from './subtitleTrack';
 import { VideoQuality } from './media';
 import { AudioTrack } from './audioTrack';
+import { LoadingState } from './source';
 
 /**
  * Base event type for all events.
@@ -139,6 +140,10 @@ export interface EventSource {
    * Metadata for this event's source.
    */
   metadata?: Record<string, any>;
+  /**
+   * The current `LoadingState` of the source.
+   */
+  loadingState: LoadingState;
 }
 
 /**


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
`loadingState` is missing in events where `Source` is used as a payload on iOS and tvOS.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Using `rawValue` fixes the problem

## Checklist
- [x] 🗒 `CHANGELOG` entry
