### PR TITLE
Fix crash on hot reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `viewRef` property to `PlayerView` to allow setting a reference to the native view
 
+### Fixed
+
+- iOS: Possible crash on hot-reload
+
 ## [0.24.0] - 2024-06-04
 
 ### Added

--- a/ios/PlayerModule.swift
+++ b/ios/PlayerModule.swift
@@ -23,6 +23,15 @@ public class PlayerModule: NSObject, RCTBridgeModule { // swiftlint:disable:this
         bridge.uiManager.methodQueue
     }
 
+    deinit {
+        // Destroy all players on the main thread when the module is deallocated.
+        // This is necessary when the IMA SDK is present in the app, as it may crash if the players are destroyed on a
+        // background thread.
+        DispatchQueue.main.async { [players] in
+            players.values.forEach { $0.destroy() }
+        }
+    }
+
     /**
      Fetches the `Player` instance associated with `nativeId` from the internal players.
      - Parameter nativeId: `Player` instance ID.


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
This PR fixes crashes on hot-reload.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Due to React Native recreating modules on hot-reload, the cached `Player` instances get deallocated on a background thread which leads to a crash.

## Checklist
- [x] 🗒 `CHANGELOG` entry
