### PR TITLE
Add CI checks for integration test build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
             .cocoapods-cache
             example/ios/Pods
             integration_test/ios/Pods
-          key: pods-${{ hashFiles('example/ios/Podfile.lock') }}
+          key: pods-${{ hashFiles('example/ios/Podfile.lock') }}-${{ hashFiles('integration_test/ios/Podfile.lock') }}
           restore-keys: pods-
 
       - name: Install pods
@@ -264,7 +264,7 @@ jobs:
             .cocoapods-cache
             example/ios/Pods
             integration_test/ios/Pods
-          key: pods-${{ hashFiles('example/ios/Podfile.lock') }}
+          key: pods-${{ hashFiles('example/ios/Podfile.lock') }}-${{ hashFiles('integration_test/ios/Podfile.lock') }}
           restore-keys: pods-
 
       - name: Install pods

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,6 @@ jobs:
 
       - name: Install pods
         run: |
-          pod repo remove trunk
           pod repo add bitmovin https://github.com/bitmovin/cocoapod-specs.git || pod repo update bitmovin
           pod install --repo-update
         working-directory: example/ios
@@ -270,7 +269,6 @@ jobs:
 
       - name: Install pods
         run: |
-          pod repo remove trunk
           pod repo add bitmovin https://github.com/bitmovin/cocoapod-specs.git || pod repo update bitmovin
           pod install --repo-update
         working-directory: example/ios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,7 @@ jobs:
           path: |
             .cocoapods-cache
             example/ios/Pods
+            integration_test/ios/Pods
           key: pods-${{ hashFiles('example/ios/Podfile.lock') }}
           restore-keys: pods-
 
@@ -220,6 +221,7 @@ jobs:
           path: |
             .cocoapods-cache
             example/ios/Pods
+            integration_test/ios/Pods
           key: ${{ steps.pods-cache-restore.outputs.cache-primary-key }}
 
       - name: Build iOS example
@@ -262,6 +264,7 @@ jobs:
           path: |
             .cocoapods-cache
             example/ios/Pods
+            integration_test/ios/Pods
           key: pods-${{ hashFiles('example/ios/Podfile.lock') }}
           restore-keys: pods-
 
@@ -281,6 +284,7 @@ jobs:
           path: |
             .cocoapods-cache
             example/ios/Pods
+            integration_test/ios/Pods
           key: ${{ steps.pods-cache-restore.outputs.cache-primary-key }}
 
       - name: Build tvOS example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,10 @@ jobs:
         run: ./gradlew assembleDebug --build-cache
         working-directory: example/android
 
+      - name: Build Android integration test host app
+        run: ./gradlew assembleDebug --build-cache
+        working-directory: integration_test/android
+
   test-build-ios:
     name: Build iOS
     runs-on: macOS-12
@@ -190,6 +194,9 @@ jobs:
 
       - name: Install node_modules (example/)
         run: yarn install --frozen-lockfile --cwd example
+
+      - name: Install node_modules (integration_test/)
+        run: yarn install --frozen-lockfile --cwd integration_test
 
       - name: Install dependencies
         run: brew bundle install
@@ -226,6 +233,12 @@ jobs:
       - name: Build iOS example
         run: set -o pipefail && xcodebuild -workspace BitmovinPlayerReactNativeExample.xcworkspace -scheme BitmovinPlayerReactNativeExample -configuration Debug build CODE_SIGNING_ALLOWED='NO' | xcpretty
         working-directory: example/ios
+        env:
+          NSUnbufferedIO: YES
+
+      - name: Build iOS integration test host app
+        run: set -o pipefail && xcodebuild -workspace IntegrationTest.xcworkspace -scheme IntegrationTest -configuration Debug build CODE_SIGNING_ALLOWED='NO' | xcpretty
+        working-directory: integration_test/ios
         env:
           NSUnbufferedIO: YES
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
       - name: Install pods
         run: |
           pod repo add bitmovin https://github.com/bitmovin/cocoapod-specs.git || pod repo update bitmovin
