### PR TITLE
Disable Flipper on CI

### DIFF
--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -15,6 +15,9 @@ on:
         required: true
         type: string
 
+env:
+  NO_FLIPPER: 1
+
 jobs:
   update:
     name: Update SDK version

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -14,6 +14,7 @@ on:
 env:
   LC_ALL: en_US.UTF-8
   LANG: en_US.UTF-8
+  NO_FLIPPER: 1
 concurrency:
   group: start-release-train-${{ inputs.version_number }}
   cancel-in-progress: true


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
This PR speeds up CI workflows when CocoaPods dependencies are also installed.
We already had this in some workflows, but not all.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Disabled Flipper via `NO_FLIPPER=1` environment variable.

## Checklist
- [x] 🗒 `CHANGELOG` entry - not applicable
