### PR TITLE
Align PR handling of default values

### DIFF
--- a/src/components/PlayerView/index.tsx
+++ b/src/components/PlayerView/index.tsx
@@ -125,21 +125,21 @@ export function PlayerView({
 
   useEffect(() => {
     const node = findNodeHandle(nativeView.current);
-    if (node && isFullscreenRequested != undefined) {
+    if (node && isFullscreenRequested !== undefined) {
       dispatch('setFullscreen', node, isFullscreenRequested);
     }
   }, [isFullscreenRequested, nativeView]);
 
   useEffect(() => {
     const node = findNodeHandle(nativeView.current);
-    if (node && scalingMode != undefined) {
+    if (node && scalingMode !== undefined) {
       dispatch('setScalingMode', node, scalingMode);
     }
   }, [scalingMode, nativeView]);
 
   useEffect(() => {
     const node = findNodeHandle(nativeView.current);
-    if (node && isPictureInPictureRequested != undefined) {
+    if (node && isPictureInPictureRequested !== undefined) {
       dispatch('setPictureInPicture', node, isPictureInPictureRequested);
     }
   }, [isPictureInPictureRequested, nativeView]);


### PR DESCRIPTION
## Problem (PRN-92)
Most of the RN SDK relies on the default value from the native side.
The 2 exceptions where fullscreen and PiP, where the default is set in TS.

Nevertheless this is not necessary because the defaults are the same in both native SDK.

## Changes
Align the default. Don't send the command if the value is undefined.

## 📚 Other PRs for this issue
- 📗 bitmovin/bitmovin-player-react-native#317
- 📘 bitmovin/bitmovin-player-react-native#345
- 📖 bitmovin/bitmovin-player-react-native#346
- 📒 bitmovin/bitmovin-player-react-native#347
- 📜 bitmovin/bitmovin-player-react-native#343