### PR TITLE
Implement `NetworkConfig.preprocessHttpRequest` for iOS and tvOS

### DIFF
--- a/ios/NetworkModule.m
+++ b/ios/NetworkModule.m
@@ -4,7 +4,7 @@
 
 RCT_EXTERN_METHOD(initWithConfig:(NSString *)nativeId config:(nullable id)config)
 RCT_EXTERN_METHOD(destroy:(NSString *)nativeId)
-RCT_EXTERN_METHOD(setPreprocessedHttpRequest:(NSString *)nativeId request:(NSDictionary *)response)
+RCT_EXTERN_METHOD(setPreprocessedHttpRequest:(NSString *)nativeId request:(NSDictionary *)request)
 RCT_EXTERN_METHOD(setPreprocessedHttpResponse:(NSString *)nativeId response:(NSDictionary *)response)
 
 @end

--- a/ios/NetworkModule.m
+++ b/ios/NetworkModule.m
@@ -4,6 +4,7 @@
 
 RCT_EXTERN_METHOD(initWithConfig:(NSString *)nativeId config:(nullable id)config)
 RCT_EXTERN_METHOD(destroy:(NSString *)nativeId)
+RCT_EXTERN_METHOD(setPreprocessedHttpRequest:(NSString *)nativeId request:(NSDictionary *)response)
 RCT_EXTERN_METHOD(setPreprocessedHttpResponse:(NSString *)nativeId response:(NSDictionary *)response)
 
 @end

