### PR TITLE
Fix PiP inconsistencies on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [unreleased]
+## [Unreleased]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Android: Entering Picture-in-Picture automatically from all screens when navigating the app to the background (after navigating to Basic Picture-in-Picture screen once)
+- Android: Entering Picture-in-Picture automatically when navigating the app to the background after activating Picture-in-Picture mode once
 - Android: Example app Toolbar not visible after going into PiP mode -> Dismissing PiP window (stopping the app) -> Opening the app again
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixed
 
-- Android: Entering Picture-in-Picture automatically from all screens when navigating the app to the background (after navigating to Picture-in-Picture sample once)
-- Android: Example app Toolbar not visible after going into PiP mode -> Dismissing PiP window (stopping the app) -> Opening the app again+
+- Android: Entering Picture-in-Picture automatically from all screens when navigating the app to the background (after navigating to Basic Picture-in-Picture screen once)
+- Android: Example app Toolbar not visible after going into PiP mode -> Dismissing PiP window (stopping the app) -> Opening the app again
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [unreleased]
+
+### Fixed
+
+- Android: Entering Picture-in-Picture automatically from all screens when navigating the app to the background (after navigating to Picture-in-Picture sample once)
+- Android: Example app Toolbar not visible after going into PiP mode -> Dismissing PiP window (stopping the app) -> Opening the app again+
+
+### Changed
+
+- Android: Default Picture-in-Picture implementation doesn't automatically hide/show the Toolbar anymore. This should be handled by the app itself, check out the sample app for an example implementation
+
 ## [0.20.0] (2024-03-29)
 
 ### Added

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -244,7 +244,7 @@ class RNPlayerView(
         isInPictureInPictureMode: Boolean,
         newConfig: Configuration,
     ) {
-        val playerView = playerView ?: error("How can this be?")
+        val playerView = playerView ?: return
         playerView.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
         if (isInPictureInPictureMode) {
             playerView.enterPictureInPicture()

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -2,8 +2,7 @@ package com.bitmovin.player.reactnative
 
 import android.annotation.SuppressLint
 import android.content.res.Configuration
-import android.graphics.Rect
-import android.view.View
+import android.os.Build
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -17,8 +16,6 @@ import com.bitmovin.player.api.event.SourceEvent
 import com.bitmovin.player.api.ui.PlayerViewConfig
 import com.bitmovin.player.api.ui.StyleConfig
 import com.bitmovin.player.reactnative.converter.toJson
-import com.bitmovin.player.reactnative.ui.RNPictureInPictureDelegate
-import com.bitmovin.player.reactnative.ui.RNPictureInPictureHandler
 import com.facebook.react.ReactActivity
 import com.facebook.react.bridge.*
 import com.facebook.react.uimanager.events.RCTEventEmitter
@@ -101,7 +98,7 @@ private val EVENT_CLASS_TO_REACT_NATIVE_NAME_MAPPING_UI = mapOf<KClass<out Event
 @SuppressLint("ViewConstructor")
 class RNPlayerView(
     private val context: ReactApplicationContext,
-) : FrameLayout(context), View.OnLayoutChangeListener, RNPictureInPictureDelegate {
+) : FrameLayout(context) {
     private val activityLifecycle = (context.currentActivity as? ReactActivity)?.lifecycle
         ?: error("Trying to create an instance of ${this::class.simpleName} while not attached to a ReactActivity")
 
@@ -153,7 +150,6 @@ class RNPlayerView(
 
     private var _playerView: PlayerView? = null
         set(value) {
-            field?.removeOnLayoutChangeListener(this)
             field = value
             viewEventRelay.eventEmitter = field
             playerEventRelay.eventEmitter = field?.player
@@ -175,11 +171,6 @@ class RNPlayerView(
             playerView?.player = value
             playerEventRelay.eventEmitter = value
         }
-
-    /**
-     * Object that handles PiP mode changes in React Native.
-     */
-    var pictureInPictureHandler: RNPictureInPictureHandler? = null
 
     /**
      * Configures the visual presentation and behaviour of the [playerView].
@@ -214,11 +205,6 @@ class RNPlayerView(
             (playerView.parent as ViewGroup?)?.removeView(playerView)
             addView(playerView, 0)
         }
-        pictureInPictureHandler?.let {
-            it.setDelegate(this)
-            playerView.setPictureInPictureHandler(it)
-            playerView.addOnLayoutChangeListener(this)
-        }
     }
 
     /**
@@ -232,61 +218,38 @@ class RNPlayerView(
         addView(subtitleView)
     }
 
+    private fun isInPictureInPictureMode(): Boolean {
+        val activity = context.currentActivity ?: return false
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            activity.isInPictureInPictureMode
+        } else {
+            false
+        }
+    }
+
+    private var isPictureInPictureMode: Boolean = isInPictureInPictureMode()
+
     /**
      * Called whenever this view's activity configuration changes.
      */
-    override fun onConfigurationChanged(newConfig: Configuration?) {
+    override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        pictureInPictureHandler?.onConfigurationChanged(newConfig)
+        if (isPictureInPictureMode != isInPictureInPictureMode()) {
+            isPictureInPictureMode = isInPictureInPictureMode()
+            onPictureInPictureModeChanged(isPictureInPictureMode, newConfig)
+        }
     }
 
-    /**
-     * Called when the player has just entered PiP mode.
-     */
-    override fun onEnterPictureInPicture() {
-        // Nothing to do
-    }
-
-    /**
-     * Called when the player has just exited PiP mode.
-     */
-    override fun onExitPictureInPicture() {
-        // Explicitly call `exitPictureInPicture()` on PlayerView when exiting PiP state, otherwise
-        // the `PictureInPictureExit` event won't get dispatched.
-        playerView?.exitPictureInPicture()
-    }
-
-    /**
-     * Called when the player's PiP mode changes with a new configuration object.
-     */
-    override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration?) {
-        playerView?.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
-    }
-
-    /**
-     * Called whenever the PiP handler needs to compute the PlayerView's global visible rect.
-     */
-    override fun setSourceRectHint(sourceRectHint: Rect) {
-        playerView?.getGlobalVisibleRect(sourceRectHint)
-    }
-
-    /**
-     * Called whenever PlayerView's layout changes.
-     */
-    override fun onLayoutChange(
-        view: View?,
-        left: Int,
-        top: Int,
-        right: Int,
-        bottom: Int,
-        oldLeft: Int,
-        oldTop: Int,
-        oldRight: Int,
-        oldBottom: Int,
+    private fun onPictureInPictureModeChanged(
+        isInPictureInPictureMode: Boolean,
+        newConfig: Configuration,
     ) {
-        if (left != oldLeft || right != oldRight || top != oldTop || bottom != oldBottom) {
-            // Update source rect hint whenever the player's layout change
-            pictureInPictureHandler?.updateSourceRectHint()
+        val playerView = playerView ?: error("How can this be?")
+        playerView.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+        if (isInPictureInPictureMode) {
+            playerView.enterPictureInPicture()
+        } else {
+            playerView.exitPictureInPicture()
         }
     }
 
@@ -341,7 +304,7 @@ class RNPlayerView(
  */
 data class RNPlayerViewConfigWrapper(
     val playerViewConfig: PlayerViewConfig?,
-    val pictureInPictureConfig: RNPictureInPictureHandler.PictureInPictureConfig?,
+    val pictureInPictureConfig: PictureInPictureConfig?,
 )
 
 data class RNStyleConfigWrapper(
@@ -352,3 +315,8 @@ data class RNStyleConfigWrapper(
 enum class UserInterfaceType {
     Bitmovin, Subtitle
 }
+
+/**
+ * Configuration type for picture in picture behaviors.
+ */
+data class PictureInPictureConfig(val isEnabled: Boolean)

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -227,16 +227,16 @@ class RNPlayerView(
         }
     }
 
-    private var isPictureInPictureMode: Boolean = isInPictureInPictureMode()
+    private var isCurrentActivityInPictureInPictureMode: Boolean = isInPictureInPictureMode()
 
     /**
      * Called whenever this view's activity configuration changes.
      */
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
-        if (isPictureInPictureMode != isInPictureInPictureMode()) {
-            isPictureInPictureMode = isInPictureInPictureMode()
-            onPictureInPictureModeChanged(isPictureInPictureMode, newConfig)
+        if (isCurrentActivityInPictureInPictureMode != isInPictureInPictureMode()) {
+            isCurrentActivityInPictureInPictureMode = isInPictureInPictureMode()
+            onPictureInPictureModeChanged(isCurrentActivityInPictureInPictureMode, newConfig)
         }
     }
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewManager.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewManager.kt
@@ -243,9 +243,6 @@ class RNPlayerViewManager(private val context: ReactApplicationContext) : Simple
      */
     private fun attachPlayer(view: RNPlayerView, playerId: NativeId, playerConfig: ReadableMap?) {
         handler.postAndLogException {
-            // PlayerView has to be initialized with Activity context
-            val currentActivity = context.currentActivity
-                ?: throw IllegalStateException("Cannot create a PlayerView, because no activity is attached.")
             val player = playerId.let { context.playerModule?.getPlayerOrNull(it) }
                 ?: throw InvalidParameterException("Cannot create a PlayerView, invalid playerId was passed: $playerId")
             val playbackConfig = playerConfig?.getMap("playbackConfig")
@@ -258,6 +255,9 @@ class RNPlayerViewManager(private val context: ReactApplicationContext) : Simple
             if (view.playerView != null) {
                 view.player = player
             } else {
+                // PlayerView has to be initialized with Activity context
+                val currentActivity = context.currentActivity
+                    ?: throw IllegalStateException("Cannot create a PlayerView, because no activity is attached.")
                 val userInterfaceType = rnStyleConfigWrapper?.userInterfaceType ?: UserInterfaceType.Bitmovin
                 val playerViewConfig: PlayerViewConfig = if (userInterfaceType != UserInterfaceType.Bitmovin) {
                     configuredPlayerViewConfig.copy(uiConfig = UiConfig.Disabled)
@@ -271,12 +271,11 @@ class RNPlayerViewManager(private val context: ReactApplicationContext) : Simple
                     LayoutParams.MATCH_PARENT,
                     LayoutParams.MATCH_PARENT,
                 )
-                view.setPlayerView(playerView)
-                attachCustomMessageHandlerBridge(view)
-
                 if (isPictureInPictureEnabled) {
                     playerView.setPictureInPictureHandler(RNPictureInPictureHandler(currentActivity, player))
                 }
+                view.setPlayerView(playerView)
+                attachCustomMessageHandlerBridge(view)
             }
 
             if (rnStyleConfigWrapper?.styleConfig?.isUiEnabled != false &&

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewManager.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewManager.kt
@@ -247,7 +247,7 @@ class RNPlayerViewManager(private val context: ReactApplicationContext) : Simple
                 ?: throw InvalidParameterException("Cannot create a PlayerView, invalid playerId was passed: $playerId")
             val playbackConfig = playerConfig?.getMap("playbackConfig")
             val isPictureInPictureEnabled = view.config?.pictureInPictureConfig?.isEnabled == true ||
-                    playbackConfig?.getBooleanOrNull("isPictureInPictureEnabled") == true
+                playbackConfig?.getBooleanOrNull("isPictureInPictureEnabled") == true
 
             val rnStyleConfigWrapper = playerConfig?.toRNStyleConfigWrapperFromPlayerConfig()
             val configuredPlayerViewConfig = view.config?.playerViewConfig ?: PlayerViewConfig()

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -51,6 +51,7 @@ import com.bitmovin.player.reactnative.RNBufferLevels
 import com.bitmovin.player.reactnative.RNPlayerViewConfigWrapper
 import com.bitmovin.player.reactnative.RNStyleConfigWrapper
 import com.bitmovin.player.reactnative.UserInterfaceType
+import com.bitmovin.player.reactnative.PictureInPictureConfig
 import com.bitmovin.player.reactnative.extensions.get
 import com.bitmovin.player.reactnative.extensions.getBooleanOrNull
 import com.bitmovin.player.reactnative.extensions.getDoubleOrNull
@@ -70,7 +71,6 @@ import com.bitmovin.player.reactnative.extensions.withInt
 import com.bitmovin.player.reactnative.extensions.withMap
 import com.bitmovin.player.reactnative.extensions.withString
 import com.bitmovin.player.reactnative.extensions.withStringArray
-import com.bitmovin.player.reactnative.ui.RNPictureInPictureHandler.PictureInPictureConfig
 import com.facebook.react.bridge.*
 import java.util.UUID
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -47,11 +47,11 @@ import com.bitmovin.player.api.ui.ScalingMode
 import com.bitmovin.player.api.ui.StyleConfig
 import com.bitmovin.player.api.ui.UiConfig
 import com.bitmovin.player.reactnative.BitmovinCastManagerOptions
+import com.bitmovin.player.reactnative.PictureInPictureConfig
 import com.bitmovin.player.reactnative.RNBufferLevels
 import com.bitmovin.player.reactnative.RNPlayerViewConfigWrapper
 import com.bitmovin.player.reactnative.RNStyleConfigWrapper
 import com.bitmovin.player.reactnative.UserInterfaceType
-import com.bitmovin.player.reactnative.PictureInPictureConfig
 import com.bitmovin.player.reactnative.extensions.get
 import com.bitmovin.player.reactnative.extensions.getBooleanOrNull
 import com.bitmovin.player.reactnative.extensions.getDoubleOrNull

--- a/android/src/main/java/com/bitmovin/player/reactnative/ui/RNPictureInPictureHandler.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/ui/RNPictureInPictureHandler.kt
@@ -1,200 +1,59 @@
 package com.bitmovin.player.reactnative.ui
 
+import android.app.Activity
 import android.app.PictureInPictureParams
-import android.content.pm.PackageManager
-import android.content.res.Configuration
-import android.graphics.Rect
 import android.os.Build
+import android.util.Log
 import android.util.Rational
 import androidx.annotation.RequiresApi
-import androidx.appcompat.app.AppCompatActivity
-import com.bitmovin.player.api.ui.PictureInPictureHandler
-import com.facebook.react.bridge.ReactApplicationContext
+import com.bitmovin.player.api.Player
+import com.bitmovin.player.ui.DefaultPictureInPictureHandler
 
-/**
- * Delegate object for `RNPictureInPictureHandler`. It delegates all view logic that needs
- * to be performed during each PiP state to this object.
- */
-interface RNPictureInPictureDelegate {
-    /**
-     * Called whenever the handler's `isInPictureInPictureMode` changes to `true`.
-     */
-    fun onExitPictureInPicture()
+private val TAG = "RNPiPHandler"
 
-    /**
-     * Called whenever the handler's `isInPictureInPictureMode` changes to `false`.
-     */
-    fun onEnterPictureInPicture()
+class RNPictureInPictureHandler(
+    private val activity: Activity,
+    private val player: Player,
+) : DefaultPictureInPictureHandler(activity, player) {
+    // Current PiP implementation on the native side requires playerView.exitPictureInPicture() to be called
+    // for `PictureInPictureExit` event to be emitted.
+    // Additionally, the event is only emitted if `isPictureInPicture` is true. At the point in time we call
+    // playerView.exitPictureInPicture() the activity will already have exited the PiP mode,
+    // and thus the event won't be emitted. To work around this we keep track of the PiP state ourselves.
+    private var _isPictureInPicture = false
 
-    /**
-     * Called whenever the activity's PiP mode state changes with the new resources configuration.
-     */
-    fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration?)
-
-    /**
-     * Called whenever the handler needs to compute a new `sourceRectHint` for PiP params.
-     * The passed rect reference is expected to be fulfilled with the PlayerView's global visible
-     * rect.
-     */
-    fun setSourceRectHint(sourceRectHint: Rect)
-}
-
-/**
- * Custom  PictureInPictureHandler` concrete implementation designed for React Native. It relies on
- * React Native's application context to manage the application's PiP state. Can be subclassed in
- * order to provide custom PiP capabilities.
- */
-open class RNPictureInPictureHandler(val context: ReactApplicationContext) : PictureInPictureHandler {
-    /**
-     * Configuration type for picture in picture behaviors.
-     */
-    data class PictureInPictureConfig(val isEnabled: Boolean)
-
-    /**
-     * PiP delegate object that contains the view logic to be performed on each PiP state change.
-     */
-    private var delegate: RNPictureInPictureDelegate? = null
-
-    /**
-     * Whether the user has enabled PiP support via `isPictureInPictureEnabled` playback configuration in JS.
-     */
-    var isPictureInPictureEnabled = false
-
-    /**
-     * Whether this view is currently in PiP mode.
-     */
-    private var isInPictureInPictureMode = false
-
-    /**
-     * Whether the current Android version supports PiP mode.
-     */
-    private val isPictureInPictureSupported: Boolean
-        get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
-            context.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
-
-    /**
-     * Whether the picture in picture feature is available and enabled.
-     */
-    override val isPictureInPictureAvailable: Boolean
-        get() = isPictureInPictureEnabled && isPictureInPictureSupported
-
-    /**
-     * Whether this view is currently in PiP mode. Required for PictureInPictureHandler interface.
-     */
     override val isPictureInPicture: Boolean
-        get() = isInPictureInPictureMode
+        get() = _isPictureInPicture
 
-    /**
-     * Current React activity computed property.
-     */
-    private val currentActivity: AppCompatActivity?
-        get() {
-            if (context.hasCurrentActivity()) {
-                return context.currentActivity as AppCompatActivity
-            }
-            return null
-        }
-
-    /**
-     * Sets the new delegate object and update the activity's PiP parameters accordingly.
-     */
-    open fun setDelegate(delegate: RNPictureInPictureDelegate?) {
-        this.delegate = delegate
-        // Update the activity's PiP params once the delegate has been set.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && isPictureInPictureAvailable) {
-            applyPictureInPictureParams()
-        }
-    }
-
-    /**
-     * Called whenever bitmovin's `PlayerView` needs to enter PiP mode.
-     */
-    override fun enterPictureInPicture() {
-        if (isPictureInPictureAvailable) {
-            currentActivity?.let {
-                it.supportActionBar?.hide()
-                it.enterPictureInPictureMode()
-            }
-        }
-    }
-
-    /**
-     * Called whenever bitmovin's `PlayerView` needs to exit PiP mode.
-     */
-    override fun exitPictureInPicture() {
-        if (isPictureInPictureAvailable) {
-            currentActivity?.supportActionBar?.show()
-        }
-    }
-
-    /**
-     * Called whenever the activity content resources have changed.
-     */
-    open fun onConfigurationChanged(newConfig: Configuration?) {
-        // PiP mode is supported since Android 7.0
-        if (isPictureInPictureAvailable) {
-            handlePictureInPictureModeChanges(newConfig)
-        }
-    }
-
-    /**
-     * Checks whether the current activity `isInPictureInPictureMode` has changed since the last lifecycle
-     * configuration change.
-     */
-    @RequiresApi(Build.VERSION_CODES.N)
-    private fun handlePictureInPictureModeChanges(newConfig: Configuration?) = currentActivity?.let {
-        if (isInPictureInPictureMode != it.isInPictureInPictureMode) {
-            delegate?.onPictureInPictureModeChanged(it.isInPictureInPictureMode, newConfig)
-            if (it.isInPictureInPictureMode) {
-                delegate?.onEnterPictureInPicture()
-            } else {
-                delegate?.onExitPictureInPicture()
-            }
-            isInPictureInPictureMode = it.isInPictureInPictureMode
-        }
-    }
-
-    /**
-     * Applies Android recommended PiP params on the current activity for smoother transitions.
-     *
-     * You can read more about the recommended settings for PiP here:
-     * - https://developer.android.com/develop/ui/views/picture-in-picture#smoother-transition
-     * - https://developer.android.com/develop/ui/views/picture-in-picture#smoother-exit
-     */
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun applyPictureInPictureParams() = currentActivity?.let {
-        // See also: https://developer.android.com/develop/ui/views/picture-in-picture#smoother-transition
-        val sourceRectHint = Rect()
-        delegate?.setSourceRectHint(sourceRectHint)
-        val ratio = Rational(16, 9)
-        val params = PictureInPictureParams.Builder()
-            .setAspectRatio(ratio)
-            .setSourceRectHint(sourceRectHint)
-        when {
-            // See also: https://developer.android.com/develop/ui/views/picture-in-picture#smoother-exit
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ->
-                params.setAutoEnterEnabled(true).setSeamlessResizeEnabled(true)
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU ->
-                params.setExpandedAspectRatio(ratio)
-        }
-        it.setPictureInPictureParams(params.build())
-    }
-
-    /**
-     * Update source rect hint on activity's PiP params.
-     */
-    open fun updateSourceRectHint() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || !isPictureInPictureAvailable) {
+    override fun enterPictureInPicture() {
+        if (!isPictureInPictureAvailable) {
+            Log.w(TAG, "Calling enterPictureInPicture without PiP support.")
             return
         }
-        currentActivity?.let {
-            val sourceRectHint = Rect()
-            delegate?.setSourceRectHint(sourceRectHint)
-            it.setPictureInPictureParams(
-                PictureInPictureParams.Builder()
-                    .setSourceRectHint(sourceRectHint)
-                    .build(),
-            )
+
+        if (isPictureInPicture) {
+            return
         }
+
+        // The default implementation doesn't properly handle the case where source isn't loaded yet.
+        // To work around it we just use a 16:9 aspect ratio if we cannot calculate it from `playbackVideoData`.
+        val aspectRatio =
+            player.playbackVideoData
+                ?.let { Rational(it.width, it.height) }
+                ?: Rational(16, 9)
+
+        val params =
+            PictureInPictureParams.Builder()
+                .setAspectRatio(aspectRatio)
+                .build()
+
+        activity.enterPictureInPictureMode(params)
+        _isPictureInPicture = true
+    }
+
+    override fun exitPictureInPicture() {
+        super.exitPictureInPicture()
+        _isPictureInPicture = false
     }
 }

--- a/android/src/main/java/com/bitmovin/player/reactnative/ui/RNPictureInPictureHandler.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/ui/RNPictureInPictureHandler.kt
@@ -9,7 +9,7 @@ import androidx.annotation.RequiresApi
 import com.bitmovin.player.api.Player
 import com.bitmovin.player.ui.DefaultPictureInPictureHandler
 
-private val TAG = "RNPiPHandler"
+private const val TAG = "RNPiPHandler"
 
 class RNPictureInPictureHandler(
     private val activity: Activity,

--- a/example/src/screens/BasicPictureInPicture.tsx
+++ b/example/src/screens/BasicPictureInPicture.tsx
@@ -69,6 +69,7 @@ export default function BasicPictureInPicture({
 
   useEffect(() => {
     navigation.setOptions({
+      headerShown: !isInPictureInPicture,
       // eslint-disable-next-line react/no-unstable-nested-components
       headerRight: () => (
         <Button

--- a/example/src/screens/BasicPictureInPicture.tsx
+++ b/example/src/screens/BasicPictureInPicture.tsx
@@ -67,9 +67,14 @@ export default function BasicPictureInPicture({
     }, [player])
   );
 
+  // Since PiP on Android is basically just the whole activity fitted in a small
+  // floating window, we only want to render the player and hide any other UI.
+  let renderOnlyPlayerView = Platform.OS === 'android' && isInPictureInPicture;
+
   useEffect(() => {
     navigation.setOptions({
-      headerShown: !isInPictureInPicture,
+      // On Android,
+      headerShown: !renderOnlyPlayerView,
       // eslint-disable-next-line react/no-unstable-nested-components
       headerRight: () => (
         <Button
@@ -80,7 +85,7 @@ export default function BasicPictureInPicture({
         />
       ),
     });
-  }, [navigation, isInPictureInPicture]);
+  }, [navigation, isInPictureInPicture, renderOnlyPlayerView]);
 
   const onEvent = useCallback((event: Event) => {
     prettyPrint(`[${event.name}]`, event);
@@ -108,7 +113,7 @@ export default function BasicPictureInPicture({
     <ContainerView
       style={
         // On Android, we need to remove the padding from the container when in PiP mode.
-        Platform.OS === 'android' && isInPictureInPicture
+        renderOnlyPlayerView
           ? [styles.container, { padding: 0 }]
           : styles.container
       }

--- a/example/src/screens/BasicPictureInPicture.tsx
+++ b/example/src/screens/BasicPictureInPicture.tsx
@@ -73,7 +73,6 @@ export default function BasicPictureInPicture({
 
   useEffect(() => {
     navigation.setOptions({
-      // On Android,
       headerShown: !renderOnlyPlayerView,
       // eslint-disable-next-line react/no-unstable-nested-components
       headerRight: () => (


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
The PiP implementation on Android was very complex and made some wrong assumptions, which caused a few bugs. Most notably: 
- Auto PiP mode entering was always enabled, which caused the app to go into PiP mode on every screen when navigating the app to the background.
Note that we do have `PictureInPictureConfig.shouldEnterOnBackground`, but it works on iOS only and implementing it carries some lifecycle handling complexity (this bug), so implementing this should be considered as a feature request. 
Reference: https://github.com/bitmovin/bitmovin-player-react-native/pull/424/files#diff-884e35b040de326e767bfbc98ce73c052358fe2319d57d4716e044dbe68b6aa1L176
- `RNPictureInPictureHandler` did toolbar hiding from the native side which is a wrong layer to do that. This caused the app to be without a toolbar after: Going into PiP mode -> Dismissing PiP window (stopping the app) -> Opening the app again. 
Reference: https://github.com/bitmovin/bitmovin-player-react-native/pull/424/files#diff-884e35b040de326e767bfbc98ce73c052358fe2319d57d4716e044dbe68b6aa1L115

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
- Greatly simplify `RNPictureInPictureHandler`, aligning it with the Flutter implementation: https://github.com/bitmovin/bitmovin-player-flutter/pull/87
  - Fix unwanted auto entering into PiP mode
  - Fix toolbar gone after PiP mode has been dismissed and app opened again

## Checklist
- [x] 🗒 `CHANGELOG` entry