-          yarn pods
+          yarn example pods
         env:
           CP_HOME_DIR: ${{ github.workspace }}/.cocoapods-cache
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,8 +215,7 @@ jobs:
       - name: Install pods
         run: |
           pod repo add bitmovin https://github.com/bitmovin/cocoapod-specs.git || pod repo update bitmovin
-          pod install --repo-update
-        working-directory: example/ios
+          yarn pods
         env:
           CP_HOME_DIR: ${{ github.workspace }}/.cocoapods-cache
 
@@ -283,8 +282,7 @@ jobs:
       - name: Install pods
         run: |
           pod repo add bitmovin https://github.com/bitmovin/cocoapod-specs.git || pod repo update bitmovin
-          pod install --repo-update
-        working-directory: example/ios
+          yarn pods
         env:
           CP_HOME_DIR: ${{ github.workspace }}/.cocoapods-cache
 

--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -49,14 +49,33 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
           cache: 'yarn'
 
+      - name: Restore Pods cache
+        id: pods-cache-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            .cocoapods-cache
+            example/ios/Pods
+            integration_test/ios/Pods
+          key: pods-${{ hashFiles('example/ios/Podfile.lock') }}-${{ hashFiles('integration_test/ios/Podfile.lock') }}
+          restore-keys: pods-
+
       - name: Bump iOS player SDK version
         if: ${{ inputs.sdk_name == 'ios' }}
         run: |
           sed -i '' 's/s.dependency "BitmovinPlayer", ".*/s.dependency "BitmovinPlayer", "${{ inputs.version_number }}"/g' RNBitmovinPlayer.podspec
-          yarn install --frozen-lockfile --cwd example
-          cd example/ios
           pod repo add bitmovin https://github.com/bitmovin/cocoapod-specs.git
-          pod update BitmovinPlayer
+          yard bootstrap
+
+      - name: Save Pods cache
+        if: steps.pods-cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            .cocoapods-cache
+            example/ios/Pods
+            integration_test/ios/Pods
+          key: ${{ steps.pods-cache-restore.outputs.cache-primary-key }}
 
       - name: Bump Android player SDK version
         if: ${{ inputs.sdk_name == 'android' }}

--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Commit version bump
         run: |
-          git add RNBitmovinPlayer.podspec android/build.gradle example/ios/Podfile.lock
+          git add RNBitmovinPlayer.podspec android/build.gradle example/ios/Podfile.lock integration_test/ios/Podfile.lock
           git commit -m "chore(${{ inputs.sdk_name }}): update ${{ inputs.sdk_name }} player version to ${{ inputs.version_number }}"
           git push origin ${{ steps.branching.outputs.branch_name }}
 

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -79,7 +79,6 @@ jobs:
 
       - name: Set up CocoaPods
         run: |
-          pod repo remove trunk
           pod repo add bitmovin https://github.com/bitmovin/cocoapod-specs.git || pod repo update bitmovin
         working-directory: example/ios
         env:

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -74,7 +74,7 @@ jobs:
             .cocoapods-cache
             example/ios/Pods
             integration_test/ios/Pods
-          key: pods-${{ hashFiles('example/ios/Podfile.lock') }}
+          key: pods-${{ hashFiles('example/ios/Podfile.lock') }}-${{ hashFiles('integration_test/ios/Podfile.lock') }}
           restore-keys: pods-
 
       - name: Set up CocoaPods

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -73,6 +73,7 @@ jobs:
           path: |
             .cocoapods-cache
             example/ios/Pods
+            integration_test/ios/Pods
           key: pods-${{ hashFiles('example/ios/Podfile.lock') }}
           restore-keys: pods-
 
@@ -98,6 +99,7 @@ jobs:
           path: |
             .cocoapods-cache
             example/ios/Pods
+            integration_test/ios/Pods
           key: ${{ steps.pods-cache-restore.outputs.cache-primary-key }}
 
       - name: Commit changelog version bump


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
To keep our integration tests stable, we need to build them on CI with every PR incoming.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Extended out CI workflow to build the integration test host apps on PRs.

## Checklist
- [x] 🗒 `CHANGELOG` entry - not applicable
