### PR TITLE
Fix integration-test `Podfile.lock` not being staged during release

### DIFF
--- a/.github/workflows/start-release-train.yml
+++ b/.github/workflows/start-release-train.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Commit changelog version bump
         if: ${{ !inputs.dry_run }}
         run: |
-          git add CHANGELOG.md package.json example/ios/Podfile.lock
+          git add CHANGELOG.md package.json example/ios/Podfile.lock integration_test/ios/Podfile.lock
           git commit -m "chore: prepare release ${{ inputs.version_number }}"
           git push origin ${{ steps.branching.outputs.branch_name }}
 


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->

The release action is not staging the changes to `integration_test/ios/Podfile.lock`, so it can stay misaligned with the pod file of the examples folder

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->

Stage `integration_test/ios/Podfile.lock` too

## Checklist
- [x] 🗒 `CHANGELOG` entry: `no need`
