### PR TITLE
Expose iOS feature `TweaksConfig.updatesNowPlayingInfoCenter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- iOS: `TweaksConfig.updatesNowPlayingInfoCenter` to decide whether AVKit should update Now Playing information automatically when using System UI. You may want to disable automatic updates in case they are interfering with manual updates you are performing.
+
 ## [0.21.0] (2024-04-08)
 
 ### Fixed

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -159,9 +159,11 @@ extension RCTConvert {
                 break
             }
         }
+#if !os(tvOS)
         if let updatesNowPlayingInfoCenter = json["updatesNowPlayingInfoCenter"] as? Bool {
             tweaksConfig.updatesNowPlayingInfoCenter = updatesNowPlayingInfoCenter
         }
+#endif
         return tweaksConfig
     }
 

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -159,6 +159,9 @@ extension RCTConvert {
                 break
             }
         }
+        if let updatesNowPlayingInfoCenter = json["updatesNowPlayingInfoCenter"] as? Bool {
+            tweaksConfig.updatesNowPlayingInfoCenter = updatesNowPlayingInfoCenter
+        }
         return tweaksConfig
     }
 

--- a/src/tweaksConfig.ts
+++ b/src/tweaksConfig.ts
@@ -158,7 +158,7 @@ export interface TweaksConfig {
    */
   preferSoftwareDecodingForAds?: boolean;
   /**
-   * Determines whether `AVKit` should update Now Playing information automatically.
+   * Determines whether `AVKit` should update Now Playing information automatically when using System UI.
    *
    * - If set to `false`, the automatic updates of Now Playing Info sent by `AVKit` are disabled.
    *   This prevents interference with manual updates you may want to perform.

--- a/src/tweaksConfig.ts
+++ b/src/tweaksConfig.ts
@@ -157,4 +157,16 @@ export interface TweaksConfig {
    * @platform Android
    */
   preferSoftwareDecodingForAds?: boolean;
+  /**
+   * Determines whether `AVKit` should update Now Playing information automatically.
+   *
+   * - If set to `false`, the automatic updates of Now Playing Info sent by `AVKit` are disabled.
+   *   This prevents interference with manual updates you may want to perform.
+   * - If set to `true`, the default behaviour is maintained, allowing `AVKit` to handle Now Playing updates.
+   *
+   * Default is `true`.
+   *
+   * @platform iOS
+   */
+  updatesNowPlayingInfoCenter?: boolean;
 }


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->

`TweaksConfig.updatesNowPlayingInfoCenter` has been added to iOS, but was not yet exposed in React Native.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->

 - Expose `TweaksConfig.updatesNowPlayingInfoCenter`
 - Update Swift serializer for `TweaksConfig`, taking into account that the feature is not available on tvOS

## Test

Not suitable for integration testing.

#### Building
Check if build phases pass on the alpha release testing branch
- ✅  [tvOS](https://github.com/bitmovin/bitmovin-player-react-native/actions/runs/8646390021/job/23705624525)
- ✅  [iOS](https://github.com/bitmovin/bitmovin-player-react-native/actions/runs/8646390021/job/23705625290)

#### Manual
- Check if `player.config.tweaksConfig` has the flag passed through correctly (should be `true` by default), and it is a boolean

## Checklist
- [x] 🗒 `CHANGELOG` entry