--- a/ios/NetworkModule.swift
+++ b/ios/NetworkModule.swift
@@ -7,6 +7,8 @@ public class NetworkModule: NSObject, RCTBridgeModule {
 
     /// In-memory mapping from `nativeId`s to `NetworkConfig` instances.
     private var networkConfigs: Registry<NetworkConfig> = [:]
+    private var preprocessHttpRequestDelegateBridges: Registry<PreprocessHttpRequestDelegate> = [:]
+    private var preprocessHttpRequestCompletionHandlers: Registry<(_ response: HttpRequest) -> Void> = [:]
     private var preprocessHttpResponseCompletionHandlers: Registry<(_ response: HttpResponse) -> Void> = [:]
 
     // swiftlint:disable:next implicitly_unwrapped_optional
@@ -46,6 +48,10 @@ public class NetworkModule: NSObject, RCTBridgeModule {
     func destroy(_ nativeId: NativeId) {
         networkConfigs.removeValue(forKey: nativeId)
 
+        preprocessHttpRequestCompletionHandlers.keys.filter { $0.starts(with: nativeId) }.forEach {
+            preprocessHttpRequestCompletionHandlers.removeValue(forKey: $0)
+        }
+        preprocessHttpRequestDelegateBridges.removeValue(forKey: nativeId)
         preprocessHttpResponseCompletionHandlers.keys.filter { $0.starts(with: nativeId) }.forEach {
             preprocessHttpResponseCompletionHandlers.removeValue(forKey: $0)
         }
@@ -53,7 +59,21 @@ public class NetworkModule: NSObject, RCTBridgeModule {
 
     private func initConfigBlocks(_ nativeId: NativeId, _ config: Any?) {
         if let json = config as? [String: Any] {
+            initPreprocessHttpRequest(nativeId, networkConfigJson: json)
             initPreprocessHttpResponse(nativeId, networkConfigJson: json)
+        }
+    }
+
+    private func initPreprocessHttpRequest(_ nativeId: NativeId, networkConfigJson: [String: Any]) {
+        guard let networkConfig = retrieve(nativeId) else {
+            return
+        }
+        if networkConfigJson["preprocessHttpRequest"] != nil {
+            preprocessHttpRequestDelegateBridges[nativeId] = PreprocessHttpRequestDelegateBridge(
+                nativeId,
+                bridge: bridge
+            )
+            networkConfig.preprocessHttpRequestDelegate = preprocessHttpRequestDelegateBridges[nativeId]
         }
     }
 
@@ -66,6 +86,35 @@ public class NetworkModule: NSObject, RCTBridgeModule {
                 self?.preprocessHttpResponseFromJS(nativeId, type, response, completionHandler)
             }
         }
+    }
+
+    internal func preprocessHttpRequestFromJS(
+        nativeId: NativeId,
+        type: String,
+        request: HttpRequest,
+        completionHandler: @escaping (
+            _ request: HttpRequest
+        ) -> Void
+    ) {
+        let requestId = "\(nativeId)@\(ObjectIdentifier(request).hashValue)"
+        let args: [Any] = [
+            requestId,
+            type,
+            RCTConvert.toJson(httpRequest: request),
+        ]
+        preprocessHttpRequestCompletionHandlers[requestId] = completionHandler
+        bridge.enqueueJSCall("Network-\(nativeId)", method: "onPreprocessHttpRequest", args: args) {}
+    }
+
+    @objc(setPreprocessedHttpRequest:request:)
+    func setPreprocessedHttpRequest(_ requestId: String, _ request: [String: Any]) {
+        guard let completionHandler = preprocessHttpRequestCompletionHandlers[requestId],
+              let httpRequest = RCTConvert.httpRequest(request) else {
+            return
+        }
+
+        preprocessHttpRequestCompletionHandlers.removeValue(forKey: requestId)
+        completionHandler(httpRequest)
     }
 
     private func preprocessHttpResponseFromJS(

--- a/ios/NetworkModule.swift
+++ b/ios/NetworkModule.swift
@@ -65,16 +65,15 @@ public class NetworkModule: NSObject, RCTBridgeModule {
     }
 
     private func initPreprocessHttpRequest(_ nativeId: NativeId, networkConfigJson: [String: Any]) {
-        guard let networkConfig = retrieve(nativeId) else {
+        guard let networkConfig = retrieve(nativeId),
+              networkConfigJson["preprocessHttpRequest"] != nil else {
             return
         }
-        if networkConfigJson["preprocessHttpRequest"] != nil {
-            preprocessHttpRequestDelegateBridges[nativeId] = PreprocessHttpRequestDelegateBridge(
-                nativeId,
-                bridge: bridge
-            )
-            networkConfig.preprocessHttpRequestDelegate = preprocessHttpRequestDelegateBridges[nativeId]
-        }
+        preprocessHttpRequestDelegateBridges[nativeId] = PreprocessHttpRequestDelegateBridge(
+            nativeId,
+            bridge: bridge
+        )
+        networkConfig.preprocessHttpRequestDelegate = preprocessHttpRequestDelegateBridges[nativeId]
     }
 
     private func initPreprocessHttpResponse(_ nativeId: NativeId, networkConfigJson: [String: Any]) {

--- a/ios/NetworkModule.swift
+++ b/ios/NetworkModule.swift
@@ -8,7 +8,7 @@ public class NetworkModule: NSObject, RCTBridgeModule {
     /// In-memory mapping from `nativeId`s to `NetworkConfig` instances.
     private var networkConfigs: Registry<NetworkConfig> = [:]
     private var preprocessHttpRequestDelegateBridges: Registry<PreprocessHttpRequestDelegate> = [:]
-    private var preprocessHttpRequestCompletionHandlers: Registry<(_ response: HttpRequest) -> Void> = [:]
+    private var preprocessHttpRequestCompletionHandlers: Registry<(_ request: HttpRequest) -> Void> = [:]
     private var preprocessHttpResponseCompletionHandlers: Registry<(_ response: HttpResponse) -> Void> = [:]
 
     // swiftlint:disable:next implicitly_unwrapped_optional

--- a/ios/PreprocessHttpRequestDelegateBridge.swift
+++ b/ios/PreprocessHttpRequestDelegateBridge.swift
@@ -14,7 +14,7 @@ internal class PreprocessHttpRequestDelegateBridge: NSObject, PreprocessHttpRequ
         _ type: String,
         httpRequest: HttpRequest,
         completionHandler: @escaping (
-            HttpRequest
+            _ request: HttpRequest
         ) -> Void
     ) {
         guard let networkModule = bridge[NetworkModule.self] else {

--- a/ios/PreprocessHttpRequestDelegateBridge.swift
+++ b/ios/PreprocessHttpRequestDelegateBridge.swift
@@ -1,0 +1,30 @@
+import BitmovinPlayer
+
+internal class PreprocessHttpRequestDelegateBridge: NSObject, PreprocessHttpRequestDelegate {
+    private let nativeId: NativeId
+    private let bridge: RCTBridge
+
+    init(_ nativeId: NativeId, bridge: RCTBridge) {
+        self.nativeId = nativeId
+        self.bridge = bridge
+        super.init()
+    }
+
+    func preprocessHttpRequest(
+        _ type: String,
+        httpRequest: HttpRequest,
+        completionHandler: @escaping (
+            HttpRequest
+        ) -> Void
+    ) {
+        guard let networkModule = bridge[NetworkModule.self] else {
+            return
+        }
+        networkModule.preprocessHttpRequestFromJS(
+            nativeId: nativeId,
+            type: type,
+            request: httpRequest,
+            completionHandler: completionHandler
+        )
+    }
+}

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -52,6 +52,31 @@ export class Network extends NativeInstance<NetworkConfig> {
   };
 
   /**
+   * Applies the user-defined `preprocessHttpRequest` function to native's `type` and `request` data and store
+   * the result back in `NetworkModule`.
+   *
+   * Called from native code when `NetworkConfig.preprocessHttpRequest` is dispatched.
+   *
+   * @param requestId Identifies the completion handler of the request.
+   * @param type Type of the request to be made.
+   * @param request The HTTP request to process.
+   */
+  onPreprocessHttpRequest = (
+    requestId: string,
+    type: HttpRequestType,
+    request: HttpRequest
+  ) => {
+    this.config
+      ?.preprocessHttpRequest?.(type, request)
+      .then((resultRequest) => {
+        NetworkModule.setPreprocessedHttpRequest(requestId, resultRequest);
+      })
+      .catch(() => {
+        NetworkModule.setPreprocessedHttpRequest(requestId, request);
+      });
+  };
+
+  /**
    * Applies the user-defined `preprocessHttpResponse` function to native's `type` and `response` data and store
    * the result back in `NetworkModule`.
    *

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -57,7 +57,7 @@ export class Network extends NativeInstance<NetworkConfig> {
    *
    * Called from native code when `NetworkConfig.preprocessHttpRequest` is dispatched.
    *
-   * @param requestId Identifies the completion handler of the request.
+   * @param requestId Passed through to identify the completion handler of the request on native.
    * @param type Type of the request to be made.
    * @param request The HTTP request to process.
    */


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Implement `NetworkConfig.preprocessHttpRequest` on iOS and tvOS after the API was defined in #449.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Implemented connecting the TS `NetworkConfig.preprocessHttpRequest` with the native `NetworkConfig.preprocessHttpRequestDelegate` on the iOS/tvOS side to enable the React Native SDK to manipulate HTTP requests before executed.

No public API changes were made.

CI checks fail for iOS/tvOS because we use an API from the iOS Player SDK that is not released yet.

## Checklist
- [x] 🗒 `CHANGELOG` entry - already exists
