### PR TITLE
Expose `TweaksConfig.preferSoftwareDecodingForAds` on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `preferSoftwareDecodingForAds` in `TweaksConfig` to use software decoding for ads, which can be useful for low-end Android devices
+
 ## [0.19.0] (2024-03-22)
 
 ### Added

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -181,6 +181,7 @@ fun ReadableMap.toTweaksConfig(): TweaksConfig = TweaksConfig().apply {
     withBoolean("useDrmSessionForClearPeriods") { useDrmSessionForClearPeriods = it }
     withBoolean("useDrmSessionForClearSources") { useDrmSessionForClearSources = it }
     withBoolean("useFiletypeExtractorFallbackForHls") { useFiletypeExtractorFallbackForHls = it }
+    withBoolean("preferSoftwareDecodingForAds") { preferSoftwareDecodingForAds = it }
 }
 
 /**

--- a/src/tweaksConfig.ts
+++ b/src/tweaksConfig.ts
@@ -150,4 +150,11 @@ export interface TweaksConfig {
    * @platform Android
    */
   useFiletypeExtractorFallbackForHls?: boolean;
+  /**
+   * Specifies whether the player should prefer software decoding over hardware decoding for ad playback.
+   * This only affects ads playback, the player will still prefer hardware decoding for the main content.
+   *
+   * @platform Android
+   */
+  preferSoftwareDecodingForAds?: boolean;
 }


### PR DESCRIPTION
## Description
`TweaksConfig.preferSoftwareDecodingForAds` is available in the native Android Player SDK but wasn't exposed so far in RN.

## Changes
Exposed `TweaksConfig.preferSoftwareDecodingForAds` and set it on the Android Player SDK

## Checklist
- [x] 🗒 `CHANGELOG` entry
