### PR TITLE
Update IMA dependencies for iOS and tvOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Update IMA SDK dependency on iOS to `3.19.1`, respectively `4.9.2` for tvOS
+
 ## [0.21.0] (2024-04-08)
 
 ### Fixed

--- a/RNBitmovinPlayer.podspec
+++ b/RNBitmovinPlayer.podspec
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
   s.dependency "BitmovinPlayer", "3.59.0"
-  s.ios.dependency "GoogleAds-IMA-iOS-SDK", "3.18.4"
-  s.tvos.dependency "GoogleAds-IMA-tvOS-SDK", "4.8.2"
+  s.ios.dependency "GoogleAds-IMA-iOS-SDK", "3.19.1"
+  s.tvos.dependency "GoogleAds-IMA-tvOS-SDK", "4.9.2"
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -24,13 +24,13 @@ PODS:
     - Protobuf (~> 3.13)
   - google-cast-sdk/Core (4.8.0):
     - Protobuf (~> 3.13)
-  - GoogleAds-IMA-iOS-SDK (3.18.4)
-  - GoogleAds-IMA-tvOS-SDK (4.8.2)
+  - GoogleAds-IMA-iOS-SDK (3.19.1)
+  - GoogleAds-IMA-tvOS-SDK (4.9.2)
   - hermes-engine (0.73.4-0):
     - hermes-engine/Pre-built (= 0.73.4-0)
   - hermes-engine/Pre-built (0.73.4-0)
   - libevent (2.1.12.1)
-  - Protobuf (3.25.3)
+  - Protobuf (3.26.1)
   - RCT-Folly (2022.05.16.00):
     - boost
     - DoubleConversion
@@ -1053,8 +1053,8 @@ PODS:
     - React-perflogger (= 0.73.4-0)
   - RNBitmovinPlayer (0.21.0):
     - BitmovinPlayer (= 3.59.0)
-    - GoogleAds-IMA-iOS-SDK (= 3.18.4)
-    - GoogleAds-IMA-tvOS-SDK (= 4.8.2)
+    - GoogleAds-IMA-iOS-SDK (= 3.19.1)
+    - GoogleAds-IMA-tvOS-SDK (= 4.9.2)
     - React-Core
   - RNCPicker (2.6.1):
     - React-Core
@@ -1252,17 +1252,17 @@ SPEC CHECKSUMS:
   BitmovinPlayer: a4deb2e3d96c1f49e924991d625a09434361eb18
   BitmovinPlayerCore: 23c03dc732abe2695b187d2e711ce37b8e3726f6
   boost: 88202336c3ba1e7a264a83c0c888784b0f360c28
-  DoubleConversion: 234abba95e31cc2aada0cf3b97cdb11bc5b90575
+  DoubleConversion: 74cb0ce4de271b23e772567504735c87134edf0a
   FBLazyVector: 33a271a7e8de0bd321e47356d8bc3b2d5fb9ddba
   FBReactNativeSpec: 55b7e93b71f300a051190f63c2afeccd839b7e9a
   fmt: 745abaaffe4da13101ae15d70dc68ec3d6a666a2
-  glog: a2ded9bf28f0cb2fce90ad21eb419299a500ff6c
+  glog: f0ddebfc00a905e9213e37801095a0a705d2e5f6
   google-cast-sdk: afeb1aac0744b1bc4f70bc3db8468e33fabbff38
-  GoogleAds-IMA-iOS-SDK: b01284e3bf3d64ba948de6692ffda531452c3713
-  GoogleAds-IMA-tvOS-SDK: 2dda9d3b34c43003222d3417315fecec22b698a1
+  GoogleAds-IMA-iOS-SDK: 18adbec04a2e79ce828a992d37a4580deadbe525
+  GoogleAds-IMA-tvOS-SDK: 7e72fb938c246fb9718a3468d3c7fa7c722b2ea1
   hermes-engine: e7981489a718dff7c3a2dacd6302b8761375928d
   libevent: a6d75fcd7be07cbc5070300ea8dbc8d55dfab88e
-  Protobuf: 8e9074797a13c484a79959fdb819ef4ae6da7dbe
+  Protobuf: a53f5173a603075b3522a5c50be63a67a5f3353a
   RCT-Folly: 46220aef278c0f21b248ba3d60d26d2f64bb36e9
   RCTRequired: 013247b5dbfcf0d918480c9282ed9aa4a142f115
   RCTTypeSafety: 74a07efe760f43e2725acdde03c37ef98dfa02f6
@@ -1305,11 +1305,11 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 20b2202e3396589a71069d12ae9f328949c7c7b8
   React-utils: 0307d396f233e47a167b5aaf045b0e4e1dc19d74
   ReactCommon: 17891ca337bfa5a7263649b09f27a8c664537bf2
