### PR TITLE
Improve `TweaksConfig` docs

### DIFF
--- a/src/tweaksConfig.ts
+++ b/src/tweaksConfig.ts
@@ -11,7 +11,7 @@ export interface TweaksConfig {
    * Default value in iOS is `1.0`.
    * Default value in Android is `0.2`.
    *
-   * @platform iOS, Android
+   * @platform Android, iOS, tvOS
    */
   timeChangedInterval?: number;
   /**
@@ -25,7 +25,7 @@ export interface TweaksConfig {
    *
    * Default is false.
    *
-   * @platform iOS
+   * @platform iOS, tvOS
    */
   isNativeHlsParsingEnabled?: boolean;
   /**
@@ -38,7 +38,7 @@ export interface TweaksConfig {
    *
    * Default is true.
    *
-   * @platform iOS
+   * @platform iOS, tvOS
    */
   isCustomHlsLoadingEnabled?: boolean;
   /**
@@ -52,7 +52,7 @@ export interface TweaksConfig {
    *
    * Default is 0.5.
    *
-   * @platform iOS
+   * @platform iOS, tvOS
    */
   seekToEndThreshold?: number;
   /**
@@ -61,7 +61,7 @@ export interface TweaksConfig {
    * - 'relaxed': Starts playback when enough media data is buffered and continuous playback without stalling can be ensured. If insufficient media data is buffered for playback to start, the player will act as if the buffer became empty during playback.
    * - 'aggressive': When the buffer is not empty, this setting will cause the player to start playback of available media immediately. If insufficient media data is buffered for playback to start, the player will act as if the buffer became empty during playback.
    *
-   * @platform iOS
+   * @platform iOS, tvOS
    */
   playbackStartBehaviour?: 'relaxed' | 'aggressive';
   /**
@@ -70,7 +70,7 @@ export interface TweaksConfig {
    * - 'relaxed': The player will wait until the buffer is filled that it can, most likely, ensure continuous playback without another stalling right after playback continued.
    * - 'aggressive': The player will try to unstall as soon as some media data became available and will start playback of this media immediately.
    *
-   * @platform iOS
+   * @platform iOS, tvOS
    */
   unstallingBehaviour?: 'relaxed' | 'aggressive';
   /**

--- a/src/tweaksConfig.ts
+++ b/src/tweaksConfig.ts
@@ -8,8 +8,8 @@ export interface TweaksConfig {
   /**
    * The frequency in seconds `onTimeChanged` is called with `TimeChangedEvent`s.
    *
-   * Default value in iOS is `1.0`.
    * Default value in Android is `0.2`.
+   * Default value in iOS/tvOS is `1.0`.
    *
    * @platform Android, iOS, tvOS
    */
@@ -23,7 +23,7 @@ export interface TweaksConfig {
    * - `Player.availableVideoQualities` includes additional information
    * - Automatic retries when HLS playlist requests failed with non-2xx HTTP status code
    *
-   * Default is false.
+   * Default is `false`.
    *
    * @platform iOS, tvOS
    */
@@ -36,7 +36,7 @@ export interface TweaksConfig {
    * - SourceWarningEvents when no `#EXT-X-PLAYLIST-TYPE` is found If set to false, enabling
    * nativeHlsParsingEnabled won’t have any effect.
    *
-   * Default is true.
+   * Default is `true`.
    *
    * @platform iOS, tvOS
    */
@@ -50,25 +50,29 @@ export interface TweaksConfig {
    * manifest. In this case, if we try to seek to the end, AVPlayer could get stuck and might stall
    * forever Therefore increasing this value could help.
    *
-   * Default is 0.5.
+   * Default is `0.5`.
    *
    * @platform iOS, tvOS
    */
   seekToEndThreshold?: number;
   /**
-   * Specifies the player behaviour when `Player.play` is called. Default is 'relaxed'.
+   * Specifies the player behaviour when `Player.play` is called.
    *
    * - 'relaxed': Starts playback when enough media data is buffered and continuous playback without stalling can be ensured. If insufficient media data is buffered for playback to start, the player will act as if the buffer became empty during playback.
    * - 'aggressive': When the buffer is not empty, this setting will cause the player to start playback of available media immediately. If insufficient media data is buffered for playback to start, the player will act as if the buffer became empty during playback.
+   *
+   * Default is `relaxed`.
    *
    * @platform iOS, tvOS
    */
   playbackStartBehaviour?: 'relaxed' | 'aggressive';
   /**
-   * Specifies the player behaviour when stalling should be exited. Default is 'relaxed'.
+   * Specifies the player behaviour when stalling should be exited.
    *
    * - 'relaxed': The player will wait until the buffer is filled that it can, most likely, ensure continuous playback without another stalling right after playback continued.
    * - 'aggressive': The player will try to unstall as soon as some media data became available and will start playback of this media immediately.
+   *
+   * Default is `relaxed`.
    *
    * @platform iOS, tvOS
    */

--- a/src/tweaksConfig.ts
+++ b/src/tweaksConfig.ts
@@ -17,9 +17,9 @@ export interface TweaksConfig {
   /**
    * If enabled, HLS playlists will be parsed and additional features and events are enabled. This includes:
    *
-   * - MetadataEvents carrying segment-specific metadata for custom HLS tags, like `#EXT-X-SCTE35`
-   * - MetadataParsedEvents carrying segment-specific metadata for custom HLS tags, like `#EXT-X-SCTE35`
-   * - DrmDataParsedEvents when a `#EXT-X-KEY` is found
+   * - `MetadataEvent`s carrying segment-specific metadata for custom HLS tags, like `#EXT-X-SCTE35`
+   * - `MetadataParsedEvent`s carrying segment-specific metadata for custom HLS tags, like `#EXT-X-SCTE35`
+   * - `DrmDataParsedEvent`s when a `#EXT-X-KEY` is found
    * - `Player.availableVideoQualities` includes additional information
    * - Automatic retries when HLS playlist requests failed with non-2xx HTTP status code
    *
@@ -32,9 +32,9 @@ export interface TweaksConfig {
    * If enabled, playlists will be downloaded by the Bitmovin Player SDK instead of AVFoundation.
    * This enables additional features and events, like:
    *
-   * - DownloadFinishedEvents for playlist downloads.
-   * - SourceWarningEvents when no `#EXT-X-PLAYLIST-TYPE` is found If set to false, enabling
-   * nativeHlsParsingEnabled won’t have any effect.
+   * - `DownloadFinishedEvent`s for playlist downloads.
+   * - `SourceWarningEvent`s when no `#EXT-X-PLAYLIST-TYPE` is found If set to false, enabling
+   * `isNativeHlsParsingEnabled` won’t have any effect.
    *
    * Default is `true`.
    *
@@ -44,10 +44,10 @@ export interface TweaksConfig {
   /**
    * The threshold which will be applied when seeking to the end in seconds. This value will be used
    * to calculate the maximum seekable time when calling `player.seek(time:)` or `player.playlist.seek(source:time:)`,
-   * so the maximum value will be duration - seekToEndThreshold.
+   * so the maximum value will be `duration - seekToEndThreshold`.
    *
    * This is useful if the duration of the segments does not match the duration specified in the
-   * manifest. In this case, if we try to seek to the end, AVPlayer could get stuck and might stall
+   * manifest. In this case, if we try to seek to the end, `AVPlayer` could get stuck and might stall
    * forever Therefore increasing this value could help.
    *
    * Default is `0.5`.

--- a/src/tweaksConfig.ts
+++ b/src/tweaksConfig.ts
@@ -58,8 +58,8 @@ export interface TweaksConfig {
   /**
    * Specifies the player behaviour when `Player.play` is called.
    *
-   * - 'relaxed': Starts playback when enough media data is buffered and continuous playback without stalling can be ensured. If insufficient media data is buffered for playback to start, the player will act as if the buffer became empty during playback.
-   * - 'aggressive': When the buffer is not empty, this setting will cause the player to start playback of available media immediately. If insufficient media data is buffered for playback to start, the player will act as if the buffer became empty during playback.
+   * - relaxed: Starts playback when enough media data is buffered and continuous playback without stalling can be ensured. If insufficient media data is buffered for playback to start, the player will act as if the buffer became empty during playback.
+   * - aggressive: When the buffer is not empty, this setting will cause the player to start playback of available media immediately. If insufficient media data is buffered for playback to start, the player will act as if the buffer became empty during playback.
    *
    * Default is `relaxed`.
    *
@@ -69,8 +69,8 @@ export interface TweaksConfig {
   /**
    * Specifies the player behaviour when stalling should be exited.
    *
-   * - 'relaxed': The player will wait until the buffer is filled that it can, most likely, ensure continuous playback without another stalling right after playback continued.
-   * - 'aggressive': The player will try to unstall as soon as some media data became available and will start playback of this media immediately.
+   * - relaxed: The player will wait until the buffer is filled that it can, most likely, ensure continuous playback without another stalling right after playback continued.
+   * - aggressive: The player will try to unstall as soon as some media data became available and will start playback of this media immediately.
    *
    * Default is `relaxed`.
    *


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->

Some fields in `TweaksConfig` do not state explicitly their tvOS availability.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->

- Sync tvOS availability with native SDK
- Format default values to be at the same place for iOS/tvOS related fields, and to use backticks
- Format object references to use backticks

## Checklist
- [ ] 🗒 `CHANGELOG` entry
