### PR TITLE
Expose iOS feature `updatesNowPlayingInfoCenter`: updated player dependency

### DIFF
--- a/RNBitmovinPlayer.podspec
+++ b/RNBitmovinPlayer.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "BitmovinPlayer", "3.59.0"
+  s.dependency "BitmovinPlayer", "3.59.1-a.1"
   s.ios.dependency "GoogleAds-IMA-iOS-SDK", "3.18.4"
   s.tvos.dependency "GoogleAds-IMA-tvOS-SDK", "4.8.2"
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -3,10 +3,10 @@ PODS:
     - BitmovinAnalyticsCollector/Core
     - BitmovinPlayerCore (~> 3.48)
   - BitmovinAnalyticsCollector/Core (3.6.1)
-  - BitmovinPlayer (3.59.0):
+  - BitmovinPlayer (3.59.1-a.1):
     - BitmovinAnalyticsCollector/BitmovinPlayer (~> 3.0)
-    - BitmovinPlayerCore (= 3.59.0)
-  - BitmovinPlayerCore (3.59.0)
+    - BitmovinPlayerCore (= 3.59.1-a.1)
+  - BitmovinPlayerCore (3.59.1-a.1)
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.73.4-0)
@@ -1052,7 +1052,7 @@ PODS:
     - React-logger (= 0.73.4-0)
     - React-perflogger (= 0.73.4-0)
   - RNBitmovinPlayer (0.21.0):
-    - BitmovinPlayer (= 3.59.0)
+    - BitmovinPlayer (= 3.59.1-a.1)
     - GoogleAds-IMA-iOS-SDK (= 3.18.4)
     - GoogleAds-IMA-tvOS-SDK (= 4.8.2)
     - React-Core
@@ -1249,14 +1249,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   BitmovinAnalyticsCollector: cc31a7ffd96850f5bd4f41b39ea22b467734e9c9
-  BitmovinPlayer: a4deb2e3d96c1f49e924991d625a09434361eb18
-  BitmovinPlayerCore: 23c03dc732abe2695b187d2e711ce37b8e3726f6
+  BitmovinPlayer: cbd8649dacd0778730cc9becd3b693c5561f16c6
+  BitmovinPlayerCore: 8f415fcef5a8346adbd3ca30ee43a0b6921d01a4
   boost: 88202336c3ba1e7a264a83c0c888784b0f360c28
-  DoubleConversion: 234abba95e31cc2aada0cf3b97cdb11bc5b90575
+  DoubleConversion: 74cb0ce4de271b23e772567504735c87134edf0a
   FBLazyVector: 33a271a7e8de0bd321e47356d8bc3b2d5fb9ddba
   FBReactNativeSpec: 55b7e93b71f300a051190f63c2afeccd839b7e9a
   fmt: 745abaaffe4da13101ae15d70dc68ec3d6a666a2
-  glog: a2ded9bf28f0cb2fce90ad21eb419299a500ff6c
+  glog: f0ddebfc00a905e9213e37801095a0a705d2e5f6
   google-cast-sdk: afeb1aac0744b1bc4f70bc3db8468e33fabbff38
   GoogleAds-IMA-iOS-SDK: b01284e3bf3d64ba948de6692ffda531452c3713
   GoogleAds-IMA-tvOS-SDK: 2dda9d3b34c43003222d3417315fecec22b698a1
@@ -1305,11 +1305,11 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 20b2202e3396589a71069d12ae9f328949c7c7b8
   React-utils: 0307d396f233e47a167b5aaf045b0e4e1dc19d74
   ReactCommon: 17891ca337bfa5a7263649b09f27a8c664537bf2
-  RNBitmovinPlayer: 64d7c5662f0a310b2c934f39e3c65024013b2045
+  RNBitmovinPlayer: 6571ee56df94f0b016f6c9366e58c39ae362660b
   RNCPicker: b18aaf30df596e9b1738e7c1f9ee55402a229dca
   RNScreens: b582cb834dc4133307562e930e8fa914b8c04ef2
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: ab50eb8f7fcf1b36aad1801b5687b66b2c0aa000
+  Yoga: e7f2a2256464d4ef7b3825d216bd22aac3b449c1
 
 PODFILE CHECKSUM: 6a89a6e0087c419fcb3ad7474478c93dc48f198d
 

