### PR TITLE
Use deploy key to push to protected branch

### DIFF
--- a/.github/workflows/finish-release-train.yml
+++ b/.github/workflows/finish-release-train.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - name: Setup Git User
         run: |


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Branch protection prevented updating the changelog directly on the `main` branch.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Use GitHub PAT for checkout to allow pushing.

## Checklist
- [ ] 🗒 `CHANGELOG` entry - not applicable
