### PR TITLE
Feature/set video quality

### DIFF
--- a/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
@@ -551,6 +551,21 @@ class PlayerModule(context: ReactApplicationContext) : BitmovinBaseModule(contex
     }
 
     /**
+     * Set [nativeId]'s player video quality.
+     * NOTE: ONLY available on Android. No effect on iOS and tvOS devices.
+     * @param nativeId Target player Id.
+     * @param qualityId The videoQualityId identifier. A list of currently available VideoQualitys can be retrieved via availableVideoQualities. To use automatic quality selection, Quality.AUTO_ID can be passed as qualityId.
+     * @param promise JS promise object.
+     */
+    @ReactMethod
+    fun setVideoQuality(nativeId: NativeId, qualityId: String, promise: Promise) {
+        promise.unit.resolveOnUiThreadWithPlayer(nativeId) {
+            source?.setVideoQuality(qualityId)
+        }
+    }
+
+
+    /**
      * Resolve [nativeId]'s current playback speed.
      */
     @ReactMethod

--- a/src/player.ts
+++ b/src/player.ts
@@ -438,6 +438,20 @@ export class Player extends NativeInstance<PlayerConfig> {
   };
 
   /**
+   * Sets the video quality.
+   * ONLY works on Android. No effect on iOS and tvOS devices.
+   */
+  setVideoQuality = (qualityId: String) => {
+    if (Platform.OS !== 'android') {
+      console.warn(
+        `[Player ${this.nativeId}] Method setVideoQuality is not available for iOS and tvOS devices. Only Android devices.`
+      );
+    } else {
+      PlayerModule.setVideoQuality(this.nativeId, qualityId);
+    }
+  };
+
+  /**
    * Sets the playback speed of the player. Fast forward, slow motion and reverse playback are supported.
    * @note
    * - Slow motion is indicated by values between `0` and `1`.


### PR DESCRIPTION
## Description
new feature to setVideoQuality on Android. This feature is not available on iOS and tvOS devices

## Changes
- Integrated with the `source.setVideoQuality` Bitmovin Android Player API
- Platform check to throw warning on non-Android devices

## Checklist
- [ ] 🗒 `CHANGELOG` entry
