### PR TITLE
Add changelog entry for Android Player 3.53.0 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - React Native version to `0.72.6`
 - React Native peer dependency version to `0.65.0+`
+- Update Bitmovin's native Android SDK version to `3.53.0`
 
 ## [0.14.2] (2023-11-27)
 


### PR DESCRIPTION
## Description
 changelog entry for Android Player 3.53.0 update is missing

## Changes
Add  changelog entry for Android Player 3.53.0 update

## Checklist
- [x] 🗒 `CHANGELOG` entry
