### PR TITLE
Fix API docs generation on CI

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -41,11 +41,14 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
           cache: 'yarn'
 
-      - name: Install dependencies
+      - name: Install node_modules
         run: yarn install --frozen-lockfile
 
-      - name: Install dependencies (example/)
-        run: yarn example install --frozen-lockfile
+      - name: Install node_modules (example/)
+        run: yarn install --frozen-lockfile --cwd example
+
+      - name: Install node_modules (integration_test/)
+        run: yarn install --frozen-lockfile --cwd integration_test
 
       - name: Detect version using jq
         run: |


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
See CI workflow error: https://github.com/bitmovin/bitmovin-player-react-native/actions/runs/7553947090/job/20565837763

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Found that on the finish release workflow API docs generation failed due to missing dependencies.
Fixed by installing dependencies for the integration test app as well.

## Checklist
- [ ] 🗒 `CHANGELOG` entry - not applicable
