### PR TITLE
iOS: support Media Controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `LockScreenControlConfig` to configure the lock screen information for the application. When `isEnabled` is `true`, the current media information will be shown on the lock-screen and within the control center.
+
 ### Changed
 
 - Update Bitmovin's native Android SDK version to `3.84.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `LockScreenControlConfig` to configure the lock screen information for the application. When `isEnabled` is `true`, the current media information will be shown on the lock-screen and within the control center.
+- `LockScreenControlConfig` to configure the lock screen information for the application. When `isEnabled` is `true`, the current media information will be shown on the lock-screen and within the control center
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Update Bitmovin's native Android SDK version to `3.84.0`
 
+### Deprecated
+
+- `TweaksConfig.updatesNowPlayingInfoCenter` in favor of `LockScreenControlConfig.isEnabled`
+
 ## [0.29.0] - 2024-09-09
 
 ### Added

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -42,6 +42,9 @@ extension RCTConvert {
         if let networkConfig = RCTConvert.networkConfig(json["networkConfig"]) {
             playerConfig.networkConfig = networkConfig
         }
+        if let nowPlayingConfig = RCTConvert.lockScreenControlConfig(json["lockScreenControlConfig"]) {
+            playerConfig.nowPlayingConfig = nowPlayingConfig
+        }
 #if os(iOS)
         if let remoteControlConfig = RCTConvert.remoteControlConfig(json["remoteControlConfig"]) {
             playerConfig.remoteControlConfig = remoteControlConfig
@@ -1327,6 +1330,17 @@ extension RCTConvert {
             "headers": httpResponse.headers,
             "body": toJson(data: httpResponse.body)
         ]
+    }
+
+    static func lockScreenControlConfig(_ json: Any?) -> NowPlayingConfig? {
+        guard let json = json as? [String: Any?] else {
+            return nil
+        }
+        let nowPlayingConfig = NowPlayingConfig()
+        if let isEnabled = json["isEnabled"] as? Bool {
+            nowPlayingConfig.isNowPlayingInfoEnabled = isEnabled
+        }
+        return nowPlayingConfig
     }
 }
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,3 +24,4 @@ export * from './playerConfig';
 export * from './liveConfig';
 export * from './bufferApi';
 export * from './network';
+export * from './lockScreenControlConfig';

