### PR TITLE
Add ref support to `PlayerView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `viewRef` property to `PlayerView` to allow setting a reference to the native view
+
 ## [0.24.0] - 2024-06-04
 
 ### Added

--- a/src/components/PlayerView/index.tsx
+++ b/src/components/PlayerView/index.tsx
@@ -149,7 +149,6 @@ export function PlayerView({
   useEffect(() => {
     if (viewRef) {
       viewRef.current = nativeView.current;
-      console.log('PlayerView ref set');
     }
   }, [viewRef, nativeView]);
 

--- a/src/components/PlayerView/index.tsx
+++ b/src/components/PlayerView/index.tsx
@@ -43,6 +43,7 @@ function dispatch(command: string, node: NodeHandle, ...args: any[]) {
  * @param options configuration options
  */
 export function PlayerView({
+  viewRef,
   style,
   player,
   config,
@@ -61,7 +62,8 @@ export function PlayerView({
     setTimeout(() => player.getDuration(), 100);
   }, [player]);
 
-  const nativeView = useRef(null);
+  const nativeView = useRef(viewRef?.current || null);
+
   // Native events proxy helper.
   const proxy = useProxy(nativeView);
   // Style resulting from merging `baseStyle` and `props.style`.
@@ -143,6 +145,13 @@ export function PlayerView({
       dispatch('setPictureInPicture', node, isPictureInPictureRequested);
     }
   }, [isPictureInPictureRequested, nativeView]);
+
+  useEffect(() => {
+    if (viewRef) {
+      viewRef.current = nativeView.current;
+      console.log('PlayerView ref set');
+    }
+  }, [viewRef, nativeView]);
 
   return (
     <NativePlayerView

--- a/src/components/PlayerView/properties.ts
+++ b/src/components/PlayerView/properties.ts
@@ -36,6 +36,7 @@ export interface BasePlayerViewProps {
  * {@link PlayerView} component props.
  */
 export interface PlayerViewProps extends BasePlayerViewProps, PlayerViewEvents {
+  viewRef?: React.MutableRefObject<null>;
   /**
    * {@link Player} instance (generally returned from {@link usePlayer} hook) that will control
    * and render audio/video inside the {@link PlayerView}.


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
This PR enables future integrations to have access to the underlying native `PlayerView` instances.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Added the possibility to inject a `React.MutableRefObject` for setting initial value and track value changes of `nativeView` reference inside `PlayerView`.
This can be then used to fetch the related native `PlayerView` based on this reference.
This is crucial for integrations accessing `PlayerView` natively.

Note: I couldn't use the property name `ref` as that triggers the error of `Function components cannot be given refs. Attempts to access this ref will fail.`

It can be used like this:
```tsx
const player = usePlayer();
const viewRef = useRef(null);

return <PlayerView viewRef={viewRef} player={player} />
```

## Checklist
- [x] 🗒 `CHANGELOG` entry
