### PR TITLE
Fix permission issue with updating changelog in finish release workflow

### DIFF
--- a/.github/workflows/finish-release-train.yml
+++ b/.github/workflows/finish-release-train.yml
@@ -22,6 +22,8 @@ jobs:
       version_number: ${{ steps.version_number.outputs.version_number }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Setup Git User
         run: |


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Branch protection prevented updating the changelog directly on the `main` branch.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Use GitHub PAT for checkout to allow pushing.

## Checklist
- [ ] 🗒 `CHANGELOG` entry - not applicable
