### PR TITLE
Treat TS lint warnings as error

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "test": "jest",
     "typescript": "tsc --noEmit",
-    "lint": "eslint \"**/*.{ts,tsx}\"",
+    "lint": "eslint --max-warnings=0 -- \"**/*.{ts,tsx}\"",
     "format": "prettier --write .",
     "build": "tsup ./src/index.ts --dts --target es2020 --format cjs,esm -d lib",
     "example": "yarn --cwd example",


### PR DESCRIPTION
There is currently no lint warnings and we want to keep it that way.
The warning currently have to be spotted by reviewers, leading to longer merge time.
The easiest solution is to treat all lint warnings as error. The CI will not approve any PR introducing a warning.