### PR TITLE
Prepare for writing player tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,8 @@ yarn integration-test test:android
 yarn integration-test test:ios
 ```
 
+To set the license key to be used for the tests, you can set the key `"licenseKey"` in `integration_test/app.json`.
+
 See available API for testing [here](/integration_test/playertesting/PlayerTesting.ts).
 
 ### Adding new tests

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -28,4 +28,6 @@ Hint: You can provide a specific iOS simulator by name when using `--simulator` 
 yarn example ios --simulator="iPhone 14 Pro"
 ```
 
+To set the license key to be used for the tests, you can set the key `"licenseKey"` in `integration_test/app.json`.
+
 Note: The tests are currently only supported on iOS simulators and Android emulators. Running them on real devices is not supported at the moment.

--- a/integration_test/playertesting/PlayerTestWorld.ts
+++ b/integration_test/playertesting/PlayerTestWorld.ts
@@ -72,10 +72,15 @@ export default class PlayerTestWorld {
     player.initialize();
     this.player = player;
 
+    // Trick to wait for the player to be initialized
+    // otherwise initial events might be missed
+    await player.isPlaying();
+
     await fn().finally(() => {
       player.destroy();
       this.isFinished_ = true;
       this.player = undefined;
+      this.eventListeners = {};
     });
   };
 

--- a/integration_test/playertesting/PlayerTesting.ts
+++ b/integration_test/playertesting/PlayerTesting.ts
@@ -126,8 +126,8 @@ export const expectEvents = async (
  * @see {@link Player}
  * @see {@link EventType}
  */
-export const callPlayerAndExpectEvent = async <E extends Event, P>(
-  fn: (player: Player) => Promise<P>,
+export const callPlayerAndExpectEvent = async <E extends Event>(
+  fn: (player: Player) => void,
   expectationConvertible: SingleEventExpectation | EventType,
   timeoutSeconds: number = 10
 ): Promise<E> => {

--- a/integration_test/tests/helper/Sources.ts
+++ b/integration_test/tests/helper/Sources.ts
@@ -1,0 +1,13 @@
+import { SourceConfig, SourceType } from 'bitmovin-player-react-native';
+
+export const Sources = {
+  artOfMotionHls: {
+    url: 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+    type: SourceType.HLS,
+  } as SourceConfig,
+
+  artOfMotionDash: {
+    url: 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+    type: SourceType.DASH,
+  } as SourceConfig,
+};

--- a/ios/Event+JSON.swift
+++ b/ios/Event+JSON.swift
@@ -5,7 +5,7 @@ extension Source {
         var json: [AnyHashable: Any] = [
             "duration": duration,
             "isActive": isActive,
-            "loadingState": loadingState,
+            "loadingState": loadingState.rawValue,
             "isAttachedToPlayer": isAttachedToPlayer
         ]
         if let metadata {


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Found problems when it comes to use the player testing framework:
1. lack of documentation about player license key used
2. wrongly typed method
3. incomplete payload for source events
4. race-condition for initial events from the player
5. lack of easy way to use a pre-built `SourceConfig`

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
1. added documentation
2. fixed the method signature
3. opened #339 and forward ported it here
4. added a workaround to not touch the SDK itself
5. introduced a `Sources` constant for easy access

## Checklist
- [x] 🗒 `CHANGELOG` entry - not applicable