-  RNBitmovinPlayer: 64d7c5662f0a310b2c934f39e3c65024013b2045
+  RNBitmovinPlayer: 62c9ee25e77b5eea7849d792f7db6c15c08f9ec4
   RNCPicker: b18aaf30df596e9b1738e7c1f9ee55402a229dca
   RNScreens: b582cb834dc4133307562e930e8fa914b8c04ef2
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: ab50eb8f7fcf1b36aad1801b5687b66b2c0aa000
+  Yoga: e7f2a2256464d4ef7b3825d216bd22aac3b449c1
 
 PODFILE CHECKSUM: 6a89a6e0087c419fcb3ad7474478c93dc48f198d
 

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
     "start": "react-native start",
     "pods": "yarn pods-install || yarn pods-update",
     "pods-install": "NO_FLIPPER=1 yarn pod-install",
-    "pods-update": "NO_FLIPPER=1 pod update --silent"
+    "pods-update": "NO_FLIPPER=1 cd ios; pod update --silent"
   },
   "dependencies": {
     "@react-native-picker/picker": "2.6.1",

--- a/integration_test/ios/Podfile.lock
+++ b/integration_test/ios/Podfile.lock
@@ -19,7 +19,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.73.4-0)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - GoogleAds-IMA-iOS-SDK (3.18.4)
+  - GoogleAds-IMA-iOS-SDK (3.19.1)
   - hermes-engine (0.73.4-0):
     - hermes-engine/Pre-built (= 0.73.4-0)
   - hermes-engine/Pre-built (0.73.4-0)
@@ -1040,10 +1040,10 @@ PODS:
     - React-jsi (= 0.73.4-0)
     - React-logger (= 0.73.4-0)
     - React-perflogger (= 0.73.4-0)
-  - RNBitmovinPlayer (0.20.0):
+  - RNBitmovinPlayer (0.21.0):
     - BitmovinPlayer (= 3.59.0)
-    - GoogleAds-IMA-iOS-SDK (= 3.18.4)
-    - GoogleAds-IMA-tvOS-SDK (= 4.8.2)
+    - GoogleAds-IMA-iOS-SDK (= 3.19.1)
+    - GoogleAds-IMA-tvOS-SDK (= 4.9.2)
     - React-Core
   - SocketRocket (0.6.1)
   - Yoga (1.14.0)
@@ -1219,12 +1219,12 @@ SPEC CHECKSUMS:
   BitmovinPlayer: a4deb2e3d96c1f49e924991d625a09434361eb18
   BitmovinPlayerCore: 23c03dc732abe2695b187d2e711ce37b8e3726f6
   boost: 88202336c3ba1e7a264a83c0c888784b0f360c28
-  DoubleConversion: 234abba95e31cc2aada0cf3b97cdb11bc5b90575
+  DoubleConversion: 74cb0ce4de271b23e772567504735c87134edf0a
   FBLazyVector: 33a271a7e8de0bd321e47356d8bc3b2d5fb9ddba
   FBReactNativeSpec: 55b7e93b71f300a051190f63c2afeccd839b7e9a
   fmt: 745abaaffe4da13101ae15d70dc68ec3d6a666a2
-  glog: a2ded9bf28f0cb2fce90ad21eb419299a500ff6c
-  GoogleAds-IMA-iOS-SDK: b01284e3bf3d64ba948de6692ffda531452c3713
+  glog: f0ddebfc00a905e9213e37801095a0a705d2e5f6
+  GoogleAds-IMA-iOS-SDK: 18adbec04a2e79ce828a992d37a4580deadbe525
   hermes-engine: e7981489a718dff7c3a2dacd6302b8761375928d
   libevent: a6d75fcd7be07cbc5070300ea8dbc8d55dfab88e
   RCT-Folly: 46220aef278c0f21b248ba3d60d26d2f64bb36e9
@@ -1267,9 +1267,9 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 20b2202e3396589a71069d12ae9f328949c7c7b8
   React-utils: 0307d396f233e47a167b5aaf045b0e4e1dc19d74
   ReactCommon: 17891ca337bfa5a7263649b09f27a8c664537bf2
-  RNBitmovinPlayer: 07626ac2df74fc8975f916b51fbac84dd38fea3d
+  RNBitmovinPlayer: 62c9ee25e77b5eea7849d792f7db6c15c08f9ec4
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: ab50eb8f7fcf1b36aad1801b5687b66b2c0aa000
+  Yoga: e7f2a2256464d4ef7b3825d216bd22aac3b449c1
 
 PODFILE CHECKSUM: 0bfe194f5e28f1cf54d3d732eda8c78fadbeeedd
 

--- a/integration_test/package.json
+++ b/integration_test/package.json
@@ -15,7 +15,7 @@
     "test:ios": "yarn stop-test:ios && yarn start-test:ios",
     "pods": "yarn pods-install || yarn pods-update",
     "pods-install": "NO_FLIPPER=1 yarn pod-install",
-    "pods-update": "NO_FLIPPER=1 pod update --silent"
+    "pods-update": "NO_FLIPPER=1 cd ios; pod update --silent"
   },
   "dependencies": {
     "cavy": "^4.0.2",


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
The currently used IMA dependencies are outdated.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Updated to the currently officially supported versions by the Bitmovin iOS Player SDK.

+1 fixed the `yarn pods` command in case of updates by fixing `yarn example pods-update` and `yarn integration-test pods-update`.

## Checklist
- [x] 🗒 `CHANGELOG` entry
