### PR TITLE
Bump fast-xml-parser from 4.4.0 to 4.4.1 in /integration_test

### DIFF
--- a/integration_test/package.json
+++ b/integration_test/package.json
@@ -34,7 +34,8 @@
     "cavy-cli": "^3.0.0",
     "patch-package": "^8.0.0",
     "pod-install": "^0.1.39",
-    "react-native-uuid": "^2.0.1"
+    "react-native-uuid": "^2.0.1",
+    "fast-xml-parser": "4.4.1"
   },
   "engines": {
     "node": ">=18"

--- a/integration_test/yarn.lock
+++ b/integration_test/yarn.lock
@@ -2453,6 +2453,13 @@ execa@^5.0.0, execa@^5.1.1:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+fast-xml-parser@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz#86dbf3f18edf8739326447bcaac31b4ae7f6514f"
+  integrity sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==
+  dependencies:
+    strnum "^1.0.5"
+
 fast-xml-parser@^4.0.12, fast-xml-parser@^4.2.4:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz#341cc98de71e9ba9e651a67f41f1752d1441a501"


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
There is a security problem with fast-xml-parser 4.4.0

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Updated to 4.4.1

## Checklist
- [ ] 🗒 `CHANGELOG` entry - not needed
