### PR TITLE
Use more verbose run names for GitHub Action workflows

### DIFF
--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -1,5 +1,7 @@
 name: Create SDK update PR
 
+run-name: Create SDK update PR for ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player to ${{ inputs.version_number }}
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/finish-release-train.yml
+++ b/.github/workflows/finish-release-train.yml
@@ -1,4 +1,7 @@
 name: Finish Release Train
+
+run-name: Finish release train on ${{ github.ref_name }}
+
 on:
   pull_request:
     types:

--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -1,4 +1,7 @@
 name: Start Release Train
+
+run-name: Start Release Train ${{ inputs.version_number }}
+
 on:
   workflow_dispatch:
     inputs:
@@ -11,13 +14,16 @@ on:
         type: boolean
         required: false
         default: false
+
 env:
   LC_ALL: en_US.UTF-8
   LANG: en_US.UTF-8
   NO_FLIPPER: 1
+
 concurrency:
   group: start-release-train-${{ inputs.version_number }}
   cancel-in-progress: true
+
 jobs:
   create_release_pr:
     name: Create release branch and bump version


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Extends current GitHub Action run names with context specific information (e.g. inputs)

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Utilized [`run-name`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#run-name) attribute to define context aware name for the GitHub Action workflow runs.

## Checklist
- [ ] 🗒 `CHANGELOG` entry - not needed, internal change only
