### PR TITLE
Update IMA SDK dependency on Android to `3.33.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Update Bitmovin's native Android SDK version to `3.82.0`
+- Update IMA SDK dependency on Android to `3.33.0`
 
 ### Changed
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     implementation "androidx.concurrent:concurrent-futures-ktx:1.1.0"
 
     // Bitmovin
-    implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.31.0'
+    implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.33.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
     implementation 'com.bitmovin.player:player:3.82.0+jason'
 }


### PR DESCRIPTION
## Description
IMA SDK version is not up to date with Android Player

## Changes
Update IMA SDK dependency on Android to `3.33.0`

## Checklist
- [x] 🗒 `CHANGELOG` entry