--- a/integration_test/ios/Podfile.lock
+++ b/integration_test/ios/Podfile.lock
@@ -3,10 +3,10 @@ PODS:
     - BitmovinAnalyticsCollector/Core
     - BitmovinPlayerCore (~> 3.48)
   - BitmovinAnalyticsCollector/Core (3.6.1)
-  - BitmovinPlayer (3.59.0):
+  - BitmovinPlayer (3.59.1-a.1):
     - BitmovinAnalyticsCollector/BitmovinPlayer (~> 3.0)
-    - BitmovinPlayerCore (= 3.59.0)
-  - BitmovinPlayerCore (3.59.0)
+    - BitmovinPlayerCore (= 3.59.1-a.1)
+  - BitmovinPlayerCore (3.59.1-a.1)
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.73.4-0)
@@ -1040,8 +1040,8 @@ PODS:
     - React-jsi (= 0.73.4-0)
     - React-logger (= 0.73.4-0)
     - React-perflogger (= 0.73.4-0)
-  - RNBitmovinPlayer (0.20.0):
-    - BitmovinPlayer (= 3.59.0)
+  - RNBitmovinPlayer (0.21.0):
+    - BitmovinPlayer (= 3.59.1-a.1)
     - GoogleAds-IMA-iOS-SDK (= 3.18.4)
     - GoogleAds-IMA-tvOS-SDK (= 4.8.2)
     - React-Core
@@ -1216,8 +1216,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   BitmovinAnalyticsCollector: cc31a7ffd96850f5bd4f41b39ea22b467734e9c9
-  BitmovinPlayer: a4deb2e3d96c1f49e924991d625a09434361eb18
-  BitmovinPlayerCore: 23c03dc732abe2695b187d2e711ce37b8e3726f6
+  BitmovinPlayer: cbd8649dacd0778730cc9becd3b693c5561f16c6
+  BitmovinPlayerCore: 8f415fcef5a8346adbd3ca30ee43a0b6921d01a4
   boost: 88202336c3ba1e7a264a83c0c888784b0f360c28
   DoubleConversion: 234abba95e31cc2aada0cf3b97cdb11bc5b90575
   FBLazyVector: 33a271a7e8de0bd321e47356d8bc3b2d5fb9ddba
@@ -1267,9 +1267,9 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 20b2202e3396589a71069d12ae9f328949c7c7b8
   React-utils: 0307d396f233e47a167b5aaf045b0e4e1dc19d74
   ReactCommon: 17891ca337bfa5a7263649b09f27a8c664537bf2
-  RNBitmovinPlayer: 07626ac2df74fc8975f916b51fbac84dd38fea3d
+  RNBitmovinPlayer: 6571ee56df94f0b016f6c9366e58c39ae362660b
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: ab50eb8f7fcf1b36aad1801b5687b66b2c0aa000
+  Yoga: e7f2a2256464d4ef7b3825d216bd22aac3b449c1
 
 PODFILE CHECKSUM: 0bfe194f5e28f1cf54d3d732eda8c78fadbeeedd
 

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -159,9 +159,11 @@ extension RCTConvert {
                 break
             }
         }
+#if !os(tvOS)
         if let updatesNowPlayingInfoCenter = json["updatesNowPlayingInfoCenter"] as? Bool {
             tweaksConfig.updatesNowPlayingInfoCenter = updatesNowPlayingInfoCenter
         }
+#endif
         return tweaksConfig
     }
 


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->

The SDK player in the main branch has not yet the functionality added, this PR uses an alpha release to make the functionality work.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->

- `pod update` BitmovinPlayer dependency to an alpha release containing the wanted feature

## Checklist
- [x] 🗒 `CHANGELOG` entry: No need
