### PR TITLE
Simplify getters by always throwing

### DIFF
--- a/android/src/main/java/com/bitmovin/player/reactnative/BitmovinBaseModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/BitmovinBaseModule.kt
@@ -1,14 +1,7 @@
 package com.bitmovin.player.reactnative
 
 import android.util.Log
-import com.bitmovin.player.api.Player
-import com.bitmovin.player.api.source.Source
-import com.bitmovin.player.reactnative.extensions.drmModule
-import com.bitmovin.player.reactnative.extensions.offlineModule
-import com.bitmovin.player.reactnative.extensions.playerModule
-import com.bitmovin.player.reactnative.extensions.sourceModule
 import com.bitmovin.player.reactnative.extensions.uiManagerModule
-import com.bitmovin.player.reactnative.offline.OfflineContentManagerBridge
 import com.facebook.react.bridge.*
 import com.facebook.react.uimanager.UIManagerModule
 
@@ -32,42 +25,11 @@ abstract class BitmovinBaseModule(
      * its return value. If [block] throws, [Promise.reject] [this] with the [Throwable].
      */
     protected inline fun <T, R : T> TPromise<T>.resolveOnUiThread(crossinline block: () -> R) {
-        val uiManager = runAndRejectOnException { uiManager } ?: return
+        val uiManager = runAndRejectOnException { context.uiManagerModule } ?: return
         uiManager.addUIBlock {
             resolveOnCurrentThread { block() }
         }
     }
-
-    protected val playerModule: PlayerModule get() = context.playerModule
-        ?: throw IllegalArgumentException("PlayerModule not found")
-
-    protected val uiManager: UIManagerModule get() = context.uiManagerModule
-        ?: throw IllegalStateException("UIManager not found")
-
-    protected val sourceModule: SourceModule get() = context.sourceModule
-        ?: throw IllegalStateException("SourceModule not found")
-
-    protected val offlineModule: OfflineModule get() = context.offlineModule
-        ?: throw IllegalStateException("OfflineModule not found")
-
-    protected val drmModule: DrmModule get() = context.drmModule
-        ?: throw IllegalStateException("DrmModule not found")
-
-    fun getPlayer(
-        nativeId: NativeId,
-        playerModule: PlayerModule = this.playerModule,
-    ): Player = playerModule.getPlayerOrNull(nativeId) ?: throw IllegalArgumentException("Invalid PlayerId $nativeId")
-
-    fun getSource(
-        nativeId: NativeId,
-        sourceModule: SourceModule = this.sourceModule,
-    ): Source = sourceModule.getSourceOrNull(nativeId) ?: throw IllegalArgumentException("Invalid SourceId $nativeId")
-
-    fun getOfflineContentManagerBridge(
-        nativeId: NativeId,
-        offlineModule: OfflineModule = this.offlineModule,
-    ): OfflineContentManagerBridge = offlineModule.getOfflineContentManagerBridgeOrNull(nativeId)
-        ?: throw IllegalArgumentException("Invalid offline content manager bridge id: $nativeId")
 }
 
 /** Compile time wrapper for Promises to type check the resolved type [T]. */

--- a/android/src/main/java/com/bitmovin/player/reactnative/BufferModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/BufferModule.kt
@@ -4,6 +4,7 @@ import com.bitmovin.player.api.buffer.BufferLevel
 import com.bitmovin.player.api.media.MediaType
 import com.bitmovin.player.reactnative.converter.toBufferType
 import com.bitmovin.player.reactnative.converter.toJson
+import com.bitmovin.player.reactnative.extensions.playerModule
 import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
 
