### PR TITLE
Feat expose ad item preload offset

### DIFF
--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -206,7 +206,7 @@ fun ReadableMap.toAdItem(): AdItem? {
     return AdItem(
         sources = getArray("sources") ?.toMapList()?.mapNotNull { it?.toAdSource() }?.toTypedArray() ?: return null,
         position = getString("position") ?: "pre",
-        preloadOffset = getString("preloadOffset") ?: 0,
+        preloadOffset = getDoubleOrNull("preloadOffset") ?: 0.0,
     )
 }
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -206,6 +206,7 @@ fun ReadableMap.toAdItem(): AdItem? {
     return AdItem(
         sources = getArray("sources") ?.toMapList()?.mapNotNull { it?.toAdSource() }?.toTypedArray() ?: return null,
         position = getString("position") ?: "pre",
+        preloadOffset = getString("preloadOffset") ?: 0,
     )
 }
 

--- a/src/advertising.ts
+++ b/src/advertising.ts
@@ -83,7 +83,7 @@ export interface AdItem {
    * i.e as compared to when the ad break is scheduled for playback.
    * Default value is 0.0
    */
-  preloadOffset: Number;
+  preloadOffset?: Number;
 }
 
 /**

--- a/src/advertising.ts
+++ b/src/advertising.ts
@@ -83,7 +83,7 @@ export interface AdItem {
    * i.e as compared to when the ad break is scheduled for playback.
    * Default value is 0.0
    */
-  preloadOffset?: Number;
+  preloadOffset?: number;
 }
 
 /**

--- a/src/advertising.ts
+++ b/src/advertising.ts
@@ -1,3 +1,5 @@
+import { Double } from 'react-native/Libraries/Types/CodegenTypes';
+
 /**
  * Quartiles that can be reached during an ad playback.
  */
@@ -76,6 +78,12 @@ export interface AdItem {
    * The fallback ad sources need to have the same `AdSourceType` as the main ad source.
    */
   sources: AdSource[];
+
+  /**
+   * The amount of seconds the ad manifest is loaded in advance;
+   * i.e as compared to when the ad break is scheduled for playback.
+   */
+  preloadOffset: Double;
 }
 
 /**

--- a/src/advertising.ts
+++ b/src/advertising.ts
@@ -1,5 +1,3 @@
-import { Double } from 'react-native/Libraries/Types/CodegenTypes';
-
 /**
  * Quartiles that can be reached during an ad playback.
  */
@@ -80,10 +78,12 @@ export interface AdItem {
   sources: AdSource[];
 
   /**
+   * @platform Android
    * The amount of seconds the ad manifest is loaded in advance;
    * i.e as compared to when the ad break is scheduled for playback.
+   * Default value is 0.0
    */
-  preloadOffset: Double;
+  preloadOffset: Number;
 }
 
 /**

--- a/src/advertising.ts
+++ b/src/advertising.ts
@@ -78,10 +78,12 @@ export interface AdItem {
   sources: AdSource[];
 
   /**
-   * @platform Android
-   * The amount of seconds the ad manifest is loaded in advance;
-   * i.e as compared to when the ad break is scheduled for playback.
+   * The amount of seconds the ad manifest is loaded in advance
+   * compared to when the ad break is scheduled for playback.
+   *
    * Default value is 0.0
+   *
+   * @platform Android
    */
   preloadOffset?: number;
 }


### PR DESCRIPTION
## Description
Expose the AdItem. preloadOffset property. This property is NOT available for iOS. Android documentation [reference](https://cdn.bitmovin.com/player/android/3/docs/player-core/com.bitmovin.player.api.advertising/-ad-item/preload-offset.html)

## Changes
1. added the property with type `Number`
2. copied the existing documentation from the Android API, including mention of default value
3. add @platform Android to the documentation to indicate it's ONLY for Android
4. Parsed the RN value and return it as an Android AdItem object in JsonConvertor.toAdItem

## Checklist
- [ ] 🗒 `CHANGELOG` entry
