### PR TITLE
Disable Flipper completely as we don't use it

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -9,8 +9,8 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "pods": "yarn pods-install || yarn pods-update",
-    "pods-install": "yarn pod-install",
-    "pods-update": "pod update --silent"
+    "pods-install": "NO_FLIPPER=1 yarn pod-install",
+    "pods-update": "NO_FLIPPER=1 pod update --silent"
   },
   "dependencies": {
     "@react-native-picker/picker": "2.5.1",

--- a/integration_test/package.json
+++ b/integration_test/package.json
@@ -14,8 +14,8 @@
     "test:android": "yarn stop-test:android && yarn start-test:android",
     "test:ios": "yarn stop-test:ios && yarn start-test:ios",
     "pods": "yarn pods-install || yarn pods-update",
-    "pods-install": "yarn pod-install",
-    "pods-update": "pod update --silent"
+    "pods-install": "NO_FLIPPER=1 yarn pod-install",
+    "pods-update": "NO_FLIPPER=1 pod update --silent"
   },
   "dependencies": {
     "cavy": "^4.0.2",


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Flipper takes a lot of time to install while we don't use it at all.
This PR disables it in a way that we can add it back easily if needed.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Added `NO_FLIPPER=1` to `package.json` scripts to prevent installing Flipper related dependencies.

## Checklist
- [x] 🗒 `CHANGELOG` entry - not available
