### PR TITLE
Allow multiple TS players to control the same native player.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Update Bitmovin's native iOS SDK version to `3.64.0`
 
+### Fixed
+
+- Android: Can't create a new Player with an existing NativeID (to bind to the same native Player)
+
 ## [0.23.0] (2024-05-08)
 
 ### Changed

--- a/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
@@ -1,6 +1,8 @@
 package com.bitmovin.player.reactnative
 
+import android.util.Log
 import com.bitmovin.analytics.api.DefaultMetadata
+import com.bitmovin.player.PlayerView
 import com.bitmovin.player.api.Player
 import com.bitmovin.player.api.PlayerConfig
 import com.bitmovin.player.api.analytics.create
@@ -14,6 +16,7 @@ import com.bitmovin.player.reactnative.extensions.mapToReactArray
 import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
 import java.security.InvalidParameterException
+import kotlin.math.log
 
 private const val MODULE_NAME = "PlayerModule"
 
@@ -63,6 +66,9 @@ class PlayerModule(context: ReactApplicationContext) : BitmovinBaseModule(contex
         promise: Promise,
     ) = promise.unit.resolveOnUiThread {
         if (players.containsKey(nativeId)) {
+            if (playerConfigJson != null || analyticsConfigJson != null) {
+                Log.w("BitmovinPlayerModule", "Cannot reconfigure an existing player")
+            }
             return@resolveOnUiThread // key can be reused to access the same native instance (see NativeInstanceConfig)
         }
         val playerConfig = playerConfigJson?.toPlayerConfig() ?: PlayerConfig()

--- a/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
@@ -63,7 +63,7 @@ class PlayerModule(context: ReactApplicationContext) : BitmovinBaseModule(contex
         promise: Promise,
     ) = promise.unit.resolveOnUiThread {
         if (players.containsKey(nativeId)) {
-            throw IllegalArgumentException("Duplicate player creation for id $nativeId")
+            return@resolveOnUiThread // key can be reused to access the same native instance (see NativeInstanceConfig)
         }
         val playerConfig = playerConfigJson?.toPlayerConfig() ?: PlayerConfig()
         val analyticsConfig = analyticsConfigJson?.toAnalyticsConfig()

--- a/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
@@ -2,7 +2,6 @@ package com.bitmovin.player.reactnative
 
 import android.util.Log
 import com.bitmovin.analytics.api.DefaultMetadata
-import com.bitmovin.player.PlayerView
 import com.bitmovin.player.api.Player
 import com.bitmovin.player.api.PlayerConfig
 import com.bitmovin.player.api.analytics.create
@@ -16,7 +15,6 @@ import com.bitmovin.player.reactnative.extensions.mapToReactArray
 import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
 import java.security.InvalidParameterException
-import kotlin.math.log
 
 private const val MODULE_NAME = "PlayerModule"
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/SourceModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/SourceModule.kt
@@ -1,5 +1,6 @@
 package com.bitmovin.player.reactnative
 
+import android.util.Log
 import com.bitmovin.player.api.analytics.create
 import com.bitmovin.player.api.source.Source
 import com.bitmovin.player.reactnative.converter.toAnalyticsSourceMetadata
@@ -77,6 +78,9 @@ class SourceModule(context: ReactApplicationContext) : BitmovinBaseModule(contex
         promise: Promise,
     ) = promise.unit.resolveOnUiThread {
         if (sources.containsKey(nativeId)) {
+            if (drmNativeId != null || config != null || analyticsSourceMetadata != null) {
+                Log.w("BitmovinSourceModule", "Cannot reconfigure an existing source")
+            }
             return@resolveOnUiThread // key can be reused to access the same native instance (see NativeInstanceConfig)
         }
         val drmConfig = drmNativeId?.let { drmModule.getConfig(it) }

--- a/android/src/main/java/com/bitmovin/player/reactnative/SourceModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/SourceModule.kt
@@ -76,12 +76,12 @@ class SourceModule(context: ReactApplicationContext) : BitmovinBaseModule(contex
         analyticsSourceMetadata: ReadableMap?,
         promise: Promise,
     ) = promise.unit.resolveOnUiThread {
+        if (sources.containsKey(nativeId)) {
+            return@resolveOnUiThread // key can be reused to access the same native instance (see NativeInstanceConfig)
+        }
         val drmConfig = drmNativeId?.let { drmModule.getConfig(it) }
         val sourceConfig = config?.toSourceConfig() ?: throw InvalidParameterException("Invalid SourceConfig")
         val sourceMetadata = analyticsSourceMetadata?.toAnalyticsSourceMetadata()
-        if (sources.containsKey(nativeId)) {
-            throw IllegalStateException("NativeId $NativeId already exists")
-        }
         sourceConfig.drmConfig = drmConfig
         sources[nativeId] = if (sourceMetadata == null) {
             Source.create(sourceConfig)

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bootstrap": "yarn bootstrap:example && yarn bootstrap:integration-test",
     "bootstrap:example": "yarn && yarn example && yarn example pods && yarn brew",
     "bootstrap:integration-test": "yarn && yarn integration-test && yarn integration-test pods && yarn brew",
-    "brew": "[ \"$(uname)\" = \"Darwin\" ] && brew bundle install --no-lock",
+    "brew": "[ \"$(uname)\" != Darwin ] || brew bundle install --no-lock",
     "prepare": "husky install",
     "docs": "typedoc"
   },


### PR DESCRIPTION
## Problem (PRN-122)
Some clients implement fullscreen by creating a new fullscreen Player instance
with the name nativeId.
This was documented as supported, but on Android, was not.

## Changes
When a native ID is reused, don't do initialize a new native instance.
Instead, reuse the same native instance.

## Test
Have 2 players on the same screen with the same native-id. Pausing one pauses the other.

![image](https://github.com/bitmovin/bitmovin-player-react-native/assets/6862950/3314e912-61b7-4672-b77e-dba0ec0b6205)


## Checklist
- [x] 🗒 `CHANGELOG` entry if applicable