### PR TITLE
Use M1 mac GitHub Actions runners on CI

### DIFF
--- a/.github/workflows/ci-ios-tvos.yml
+++ b/.github/workflows/ci-ios-tvos.yml
@@ -38,7 +38,7 @@ env:
 jobs:
   code-style-ios:
     name: Code style iOS
-    runs-on: macOS-latest
+    runs-on: macOS-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
 
   test-build-ios:
     name: Build iOS
-    runs-on: macOS-12
+    runs-on: macOS-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
 
   test-build-tvos:
     name: Build tvOS
-    runs-on: macOS-12
+    runs-on: macOS-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci-ios-tvos.yml
+++ b/.github/workflows/ci-ios-tvos.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '14.2'
+          xcode-version: '14.3'
 
       - name: Install dependencies
         run: brew bundle install
@@ -69,7 +69,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '14.2'
+          xcode-version: '14.3'
 
       - name: Install node_modules
         run: yarn install --frozen-lockfile
@@ -139,7 +139,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '14.2'
+          xcode-version: '14.3'
 
       - name: Install node_modules
         run: yarn install --frozen-lockfile

--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   update:
     name: Update SDK version
-    runs-on: macos-latest
+    runs-on: macos-14
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   create_release_pr:
     name: Create release branch and bump version
-    runs-on: macos-latest
+    runs-on: macos-14
     outputs:
       branch_name: ${{ steps.branching.outputs.branch_name }}
     steps:


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
GitHub introduced M1 macOS runners for open source repos, announced [here](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/).
We can now use them for free to speed up our workflows running on macOS.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Updated all workflows using macOS runners to use the new `macos-14` runner.
+1 had to update Xcode selection to use 14.3 instead of 14.2 as the latter is not available anymore.


Checks ran for 5m: https://github.com/bitmovin/bitmovin-player-react-native/actions/runs/7726258089?pr=393
Compared to previous best 12m: https://github.com/bitmovin/bitmovin-player-react-native/actions/runs/7667270581

## Checklist
- [ ] 🗒 `CHANGELOG` entry - not applicable
