### PR TITLE
Fix Husky hook on Linux (make it POSIX compliant)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,12 +1,12 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-if [[ "$(uname -m)" == arm64 ]]; then
+if [ "$(uname -m)" = arm64 ]; then
     export PATH="/opt/homebrew/bin:$PATH"
 fi
 
 yarn lint-staged
 
-if [ "$(uname)" == "Darwin" ]; then
+if [ "$(uname)" = Darwin ]; then
     swiftlint lint --strict
 fi


### PR DESCRIPTION
## Problem (untracked)
`Husky` runs hooks with `sh`, a POSIX shell. Nevertheless our hooks are using bashisms. This only works on macos where sh is an alias to bash/zsh/fish, but not on Ubuntu where sh is a minimal POSIX shell.

## Changes
Replace bash syntax by POSIX sh.

Note: Please use https://www.shellcheck.net/ when writing shell scripts :pray: 
