### PR TITLE
Expose hideFirstFrame config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `hideFirstFrame` in `PlayerViewConfig` to ensure no frame of the main content is shown before pre-roll ads
+
 ## [0.19.0] (2024-03-22)
 
 ### Added

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -750,6 +750,9 @@ fun toPlayerViewConfig(json: ReadableMap) = PlayerViewConfig(
             ?.getBooleanOrNull("playbackSpeedSelectionEnabled")
             ?: true,
     ),
+    hideFirstFrame = json.getMap("hideFirstFrame")
+        ?.getBooleanOrNull("hideFirstFrame")
+        ?: false,
 )
 
 private fun ReadableMap.toUserInterfaceTypeFromPlayerConfig(): UserInterfaceType? =

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -751,9 +751,7 @@ fun toPlayerViewConfig(json: ReadableMap) = PlayerViewConfig(
             ?.getBooleanOrNull("playbackSpeedSelectionEnabled")
             ?: true,
     ),
-    hideFirstFrame = json.getMap("hideFirstFrame")
-        ?.getBooleanOrNull("hideFirstFrame")
-        ?: false,
+    hideFirstFrame = json.getBooleanOrNull("hideFirstFrame") ?: false,
 )
 
 private fun ReadableMap.toUserInterfaceTypeFromPlayerConfig(): UserInterfaceType? =

--- a/example/src/screens/BasicAds.tsx
+++ b/example/src/screens/BasicAds.tsx
@@ -8,6 +8,7 @@ import {
   SourceType,
   AdSourceType,
   AdSkippedEvent,
+  PlayerViewConfig,
 } from 'bitmovin-player-react-native';
 import { useTVGestures } from '../hooks';
 
