### PR TITLE
Feat/initial bandwidth estimate override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Android: `AdaptationConfig.initialBandwidthEstimateOverride` to override the selection of the optimal media tracks before actual bandwidth data is available
+
 ## [0.28.0] - 2024-08-07
 
 ### Added

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -144,6 +144,7 @@ private fun String.toTimelineReferencePoint(): TimelineReferencePoint? = when (t
  */
 private fun ReadableMap.toAdaptationConfig(): AdaptationConfig = AdaptationConfig().apply {
     withInt("maxSelectableBitrate") { maxSelectableVideoBitrate = it }
+    withInt("initialBandwidthEstimateOverride") { initialBandwidthEstimateOverride = it.toLong(); }
 }
 
 /**

--- a/src/adaptationConfig.ts
+++ b/src/adaptationConfig.ts
@@ -7,4 +7,12 @@ export interface AdaptationConfig {
    * Can be set to `undefined` for no limitation.
    */
   maxSelectableBitrate?: number;
+
+  /**
+   * The initial bandwidth estimate in bits per second the player uses to select the optimal media tracks before actual bandwidth data is available. Overriding this value should only be done in specific cases and will most of the time not result in better selection logic.
+   *
+   * @platform Android
+   * @see https://cdn.bitmovin.com/player/android/3/docs/player-core/com.bitmovin.player.api.media/-adaptation-config/initial-bandwidth-estimate-override.html?query=var%20initialBandwidthEstimateOverride:%20Long?
+   */
+  initialBandwidthEstimateOverride?: number;
 }

--- a/src/adaptationConfig.ts
+++ b/src/adaptationConfig.ts
@@ -12,7 +12,7 @@ export interface AdaptationConfig {
    * The initial bandwidth estimate in bits per second the player uses to select the optimal media tracks before actual bandwidth data is available. Overriding this value should only be done in specific cases and will most of the time not result in better selection logic.
    *
    * @platform Android
-   * @see https://cdn.bitmovin.com/player/android/3/docs/player-core/com.bitmovin.player.api.media/-adaptation-config/initial-bandwidth-estimate-override.html?query=var%20initialBandwidthEstimateOverride:%20Long?
+   * @see https://cdn.bitmovin.com/player/android/3/docs/player-core/com.bitmovin.player.api.media/-adaptation-config/initial-bandwidth-estimate-override.html
    */
   initialBandwidthEstimateOverride?: number;
 }


### PR DESCRIPTION
## Description
Added support for the `adaptationConfig.initialBandwidthEstimateOverride` config parameter.

## Changes
Android initialBandwidthEstimateOverride is type Long. No such type on JS hence converted from int to long. Hope that's ok. Max value of Int `2,147,483,647 ` should be sufficient for this usecase I believe.

## Checklist
- [ ] 🗒 `CHANGELOG` entry