### PR TITLE
Fix `NO_FLIPPER` flag not working

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
     "start": "react-native start",
     "pods": "yarn pods-install || yarn pods-update",
     "pods-install": "NO_FLIPPER=1 yarn pod-install",
-    "pods-update": "NO_FLIPPER=1 cd ios; pod update --silent"
+    "pods-update": "cd ios && NO_FLIPPER=1 pod update --silent"
   },
   "dependencies": {
     "@react-native-picker/picker": "2.6.1",

--- a/integration_test/package.json
+++ b/integration_test/package.json
@@ -15,7 +15,7 @@
     "test:ios": "yarn stop-test:ios && yarn start-test:ios",
     "pods": "yarn pods-install || yarn pods-update",
     "pods-install": "NO_FLIPPER=1 yarn pod-install",
-    "pods-update": "NO_FLIPPER=1 cd ios; pod update --silent"
+    "pods-update": "cd ios && NO_FLIPPER=1 pod update --silent"
   },
   "dependencies": {
     "cavy": "^4.0.2",


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->

`NO_FLIPPER=1` was not working on some systems like mine

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->

Reorder the commands using the env flag in `package.json` files

## Test

Run `yarn bootstrap` and check podfile locks

## Checklist
- [x] 🗒 `CHANGELOG` entry - `no need`