@@ -23,7 +24,7 @@ class BufferModule(context: ReactApplicationContext) : BitmovinBaseModule(contex
     @ReactMethod
     fun getLevel(nativeId: NativeId, type: String, promise: Promise) {
         promise.map.resolveOnUiThread {
-            val player = getPlayer(nativeId)
+            val player = context.playerModule.getPlayer(nativeId)
             val bufferType = type.toBufferTypeOrThrow()
             RNBufferLevels(
                 audio = player.buffer.getLevel(bufferType, MediaType.Audio),
@@ -41,7 +42,7 @@ class BufferModule(context: ReactApplicationContext) : BitmovinBaseModule(contex
     @ReactMethod
     fun setTargetLevel(nativeId: NativeId, type: String, value: Double, promise: Promise) {
         promise.unit.resolveOnUiThread {
-            getPlayer(nativeId).buffer.setTargetLevel(type.toBufferTypeOrThrow(), value)
+            context.playerModule.getPlayer(nativeId).buffer.setTargetLevel(type.toBufferTypeOrThrow(), value)
         }
     }
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/OfflineModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/OfflineModule.kt
@@ -29,9 +29,10 @@ class OfflineModule(context: ReactApplicationContext) : BitmovinBaseModule(conte
     /**
      * Fetches the `OfflineManager` instance associated with `nativeId` from the internal offline managers.
      */
-    fun getOfflineContentManagerBridgeOrNull(
+    fun getOfflineContentManagerBridge(
         nativeId: NativeId,
-    ): OfflineContentManagerBridge? = offlineContentManagerBridges[nativeId]
+    ): OfflineContentManagerBridge = offlineContentManagerBridges[nativeId]
+        ?: throw IllegalArgumentException("Invalid offline content manager bridge id: $nativeId")
 
     /**
      * Callback when a new NativeEventEmitter is created from the Typescript layer.
@@ -65,7 +66,7 @@ class OfflineModule(context: ReactApplicationContext) : BitmovinBaseModule(conte
             val sourceConfig = config.getMap("sourceConfig")?.toSourceConfig()
                 ?: throw IllegalArgumentException("Invalid source config")
 
-            sourceConfig.drmConfig = context.drmModule?.getConfig(drmNativeId)
+            sourceConfig.drmConfig = context.drmModule.getConfig(drmNativeId)
 
             offlineContentManagerBridges[nativeId] = OfflineContentManagerBridge(
                 nativeId,
@@ -235,9 +236,7 @@ class OfflineModule(context: ReactApplicationContext) : BitmovinBaseModule(conte
     private inline fun <T> TPromise<T>.resolveWithBridge(
         nativeId: NativeId,
         crossinline block: OfflineContentManagerBridge.() -> T,
-    ) {
-        resolveOnCurrentThread {
-            getOfflineContentManagerBridge(nativeId, this@OfflineModule).block()
-        }
+    ) = resolveOnCurrentThread {
+        getOfflineContentManagerBridge(nativeId).block()
     }
 }

--- a/android/src/main/java/com/bitmovin/player/reactnative/PlayerAnalyticsModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/PlayerAnalyticsModule.kt
@@ -3,6 +3,7 @@ package com.bitmovin.player.reactnative
 import com.bitmovin.player.api.analytics.AnalyticsApi
 import com.bitmovin.player.api.analytics.AnalyticsApi.Companion.analytics
 import com.bitmovin.player.reactnative.converter.toAnalyticsCustomData
+import com.bitmovin.player.reactnative.extensions.playerModule
 import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
 
@@ -44,7 +45,7 @@ class PlayerAnalyticsModule(context: ReactApplicationContext) : BitmovinBaseModu
         playerId: NativeId,
         crossinline block: AnalyticsApi.() -> T,
     ) = resolveOnUiThread {
-        val analytics = getPlayer(playerId).analytics
+        val analytics = context.playerModule.getPlayer(playerId).analytics
             ?: throw IllegalStateException("Analytics is disabled for player $playerId")
         analytics.block()
     }

--- a/android/src/main/java/com/bitmovin/player/reactnative/extensions/ReactContextExtension.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/extensions/ReactContextExtension.kt
@@ -4,15 +4,24 @@ import com.bitmovin.player.reactnative.DrmModule
 import com.bitmovin.player.reactnative.OfflineModule
 import com.bitmovin.player.reactnative.PlayerModule
 import com.bitmovin.player.reactnative.SourceModule
+import com.bitmovin.player.reactnative.ui.CustomMessageHandlerModule
+import com.bitmovin.player.reactnative.ui.FullscreenHandlerModule
 import com.facebook.react.bridge.*
 import com.facebook.react.uimanager.UIManagerModule
 
-inline fun <reified T : ReactContextBaseJavaModule> ReactContext.getModule(): T? {
-    return getNativeModule(T::class.java)
-}
+private inline fun <reified T : ReactContextBaseJavaModule> ReactContext.getModuleOrThrow(
+    name: String,
+): T = getNativeModule(T::class.java).throwIfNull(name)
 
-val ReactApplicationContext.playerModule get() = getModule<PlayerModule>()
-val ReactApplicationContext.sourceModule get() = getModule<SourceModule>()
-val ReactApplicationContext.offlineModule get() = getModule<OfflineModule>()
-val ReactApplicationContext.uiManagerModule get() = getModule<UIManagerModule>()
-val ReactApplicationContext.drmModule get() = getModule<DrmModule>()
+private fun <T : ReactContextBaseJavaModule> T?.throwIfNull(name: String): T = this
+    ?: throw IllegalStateException("${name}Module not found")
+
+val ReactApplicationContext.playerModule: PlayerModule get() = getModuleOrThrow("Player")
+val ReactApplicationContext.sourceModule: SourceModule get() = getModuleOrThrow("Source")
+val ReactApplicationContext.offlineModule: OfflineModule get() = getModuleOrThrow("Offline")
+val ReactApplicationContext.uiManagerModule: UIManagerModule get() = getModuleOrThrow("UIManager")
+val ReactApplicationContext.drmModule: DrmModule get() = getModuleOrThrow("Drm")
+val ReactApplicationContext.customMessageHandlerModule: CustomMessageHandlerModule
+    get() = getModuleOrThrow("CustomMessageHandler")
+val ReactApplicationContext.fullscreenHandlerModule: FullscreenHandlerModule
+    get() = getModuleOrThrow("fullscreenHandler")

--- a/android/src/main/java/com/bitmovin/player/reactnative/ui/CustomMessageHandlerBridge.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/ui/CustomMessageHandlerBridge.kt
@@ -2,7 +2,7 @@ package com.bitmovin.player.reactnative.ui
 
 import android.webkit.JavascriptInterface
 import com.bitmovin.player.reactnative.NativeId
-import com.bitmovin.player.reactnative.extensions.getModule
+import com.bitmovin.player.reactnative.extensions.customMessageHandlerModule
 import com.bitmovin.player.ui.CustomMessageHandler
 import com.facebook.react.bridge.ReactApplicationContext
 
@@ -14,13 +14,13 @@ class CustomMessageHandlerBridge(
         object : Any() {
             @JavascriptInterface
             fun sendSynchronous(name: String, data: String?): String? = context
-                .getModule<CustomMessageHandlerModule>()
-                ?.receivedSynchronousMessage(nativeId, name, data)
+                .customMessageHandlerModule
+                .receivedSynchronousMessage(nativeId, name, data)
 
             @JavascriptInterface
             fun sendAsynchronous(name: String, data: String?) = context
-                .getModule<CustomMessageHandlerModule>()
-                ?.receivedAsynchronousMessage(nativeId, name, data)
+                .customMessageHandlerModule
+                .receivedAsynchronousMessage(nativeId, name, data)
         },
     )
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/ui/FullscreenHandlerBridge.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/ui/FullscreenHandlerBridge.kt
@@ -2,7 +2,7 @@ package com.bitmovin.player.reactnative.ui
 
 import com.bitmovin.player.api.ui.FullscreenHandler
 import com.bitmovin.player.reactnative.NativeId
-import com.bitmovin.player.reactnative.extensions.getModule
+import com.bitmovin.player.reactnative.extensions.fullscreenHandlerModule
 import com.facebook.react.bridge.ReactApplicationContext
 
 class FullscreenHandlerBridge(
@@ -16,15 +16,11 @@ class FullscreenHandlerBridge(
     }
 
     override fun onFullscreenExitRequested() {
-        context
-            .getModule<FullscreenHandlerModule>()
-            ?.requestExitFullscreen(nativeId)
+        context.fullscreenHandlerModule.requestExitFullscreen(nativeId)
     }
 
     override fun onFullscreenRequested() {
-        context
-            .getModule<FullscreenHandlerModule>()
-            ?.requestEnterFullscreen(nativeId)
+        context.fullscreenHandlerModule.requestEnterFullscreen(nativeId)
     }
 
     override fun onPause() {


### PR DESCRIPTION
## Problem (PRN-92)
Getters were duplicated between returning null or throwing. Now that Exception are consistently caught, those returning a nullable type can be removed.

## Changes
Remove and inline many getters.