### PR TITLE
Fix `currentTime` mode handling 

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -192,7 +192,9 @@ export class Player extends NativeInstance<PlayerConfig> {
    *
    * @param mode - The time mode to specify: an absolute UNIX timestamp ('absolute') or relative time ('relative').
    */
-  getCurrentTime = async (mode?: 'relative' | 'absolute'): Promise<number> => {
+  getCurrentTime = async (
+    mode: 'relative' | 'absolute' = 'absolute'
+  ): Promise<number> => {
     return PlayerModule.currentTime(this.nativeId, mode);
   };
 


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
`mode` parameter was marked optional for `Player.currentTime`, while we only accept one of two values.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Added default value `absolute` and removed the optionality.

## Checklist
- [x] 🗒 `CHANGELOG` entry - no entry needed as it was broken recently with nullability refactoring.