--- a/src/lockScreenControlConfig.ts
+++ b/src/lockScreenControlConfig.ts
@@ -13,7 +13,7 @@ export interface LockScreenControlConfig {
    * For a detailed list of the supported features in the **default behavior**,
    * check the **Default Supported Features** section.
    *
-   * @note Enabling this flag will automatically treat `TweaksConfig.updatesNowPlayingInfoCenter` as `false`.
+   * @note Enabling this flag will automatically treat {@link TweaksConfig.updatesNowPlayingInfoCenter} as `false`.
    *
    * ## Limitations
    * ---

--- a/src/lockScreenControlConfig.ts
+++ b/src/lockScreenControlConfig.ts
@@ -1,0 +1,5 @@
+// TODO: docs
+export interface LockScreenControlConfig {
+  // TODO: docs
+  isEnabled?: boolean;
+}

--- a/src/lockScreenControlConfig.ts
+++ b/src/lockScreenControlConfig.ts
@@ -1,6 +1,6 @@
 /**
  * Configures the lock screen information for the application. This information will be displayed
- * wherever lock screen information typically appears, such as the lock screen
+ * wherever current media information typically appears, such as the lock screen
  * and inside the control center.
  */
 export interface LockScreenControlConfig {

--- a/src/lockScreenControlConfig.ts
+++ b/src/lockScreenControlConfig.ts
@@ -4,7 +4,6 @@
  * and inside the control center.
  */
 export interface LockScreenControlConfig {
-  // TODO: android docs, and merge them.
   /**
    * Enable the default behavior of displaying media information
    * on the lock screen and within the control center.

--- a/src/lockScreenControlConfig.ts
+++ b/src/lockScreenControlConfig.ts
@@ -1,4 +1,8 @@
-// TODO: docs
+/**
+ * Configures the lock screen information for the application. This information will be displayed
+ * wherever lock screen information typically appears, such as the lock screen
+ * and inside the control center.
+ */
 export interface LockScreenControlConfig {
   // TODO: docs
   isEnabled?: boolean;

--- a/src/lockScreenControlConfig.ts
+++ b/src/lockScreenControlConfig.ts
@@ -4,6 +4,47 @@
  * and inside the control center.
  */
 export interface LockScreenControlConfig {
-  // TODO: docs
+  // TODO: android docs, and merge them.
+  /**
+   * Enable the default behavior of displaying Now Playing information
+   * on the lock screen and inside the control center.
+   * Default is `false`.
+   *
+   * For a detailed list of the supported features in the **default behavior**,
+   * check the **Default Supported Features** section.
+   *
+   * @note Enabling this flag will automatically treat `TweaksConfig.updatesNowPlayingInfoCenter` as `false`.
+   *
+   * ## Limitations
+   * ---
+   * - Currently, the current Now Playing information is disabled during casting.
+   *
+   * ## Known Issues
+   * ---
+   * - There is unexpected behavior when using the IMA SDK. The Google IMA SDK adds its own commands
+   *   for play/pause as soon as the ad starts loading (not when it starts playing). Within this window
+   *   (approximately around 10 seconds), it is possible that both the ad and the main content are playing
+   *   at the same time when a user interacts with the Now Playing feature.
+   *
+   * ## Default Supported Features
+   * ---
+   * Here is the list of features supported by the default behavior.
+   *
+   * ### Populated Metadata
+   * - asset URL (to visualize the correct kind of data — _e.g. a waveform for audio files_)
+   * - title
+   * - artwork
+   * - live or VOD status
+   * - playback rate
+   * - default playback rate
+   * - elapsed time
+   * - duration
+   *
+   * ### Registered Commands
+   * - toggle play/pause
+   * - change playback position
+   * - skip forward
+   * - skip backward
+   */
   isEnabled?: boolean;
 }

--- a/src/lockScreenControlConfig.ts
+++ b/src/lockScreenControlConfig.ts
@@ -6,8 +6,8 @@
 export interface LockScreenControlConfig {
   // TODO: android docs, and merge them.
   /**
-   * Enable the default behavior of displaying Now Playing information
-   * on the lock screen and inside the control center.
+   * Enable the default behavior of displaying media information
+   * on the lock screen and within the control center.
    * Default is `false`.
    *
    * For a detailed list of the supported features in the **default behavior**,
@@ -17,14 +17,15 @@ export interface LockScreenControlConfig {
    *
    * ## Limitations
    * ---
-   * - At the moment, the current Now Playing information is disabled during casting.
+   * - At the moment, the current media information is disabled during casting.
    *
    * ## Known Issues
    * ---
+   * **iOS**:
    * - There is unexpected behavior when using the IMA SDK. The Google IMA SDK adds its own commands
    *   for play/pause as soon as the ad starts loading (not when it starts playing). Within this window
    *   (approximately around 10 seconds), it is possible that both the ad and the main content are playing
-   *   at the same time when a user interacts with the Now Playing feature.
+   *   at the same time when a user interacts with the lock-screen control feature.
    *
    * ## Default Supported Features
    * ---

--- a/src/lockScreenControlConfig.ts
+++ b/src/lockScreenControlConfig.ts
@@ -17,7 +17,7 @@ export interface LockScreenControlConfig {
    *
    * ## Limitations
    * ---
-   * - Currently, the current Now Playing information is disabled during casting.
+   * - At the moment, the current Now Playing information is disabled during casting.
    *
    * ## Known Issues
    * ---

--- a/src/playerConfig.ts
+++ b/src/playerConfig.ts
@@ -74,6 +74,10 @@ export interface PlayerConfig extends NativeInstanceConfig {
    * Configures network request manipulation functionality. A default {@link NetworkConfig} is set initially.
    */
   networkConfig?: NetworkConfig;
-  // TODO: docs
+  /**
+   * Configures the lock screen information for the application. This information will be displayed
+   * wherever lock screen information typically appears, such as the lock screen
+   * and inside the control center.
+   */
   lockScreenControlConfig?: LockScreenControlConfig;
 }

--- a/src/playerConfig.ts
+++ b/src/playerConfig.ts
@@ -9,6 +9,7 @@ import { NativeInstanceConfig } from './nativeInstance';
 import { PlaybackConfig } from './playbackConfig';
 import { LiveConfig } from './liveConfig';
 import { NetworkConfig } from './network/networkConfig';
+import { LockScreenControlConfig } from './lockScreenControlConfig';
 
 /**
  * Object used to configure a new `Player` instance.
@@ -73,4 +74,6 @@ export interface PlayerConfig extends NativeInstanceConfig {
    * Configures network request manipulation functionality. A default {@link NetworkConfig} is set initially.
    */
   networkConfig?: NetworkConfig;
+  // TODO: docs
+  lockScreenControlConfig?: LockScreenControlConfig;
 }

--- a/src/playerConfig.ts
+++ b/src/playerConfig.ts
@@ -76,7 +76,7 @@ export interface PlayerConfig extends NativeInstanceConfig {
   networkConfig?: NetworkConfig;
   /**
    * Configures the lock screen information for the application. This information will be displayed
-   * wherever lock screen information typically appears, such as the lock screen
+   * wherever current media information typically appears, such as the lock screen
    * and inside the control center.
    */
   lockScreenControlConfig?: LockScreenControlConfig;

--- a/src/tweaksConfig.ts
+++ b/src/tweaksConfig.ts
@@ -166,6 +166,7 @@ export interface TweaksConfig {
    *
    * Default is `true`.
    *
+   * @deprecated To enable the Now Playing information use {@link LockScreenControlConfig.isEnabled}
    * @platform iOS
    */
   updatesNowPlayingInfoCenter?: boolean;


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->

Introduce the lock-screen control config!
Use it to make the system display the current media information on the lock-screen, in notifications, and within the control-center

### PR-planning
- 📍  iOS part
- 🔜  Android part: #539 
Both will be merged together on a **base branch**

### Overview Pics

<img width="280" alt="image" src="https://github.com/user-attachments/assets/cb81dd70-1076-44ba-b5b1-fabed9abb886">
<img width="280" alt="image" src="https://github.com/user-attachments/assets/2c7eddd5-a6be-4516-b65b-b52fd1ef42b7">
<img width="280" alt="image" src="https://github.com/user-attachments/assets/a7294f27-134e-49e6-a3d7-8ef06b78c2e2">





## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->

Introduce `LockScreenControlConfig`
- Currently it only supports `isEnabled` to enable/disable the feature

Deprecate `TweaksConfig.updatesNowPlayingInfoCenter`

## Test

Manually test the integration being turned on/off by adding the new config into a sample (e.g. **BasicPlayback**):
```diff
  const player = usePlayer({
    remoteControlConfig: {
      isCastEnabled: false,
    },
+    lockScreenControlConfig: {
+      isEnabled: true,
+    },
  });
```

## Checklist
- [x] 🗒 `CHANGELOG` entry
