### PR TITLE
Showcase ambient mode / screen timeout handling

### DIFF
--- a/example/android/app/src/main/java/com/bitmovin/player/reactnative/example/MainActivity.java
+++ b/example/android/app/src/main/java/com/bitmovin/player/reactnative/example/MainActivity.java
@@ -8,6 +8,8 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
 import com.facebook.react.defaults.DefaultReactActivityDelegate;
 import com.google.android.gms.cast.framework.CastContext;
 
+import static android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON;
+
 public class MainActivity extends ReactActivity {
   @Override
   public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -19,6 +21,11 @@ public class MainActivity extends ReactActivity {
     } catch (Exception e) {
       // cast framework not supported
     }
+
+    // Prevent going into ambient mode on Android TV devices / screen timeout on mobile devices during playback.
+    // If your app uses multiple activities make sure to add this flag to the activity that hosts the player.
+    // Reference: https://developer.android.com/training/scheduling/wakelock#screen
+    getWindow().addFlags(FLAG_KEEP_SCREEN_ON);
   }
 
   /**


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Default samples go into ambient mode / screen timeout due to screen inactivity. Since the handling should be implemented on the app to app basis, this PR just adds an example and reference on how this can be handled.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
- Add `getWindow().addFlags(FLAG_KEEP_SCREEN_ON);` to `MainActivity.java`

## Checklist
- [x] 🗒 `CHANGELOG` entry - No changelog as only example code was updated
