### PR TITLE
Lint Kotlin code in pre-commit hook (like TS & Swift)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -10,3 +10,5 @@ yarn lint-staged
 if [ "$(uname)" == "Darwin" ]; then
     swiftlint lint --strict
 fi
+
+(cd android && ./gradlew ktlintFormat)


### PR DESCRIPTION
## Problem (untracked)
Our git pre-commit hook was formatting Swift and Typescript, but not Kotlin.

## Changes
Run the Kotlin formatted in the pre-commit hook.
