### PR TITLE
Move RN function call into the lock block, to avoid missing the condition signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Android: Player Web UI freezing sometimes, under excessive WebUI-RN code messaging
+
 ## [0.22.0] (2024-04-15)
 
 ### Added

--- a/android/src/main/java/com/bitmovin/player/reactnative/ui/CustomMessageHandlerModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/ui/CustomMessageHandlerModule.kt
@@ -62,12 +62,12 @@ class CustomMessageHandlerModule(private val context: ReactApplicationContext) :
         val args = Arguments.createArray()
         args.pushString(message)
         args.pushString(data)
-        context.catalystInstance.callFunction(
-            "CustomMessageBridge-$nativeId",
-            "receivedSynchronousMessage",
-            args as NativeArray,
-        )
         lock.withLock {
+            context.catalystInstance.callFunction(
+                "CustomMessageBridge-$nativeId",
+                "receivedSynchronousMessage",
+                args as NativeArray,
+            )
             customMessageHandlerResultChangedCondition.await()
         }
         return customMessageHandler[nativeId]?.popSynchronousResult()


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
When sending many messages in a short time over the custom message bridge, which connects the native/RN code to the javascript code in the WebUi, it can happen that the synchronous communication channel blocks due to a race condition in the condition signaling.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Move the RN function call block into the lock guarded block, so that we for sure wait for the condition signal, before sending it. The same behaviour is already present for iOS as far as I can see. (cc @rolandkakonyi)

## Checklist
- [x] 🗒 `CHANGELOG` entry