@@ -56,6 +57,10 @@ const advertisingConfig = {
 
 const remoteControlConfig = {
   isCastEnabled: false,
+};
+
+const playerViewConfig: PlayerViewConfig = {
+  hideFirstFrame: true,
 };
 
 export default function BasicAds() {
@@ -126,6 +131,7 @@ export default function BasicAds() {
       <PlayerView
         player={player}
         style={styles.player}
+        config={playerViewConfig}
         onAdBreakFinished={onEvent}
         onAdBreakStarted={onEvent}
         onAdClicked={onEvent}

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -1157,7 +1157,7 @@ extension RCTConvert {
         return RNPlayerViewConfig(
             uiConfig: rnUiConfig(json["uiConfig"]),
             pictureInPictureConfig: pictureInPictureConfig(json["pictureInPictureConfig"]),
-            hideFirstFrame: json["hideFirstFrame"] as? Bool ?? false
+            hideFirstFrame: json["hideFirstFrame"] as? Bool
         )
     }
 

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -1265,7 +1265,7 @@ internal struct RNPlayerViewConfig {
      * To reliably hide the first frame before a pre-roll ad, please ensure that you are using the
      * `AdvertisingConfig` to schedule ads and not the `scheduleAd` API call.
      */
-    var hideFirstFrame: Bool
+    var hideFirstFrame: Bool?
 }
 
 /**

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -1156,7 +1156,8 @@ extension RCTConvert {
 
         return RNPlayerViewConfig(
             uiConfig: rnUiConfig(json["uiConfig"]),
-            pictureInPictureConfig: pictureInPictureConfig(json["pictureInPictureConfig"])
+            pictureInPictureConfig: pictureInPictureConfig(json["pictureInPictureConfig"]),
+            hideFirstFrame: json["hideFirstFrame"] as? Bool ?? false
         )
     }
 
@@ -1256,6 +1257,15 @@ internal struct RNPlayerViewConfig {
         }
         return config
     }
+
+    /**
+     * When set to `true` the first frame of the main content will not be rendered before playback starts.
+     * Default is `false`.
+     *
+     * To reliably hide the first frame before a pre-roll ad, please ensure that you are using the
+     * `AdvertisingConfig` to schedule ads and not the `scheduleAd` API call.
+     */
+    var hideFirstFrame: Bool
 }
 
 /**

--- a/ios/RNPlayerViewManager.swift
+++ b/ios/RNPlayerViewManager.swift
@@ -80,7 +80,7 @@ public class RNPlayerViewManager: RCTViewManager {
             }
 
             if let customMessageHandlerBridgeId = self.customMessageHandlerBridgeId,
-                let customMessageHandlerBridge = self.bridge[CustomMessageHandlerModule.self]?
+               let customMessageHandlerBridge = self.bridge[CustomMessageHandlerModule.self]?
                 .retrieve(customMessageHandlerBridgeId) {
                 bitmovinUserInterfaceConfig.customMessageHandler = customMessageHandlerBridge.customMessageHandler
             }
@@ -89,12 +89,14 @@ public class RNPlayerViewManager: RCTViewManager {
         }
 #endif
         if styleConfig.userInterfaceType == .system {
-          let systemUserInterfaceConfig = styleConfig
+            let systemUserInterfaceConfig = styleConfig
                 .userInterfaceConfig as? SystemUserInterfaceConfig ?? SystemUserInterfaceConfig()
 
-          systemUserInterfaceConfig.hideFirstFrame = playerViewConfig?.hideFirstFrame ?? false
+            if let hideFirstFrame = playerViewConfig?.hideFirstFrame {
+                systemUserInterfaceConfig.hideFirstFrame = hideFirstFrame
+            }
 
-          return systemUserInterfaceConfig
+            return systemUserInterfaceConfig
         }
 
         return nil

--- a/ios/RNPlayerViewManager.swift
+++ b/ios/RNPlayerViewManager.swift
@@ -62,7 +62,7 @@ public class RNPlayerViewManager: RCTViewManager {
         }
     }
 
-    func maybeCreateUserInterfaceConfig(
+    private func maybeCreateUserInterfaceConfig(
         styleConfig: StyleConfig,
         playerViewConfig: RNPlayerViewConfig?
     ) -> UserInterfaceConfig? {

--- a/ios/RNPlayerViewManager.swift
+++ b/ios/RNPlayerViewManager.swift
@@ -75,7 +75,9 @@ public class RNPlayerViewManager: RCTViewManager {
                 bitmovinUserInterfaceConfig
                     .playbackSpeedSelectionEnabled = uiConfig.playbackSpeedSelectionEnabled
             }
-            bitmovinUserInterfaceConfig.hideFirstFrame = playerViewConfig?.hideFirstFrame ?? false
+            if let hideFirstFrame = playerViewConfig?.hideFirstFrame {
+                bitmovinUserInterfaceConfig.hideFirstFrame = hideFirstFrame
+            }
 
             if let customMessageHandlerBridgeId = self.customMessageHandlerBridgeId,
                 let customMessageHandlerBridge = self.bridge[CustomMessageHandlerModule.self]?

--- a/src/components/PlayerView/playerViewConfig.ts
+++ b/src/components/PlayerView/playerViewConfig.ts
@@ -22,7 +22,7 @@ export interface PlayerViewConfig {
 
   /**
    * When set to `true`, the first frame of the main content will not be rendered before playback starts. Default is `false`.
-   * This configuration has no effect for the ${@link UserInterfaceType.Subtitle} on iOS/tvOS.
+   * This configuration has no effect for the {@link UserInterfaceType.Subtitle} on iOS/tvOS.
    *
    * To reliably hide the first frame before a pre-roll ad, please ensure that you are using the {@link AdvertisingConfig} to schedule ads and not the {@link Player.scheduleAd} API call.
    */

--- a/src/components/PlayerView/playerViewConfig.ts
+++ b/src/components/PlayerView/playerViewConfig.ts
@@ -23,7 +23,7 @@ export interface PlayerViewConfig {
   /**
    * When set to `true`, the first frame of the main content will not be rendered before playback starts. Default is `false`.
    *
-   * To reliably hide the first frame before a pre-roll ad, please ensure that you are using the {@link AdvertisingConfig} to schedule ads and not the {@link scheduleAd} API call.
+   * To reliably hide the first frame before a pre-roll ad, please ensure that you are using the {@link AdvertisingConfig} to schedule ads and not the {@link Player.scheduleAd} API call.
    */
   hideFirstFrame?: boolean;
 }

--- a/src/components/PlayerView/playerViewConfig.ts
+++ b/src/components/PlayerView/playerViewConfig.ts
@@ -19,6 +19,13 @@ export interface PlayerViewConfig {
    * Provides options to configure Picture in Picture playback.
    */
   pictureInPictureConfig?: PictureInPictureConfig;
+
+  /**
+   * When set to `true`, the first frame of the main content will not be rendered before playback starts. Default is `false`.
+   *
+   * To reliably hide the first frame before a pre-roll ad, please ensure that you are using the {@link AdvertisingConfig} to schedule ads and not the {@link scheduleAd} API call.
+   */
+  hideFirstFrame?: boolean;
 }
 
 /**

--- a/src/components/PlayerView/playerViewConfig.ts
+++ b/src/components/PlayerView/playerViewConfig.ts
@@ -22,6 +22,7 @@ export interface PlayerViewConfig {
 
   /**
    * When set to `true`, the first frame of the main content will not be rendered before playback starts. Default is `false`.
+   * This configuration has no effect for the ${@link UserInterfaceType.Subtitle} on iOS/tvOS.
    *
    * To reliably hide the first frame before a pre-roll ad, please ensure that you are using the {@link AdvertisingConfig} to schedule ads and not the {@link Player.scheduleAd} API call.
    */


### PR DESCRIPTION
## Description
Our native SDKs contains a configuration to ensure the first frame of the main content is not shown, which is useful for pre-roll ads in some scenarios. This configuration was not exposed to the React Native app.

## Changes
Expose `PlayerViewConfig.hideFirstFrame`, which maps to
- `PlayerViewConfig.hideFirstFrame` on Android, and
- `BitmovinUserInterfaceConfig.hideFirstFrame` and `SystemUserInterfaceConfig.hideFirstFrame` on iOS/tvOS.

## Checklist
- [x] 🗒 `CHANGELOG` entry
