### PR TITLE
Include the possibility to define uiManagerFactoryFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `WebUiConfig.variant` to set the UI variant that should be used by the Bitmovin Web UI
+
+### Fixed
+
+- Spatial navigation in the Web UI does not work properly
+
 ## [0.29.0] - 2024-09-09
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -105,5 +105,5 @@ dependencies {
     // Bitmovin
     implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.33.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
-    implementation 'com.bitmovin.player:player:3.82.0+jason'
+    implementation 'com.bitmovin.player:player:3.90.0+jason'
 }

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -763,9 +763,7 @@ fun ReadableMap.toPlayerViewConfig(): PlayerViewConfig {
 
     return PlayerViewConfig(
         uiConfig = UiConfig.WebUi(
-            playbackSpeedSelectionEnabled = uiConfig
-                .getBooleanOrNull("playbackSpeedSelectionEnabled")
-                ?: true,
+            playbackSpeedSelectionEnabled = uiConfig.getBooleanOrNull("playbackSpeedSelectionEnabled") ?: true,
             variant = variant,
             focusUiOnInitialization = focusUiOnInitialization ?: defaultFocusUiOnInitialization,
         ),

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -752,30 +752,28 @@ fun ReadableMap.toPictureInPictureConfig(): PictureInPictureConfig = PictureInPi
     isEnabled = getBooleanOrNull("isEnabled") ?: false,
 )
 
-/**
- * Converts the [json] to a `RNUiConfig` object.
- */
-fun ReadableMap.toPlayerViewConfig(): PlayerViewConfig {
-    val uiConfig = getMap("uiConfig") ?: return PlayerViewConfig()
-    val variant = uiConfig.toVariant()
-    val focusUiOnInitialization = uiConfig.getBooleanOrNull("focusUiOnInitialization")
+fun ReadableMap.toPlayerViewConfig(): PlayerViewConfig = PlayerViewConfig(
+    uiConfig = getMap("uiConfig")?.toUiConfig() ?: UiConfig.WebUi(),
+    hideFirstFrame = getBooleanOrNull("hideFirstFrame") ?: false,
+)
+
+private fun ReadableMap.toUiConfig(): UiConfig {
+    val variant = toVariant() ?: UiConfig.WebUi.Variant.SmallScreenUi
+    val focusUiOnInitialization = getBooleanOrNull("focusUiOnInitialization")
     val defaultFocusUiOnInitialization = variant == UiConfig.WebUi.Variant.TvUi
 
-    return PlayerViewConfig(
-        uiConfig = UiConfig.WebUi(
-            playbackSpeedSelectionEnabled = uiConfig.getBooleanOrNull("playbackSpeedSelectionEnabled") ?: true,
-            variant = variant,
-            focusUiOnInitialization = focusUiOnInitialization ?: defaultFocusUiOnInitialization,
-        ),
-        hideFirstFrame = getBooleanOrNull("hideFirstFrame") ?: false,
+    return UiConfig.WebUi(
+        playbackSpeedSelectionEnabled = getBooleanOrNull("playbackSpeedSelectionEnabled") ?: true,
+        variant = variant,
+        focusUiOnInitialization = focusUiOnInitialization ?: defaultFocusUiOnInitialization,
     )
 }
 
-private fun ReadableMap.toVariant(): UiConfig.WebUi.Variant {
-    val uiManagerFactoryFunction = getMap("variant")?.getString("uiManagerFactoryFunction")
+private fun ReadableMap.toVariant(): UiConfig.WebUi.Variant? {
+    val uiManagerFactoryFunction = getMap("variant")?.getString("uiManagerFactoryFunction") ?: return null
 
     return when (uiManagerFactoryFunction) {
-        "bitmovin.playerui.UIFactory.buildDefaultSmallScreenUI", null -> UiConfig.WebUi.Variant.SmallScreenUi
+        "bitmovin.playerui.UIFactory.buildDefaultSmallScreenUI" -> UiConfig.WebUi.Variant.SmallScreenUi
         "bitmovin.playerui.UIFactory.buildDefaultTvUI" -> UiConfig.WebUi.Variant.TvUi
         else -> UiConfig.WebUi.Variant.Custom(uiManagerFactoryFunction)
     }

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -755,14 +755,32 @@ fun ReadableMap.toPictureInPictureConfig(): PictureInPictureConfig = PictureInPi
 /**
  * Converts the [json] to a `RNUiConfig` object.
  */
-fun toPlayerViewConfig(json: ReadableMap) = PlayerViewConfig(
-    uiConfig = UiConfig.WebUi(
-        playbackSpeedSelectionEnabled = json.getMap("uiConfig")
-            ?.getBooleanOrNull("playbackSpeedSelectionEnabled")
-            ?: true,
-    ),
-    hideFirstFrame = json.getBooleanOrNull("hideFirstFrame") ?: false,
-)
+fun ReadableMap.toPlayerViewConfig(): PlayerViewConfig {
+    val uiConfig = getMap("uiConfig") ?: return PlayerViewConfig()
+    val variant = uiConfig.toVariant() ?: UiConfig.WebUi.Variant.SmallScreenUi
+    val focusUiOnInitialization = uiConfig.getBooleanOrNull("focusUiOnInitialization")
+    val defaultFocusUiOnInitialization = variant == UiConfig.WebUi.Variant.TvUi
+
+    return PlayerViewConfig(
+        uiConfig = UiConfig.WebUi(
+            playbackSpeedSelectionEnabled = uiConfig
+                .getBooleanOrNull("playbackSpeedSelectionEnabled")
+                ?: true,
+            variant = variant,
+            focusUiOnInitialization = focusUiOnInitialization ?: defaultFocusUiOnInitialization,
+        ),
+        hideFirstFrame = getBooleanOrNull("hideFirstFrame") ?: false,
+    )
+}
+
+private fun ReadableMap.toVariant(): UiConfig.WebUi.Variant? {
+    val uiManagerFactoryFunction = this.getMap("variant")?.getString("uiManagerFactoryFunction") ?: return null
+    return when (uiManagerFactoryFunction) {
+        "bitmovin.playerui.UIFactory.buildDefaultSmallScreenUI" -> UiConfig.WebUi.Variant.SmallScreenUi
+        "bitmovin.playerui.UIFactory.buildDefaultTvUI" -> UiConfig.WebUi.Variant.TvUi
+        else -> UiConfig.WebUi.Variant.Custom(uiManagerFactoryFunction)
+    }
+}
 
 private fun ReadableMap.toUserInterfaceTypeFromPlayerConfig(): UserInterfaceType? =
     when (getMap("styleConfig")?.getString("userInterfaceType")) {
@@ -775,7 +793,7 @@ private fun ReadableMap.toUserInterfaceTypeFromPlayerConfig(): UserInterfaceType
  * Converts the [this@toRNPlayerViewConfigWrapper] to a `RNPlayerViewConfig` object.
  */
 fun ReadableMap.toRNPlayerViewConfigWrapper() = RNPlayerViewConfigWrapper(
-    playerViewConfig = toPlayerViewConfig(this),
+    playerViewConfig = toPlayerViewConfig(),
     pictureInPictureConfig = getMap("pictureInPictureConfig")?.toPictureInPictureConfig(),
 )
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -757,7 +757,7 @@ fun ReadableMap.toPictureInPictureConfig(): PictureInPictureConfig = PictureInPi
  */
 fun ReadableMap.toPlayerViewConfig(): PlayerViewConfig {
     val uiConfig = getMap("uiConfig") ?: return PlayerViewConfig()
-    val variant = uiConfig.toVariant() ?: UiConfig.WebUi.Variant.SmallScreenUi
+    val variant = uiConfig.toVariant()
     val focusUiOnInitialization = uiConfig.getBooleanOrNull("focusUiOnInitialization")
     val defaultFocusUiOnInitialization = variant == UiConfig.WebUi.Variant.TvUi
 
@@ -773,10 +773,11 @@ fun ReadableMap.toPlayerViewConfig(): PlayerViewConfig {
     )
 }
 
-private fun ReadableMap.toVariant(): UiConfig.WebUi.Variant? {
-    val uiManagerFactoryFunction = this.getMap("variant")?.getString("uiManagerFactoryFunction") ?: return null
+private fun ReadableMap.toVariant(): UiConfig.WebUi.Variant {
+    val uiManagerFactoryFunction = getMap("variant")?.getString("uiManagerFactoryFunction")
+
     return when (uiManagerFactoryFunction) {
-        "bitmovin.playerui.UIFactory.buildDefaultSmallScreenUI" -> UiConfig.WebUi.Variant.SmallScreenUi
+        "bitmovin.playerui.UIFactory.buildDefaultSmallScreenUI", null -> UiConfig.WebUi.Variant.SmallScreenUi
         "bitmovin.playerui.UIFactory.buildDefaultTvUI" -> UiConfig.WebUi.Variant.TvUi
         else -> UiConfig.WebUi.Variant.Custom(uiManagerFactoryFunction)
     }

--- a/example/src/screens/BasicPlayback.tsx
+++ b/example/src/screens/BasicPlayback.tsx
@@ -6,6 +6,9 @@ import {
   usePlayer,
   PlayerView,
   SourceType,
+  TvUi,
+  SmallScreenUi,
+  PlayerViewConfig,
 } from 'bitmovin-player-react-native';
 import { useTVGestures } from '../hooks';
 
@@ -21,6 +24,12 @@ export default function BasicPlayback() {
       isCastEnabled: false,
     },
   });
+
+  const config: PlayerViewConfig = {
+    uiConfig: {
+      variant: Platform.isTV ? new TvUi() : new SmallScreenUi(),
+    },
+  };
 
   useFocusEffect(
     useCallback(() => {
@@ -56,6 +65,7 @@ export default function BasicPlayback() {
       <PlayerView
         player={player}
         style={styles.player}
+        config={config}
         onPlay={onEvent}
         onPlaying={onEvent}
         onPaused={onEvent}

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -1239,9 +1239,13 @@ extension RCTConvert {
         guard let json = json as? [String: Any?] else {
             return nil
         }
+        let variant = json["variant"] as? [String: Any?]
+        let uiManagerFactoryFunction = variant?["uiManagerFactoryFunction"] as? String
+        let defaultUiManagerFactoryFunction = "bitmovin.playerui.UIFactory.buildDefaultSmallScreenUI"
 
         return RNUiConfig(
-            playbackSpeedSelectionEnabled: json["playbackSpeedSelectionEnabled"] as? Bool ?? true
+            playbackSpeedSelectionEnabled: json["playbackSpeedSelectionEnabled"] as? Bool ?? true,
+            uiManagerFactoryFunction: uiManagerFactoryFunction ?? defaultUiManagerFactoryFunction
         )
     }
 
@@ -1369,6 +1373,7 @@ internal struct RNPlayerViewConfig {
  */
 internal struct RNUiConfig {
     let playbackSpeedSelectionEnabled: Bool
+    let uiManagerFactoryFunction: String
 }
 
 /**

--- a/ios/RNPlayerViewManager.swift
+++ b/ios/RNPlayerViewManager.swift
@@ -74,6 +74,7 @@ public class RNPlayerViewManager: RCTViewManager {
             if let uiConfig = playerViewConfig?.uiConfig {
                 bitmovinUserInterfaceConfig
                     .playbackSpeedSelectionEnabled = uiConfig.playbackSpeedSelectionEnabled
+                bitmovinUserInterfaceConfig.uiManagerFactoryFunction = uiConfig.uiManagerFactoryFunction
             }
             if let hideFirstFrame = playerViewConfig?.hideFirstFrame {
                 bitmovinUserInterfaceConfig.hideFirstFrame = hideFirstFrame

--- a/src/components/PlayerView/playerViewConfig.ts
+++ b/src/components/PlayerView/playerViewConfig.ts
@@ -45,6 +45,8 @@ export interface WebUiConfig extends UiConfig {
   playbackSpeedSelectionEnabled?: boolean;
   /**
    * The Ui variant to use for the Bitmovin Player Web UI.
+   *
+   * Default is {@link SmallScreenUi}
    */
   variant?: SmallScreenUi | TvUi | CustomUi;
   /**
@@ -67,10 +69,10 @@ export abstract class Variant {
    * the `UIConfig` as the second argument.
    *
    * Example:
-   * When you added a new function or want to use a different function of our
-   * [`UIFactory`](https://github.com/bitmovin/bitmovin-player-ui/blob/develop/src/ts/uifactory.ts#L60),
+   * When you added a new function or want to use a different function of our `UIFactory`,
    * you can specify the full qualifier name including namespaces.
-   * e.g. `bitmovin.playerui.UIFactory.buildDefaultSmallScreenUI` for the SmallScreenUi
+   * e.g. `bitmovin.playerui.UIFactory.buildDefaultSmallScreenUI` for the SmallScreenUi.
+   * @see UIFactory https://github.com/bitmovin/bitmovin-player-ui/blob/develop/src/ts/uifactory.ts#L60
    *
    * Notes:
    * - It's not necessary to use our `UIFactory`. Any static function can be specified.

--- a/src/components/PlayerView/playerViewConfig.ts
+++ b/src/components/PlayerView/playerViewConfig.ts
@@ -44,7 +44,7 @@ export interface WebUiConfig extends UiConfig {
    */
   playbackSpeedSelectionEnabled?: boolean;
   /**
-   * The Ui variant to use for the Bitmovin Player Web UI.
+   * The UI variant to use for the Bitmovin Player Web UI.
    *
    * Default is {@link SmallScreenUi}
    */

--- a/src/components/PlayerView/playerViewConfig.ts
+++ b/src/components/PlayerView/playerViewConfig.ts
@@ -43,4 +43,55 @@ export interface WebUiConfig extends UiConfig {
    * Default is `true`.
    */
   playbackSpeedSelectionEnabled?: boolean;
+  /**
+   * The Ui variant to use for the Bitmovin Player Web UI.
+   */
+  variant?: SmallScreenUi | TvUi | CustomUi;
+  /**
+   * Whether the WebView should be focused on initialization.
+   *
+   * By default this is enabled only for the TV UI variant, as it's needed there to
+   * initiate spatial navigation using the remote control.
+   *
+   * @platform Android
+   */
+  focusUiOnInitialization?: boolean;
+}
+
+export abstract class Variant {
+  /**
+   * Specifies the function name that will be used to initialize the `UIManager`
+   * for the Bitmovin Player Web UI.
+   *
+   * The function is called on the `window` object with the `Player` as the first argument and
+   * the `UIConfig` as the second argument.
+   *
+   * Example:
+   * When you added a new function or want to use a different function of our
+   * [`UIFactory`](https://github.com/bitmovin/bitmovin-player-ui/blob/develop/src/ts/uifactory.ts#L60),
+   * you can specify the full qualifier name including namespaces.
+   * e.g. `bitmovin.playerui.UIFactory.buildDefaultSmallScreenUI` for the SmallScreenUi
+   *
+   * Notes:
+   * - It's not necessary to use our `UIFactory`. Any static function can be specified.
+   */
+  constructor(public readonly uiManagerFactoryFunction: string) {}
+}
+
+export class SmallScreenUi extends Variant {
+  constructor() {
+    super('bitmovin.playerui.UIFactory.buildDefaultSmallScreenUI');
+  }
+}
+
+export class TvUi extends Variant {
+  constructor() {
+    super('bitmovin.playerui.UIFactory.buildDefaultTvUI');
+  }
+}
+
+export class CustomUi extends Variant {
+  constructor(uiManagerFactoryFunction: string) {
+    super(uiManagerFactoryFunction);
+  }
 }

--- a/src/components/PlayerView/playerViewConfig.ts
+++ b/src/components/PlayerView/playerViewConfig.ts
@@ -48,7 +48,7 @@ export interface WebUiConfig extends UiConfig {
    *
    * Default is {@link SmallScreenUi}
    */
-  variant?: SmallScreenUi | TvUi | CustomUi;
+  variant?: Variant;
   /**
    * Whether the WebView should be focused on initialization.
    *


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
Native SDKs support defining `uiManagerFactoryFunction` via: 
- Android: https://cdn.bitmovin.com/player/android/3/docs/player-ui-web/com.bitmovin.player.api.ui/-ui-config/-web-ui/-variant/index.html
- iOS: https://cdn.bitmovin.com/player/ios/3/docs/Classes/BitmovinUserInterfaceConfig.html#/:~:text=uiManagerFactoryFunction

On Android this is an important use case, since the default small screen UI doesn't support TV spatial navigation out of the box.

_For the public API in this PR I tried to keep it close to what we have on Android._

Right now the sample is integrated in the basic playback sample, meaning that other samples won't have the TV spatial navigation enabled by default. I'm a bit unsure if we should just add it to all the samples, as I would assume this should be enough.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
- Update Android Bitmovin player to 3.90.0
- Sample: https://github.com/bitmovin/bitmovin-player-react-native/pull/546/commits/9a526c8949672d2cbcd2fa75def2fca450c25379

## Checklist
- [x] 🗒 `CHANGELOG` entry
