### PR TITLE
Increase min. React Native version to `0.65`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - React Native version to `0.72.6`
+- React Native peer dependency version to `0.65.0+`
 
 ## [0.14.2] (2023-11-27)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is an open-source project created to enable customers to integrate the Bitm
 
 ## Platform Support
 
-This library requires at least React Native 0.64+ and React 17+ to work properly. The **officially supported** platforms are:
+This library requires at least React Native 0.65+ and React 17+ to work properly. The **officially supported** platforms are:
 
 - **iOS/iPadOS/tvOS:** 14.0+
 - **Android:** 5.0+

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   },
   "peerDependencies": {
     "react": ">=17",
-    "react-native": ">=0.64"
+    "react-native": ">=0.65"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
These changes increase the minimum supported React Native version.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Increased React Native peer dependency version to `0.65` due to upgrading our React Native support in #318

## Checklist
- [x] 🗒 `CHANGELOG` entry
