### PR TITLE
Add SRT (SubRip) subtitle support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for side-loaded SRT (SubRip) subtitles
+
 ### Fixed
 
 - Remove `patch-package` usage from released product

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -530,7 +530,12 @@ fun ReadableMap.toSubtitleTrack(): SubtitleTrack? {
 /**
  * Converts any subtitle format name in its mime type representation.
  */
-private fun String.toSubtitleMimeType(): String = "text/$this"
+private fun String.toSubtitleMimeType(): String = when (this) {
+    "vtt" -> "text/vtt"
+    "srt" -> "application/x-subrip"
+    "ttml" -> "application/ttml+xml"
+    else -> "text/$this"
+}
 
 /**
  * Converts any `SubtitleTrack` into its json representation.

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -531,7 +531,6 @@ fun ReadableMap.toSubtitleTrack(): SubtitleTrack? {
  * Converts any subtitle format name in its mime type representation.
  */
 private fun String.toSubtitleMimeType(): String = when (this) {
-    "vtt" -> "text/vtt"
     "srt" -> "application/x-subrip"
     "ttml" -> "application/ttml+xml"
     else -> "text/$this"

--- a/example/src/screens/SubtitlePlayback.tsx
+++ b/example/src/screens/SubtitlePlayback.tsx
@@ -34,12 +34,19 @@ export default function SubtitlePlayback() {
         poster: 'https://bitmovin-a.akamaihd.net/content/sintel/poster.png',
         // External subtitle tracks to be added to the source.
         subtitleTracks: [
-          // Add custom english subtitles. You can select 'Custom English' in the subtitles menu.
+          // Add custom english subtitles. You can select 'Custom English (WebVTT)' in the subtitles menu.
           {
             url: 'https://bitdash-a.akamaihd.net/content/sintel/subtitles/subtitles_en.vtt',
-            label: 'Custom English',
+            label: 'Custom English (WebVTT)',
             language: 'en',
             format: SubtitleFormat.VTT,
+          },
+          // Add custom english subtitles. You can select 'Custom English (SRT)' in the subtitles menu.
+          {
+            url: 'https://bitdash-a.akamaihd.net/content/sintel/subtitles/subtitles_en.srt',
+            label: 'Custom English (SRT)',
+            language: 'en',
+            format: SubtitleFormat.SRT,
           },
         ],
       });

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -553,6 +553,8 @@ extension RCTConvert {
             return .webVtt
         case "ttml":
             return .ttml
+        case "srt":
+            return .srt
         default:
             return nil
         }
@@ -582,6 +584,8 @@ extension RCTConvert {
                     return "vtt"
                 case .ttml:
                     return "ttml"
+                case .srt:
+                    return "srt"
                 }
             }(),
         ]

--- a/src/subtitleTrack.ts
+++ b/src/subtitleTrack.ts
@@ -20,7 +20,7 @@ export enum SubtitleFormat {
   VTT = 'vtt',
   /**
    * SubRip (SRT) subtitle format.
-   * @platform iOS, tvOS, tvOS
+   * @platform Android, iOS, tvOS
    */
   SRT = 'srt',
 }

--- a/src/subtitleTrack.ts
+++ b/src/subtitleTrack.ts
@@ -1,14 +1,33 @@
 /**
  * Supported subtitle/caption file formats.
+ * @platform Android, iOS, tvOS
  */
 export enum SubtitleFormat {
+  /**
+   * Closed Captioning (CEA) subtitle format.
+   * @platform Android, iOS, tvOS
+   */
   CEA = 'cea',
+  /**
+   * Timed Text Markup Language (TTML) subtitle format.
+   * @platform Android, iOS, tvOS
+   */
   TTML = 'ttml',
+  /**
+   * Web Video Text Tracks Format (WebVTT) subtitle format.
+   * @platform Android, iOS, tvOS
+   */
   VTT = 'vtt',
+  /**
+   * SubRip (SRT) subtitle format.
+   * @platform iOS, tvOS, tvOS
+   */
+  SRT = 'srt',
 }
 
 /**
  * Describes a subtitle track.
+ * @platform Android, iOS, tvOS
  */
 export interface SubtitleTrack {
   /**
@@ -47,7 +66,6 @@ export interface SubtitleTrack {
 
 /**
  * A subtitle track that can be added to `SourceConfig.subtitleTracks`.
- *
  */
 export interface SideLoadedSubtitleTrack extends SubtitleTrack {
   url: string;


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
This PR adds support for SubRip (SRT) subtitle support for side-loaded subtitles.
In #387 the build broke due to the iOS Player update changes with new enum values.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Added support for SRT subtitles by mapping the relevant enum cases and mime types accordingly.

## Checklist
- [x] 🗒 `CHANGELOG` entry
