### PR TITLE
Add Basic TV playback sample

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -65,6 +65,7 @@ export type RootStackParamsList = {
 const RootStack = createNativeStackNavigator<RootStackParamsList>();
 
 const isTVOS = Platform.OS === 'ios' && Platform.isTV;
+const isAndroidTV = Platform.OS === 'android' && Platform.isTV;
 
 export default function App() {
   useEffect(() => {
@@ -86,10 +87,6 @@ export default function App() {
       {
         title: 'Basic playback',
         routeName: 'BasicPlayback' as keyof RootStackParamsList,
-      },
-      {
-        title: 'Basic TV playback',
-        routeName: 'BasicTvPlayback' as keyof RootStackParamsList,
       },
       {
         title: 'Basic Analytics',
@@ -117,6 +114,13 @@ export default function App() {
       },
     ],
   };
+
+  if (isAndroidTV) {
+    stackParams.data.unshift({
+      title: 'Basic TV playback',
+      routeName: 'BasicTvPlayback',
+    });
+  }
 
   if (!isTVOS) {
     stackParams.data.push({
@@ -192,7 +196,7 @@ export default function App() {
           component={BasicPlayback}
           options={{ title: 'Basic playback' }}
         />
-        {Platform.OS === 'android' && Platform.isTV && (
+        {isAndroidTV && (
           <RootStack.Screen
             name="BasicTvPlayback"
             component={BasicTvPlayback}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -8,6 +8,7 @@ import ExamplesList from './screens/ExamplesList';
 import BasicAds from './screens/BasicAds';
 import BasicAnalytics from './screens/BasicAnalytics';
 import BasicPlayback from './screens/BasicPlayback';
+import BasicTvPlayback from './screens/BasicTvPlayback';
 import BasicDrmPlayback from './screens/BasicDrmPlayback';
 import SubtitlePlayback from './screens/SubtitlePlayback';
 import ProgrammaticTrackSelection from './screens/ProgrammaticTrackSelection';
@@ -31,6 +32,7 @@ export type RootStackParamsList = {
   BasicAds: undefined;
   BasicAnalytics: undefined;
   BasicPlayback: undefined;
+  BasicTvPlayback: undefined;
   BasicDrmPlayback: undefined;
   BasicPictureInPicture: {
     navigation: NativeStackNavigationProp<RootStackParamsList>;
@@ -84,6 +86,10 @@ export default function App() {
       {
         title: 'Basic playback',
         routeName: 'BasicPlayback' as keyof RootStackParamsList,
+      },
+      {
+        title: 'Basic TV playback',
+        routeName: 'BasicTvPlayback' as keyof RootStackParamsList,
       },
       {
         title: 'Basic Analytics',
@@ -185,6 +191,11 @@ export default function App() {
           name="BasicPlayback"
           component={BasicPlayback}
           options={{ title: 'Basic playback' }}
+        />
+        <RootStack.Screen
+          name="BasicTvPlayback"
+          component={BasicTvPlayback}
+          options={{ title: 'Basic TV playback' }}
         />
         <RootStack.Screen
           name="BasicDrmPlayback"

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -192,11 +192,13 @@ export default function App() {
           component={BasicPlayback}
           options={{ title: 'Basic playback' }}
         />
-        <RootStack.Screen
-          name="BasicTvPlayback"
-          component={BasicTvPlayback}
-          options={{ title: 'Basic TV playback' }}
-        />
+        {Platform.OS === 'android' && Platform.isTV && (
+          <RootStack.Screen
+            name="BasicTvPlayback"
+            component={BasicTvPlayback}
+            options={{ title: 'Basic TV playback' }}
+          />
+        )}
         <RootStack.Screen
           name="BasicDrmPlayback"
           component={BasicDrmPlayback}

--- a/example/src/screens/BasicTvPlayback.tsx
+++ b/example/src/screens/BasicTvPlayback.tsx
@@ -6,6 +6,8 @@ import {
   usePlayer,
   PlayerView,
   SourceType,
+  PlayerViewConfig,
+  TvUi,
 } from 'bitmovin-player-react-native';
 import { useTVGestures } from '../hooks';
 
@@ -13,7 +15,7 @@ function prettyPrint(header: string, obj: any) {
   console.log(header, JSON.stringify(obj, null, 2));
 }
 
-export default function BasicPlayback() {
+export default function BasicTvPlayback() {
   useTVGestures();
 
   const player = usePlayer({
@@ -21,6 +23,13 @@ export default function BasicPlayback() {
       isCastEnabled: false,
     },
   });
+
+  const config: PlayerViewConfig = {
+    uiConfig: {
+      // This is only applied for Android TVs, as on TvOS only the system UI is supported.
+      variant: new TvUi(),
+    },
+  };
 
   useFocusEffect(
     useCallback(() => {
@@ -56,6 +65,7 @@ export default function BasicPlayback() {
       <PlayerView
         player={player}
         style={styles.player}
+        config={config}
         onPlay={onEvent}
         onPlaying={onEvent}
         onPaused={onEvent}

--- a/integration_test/ios/Podfile.lock
+++ b/integration_test/ios/Podfile.lock
@@ -1219,11 +1219,11 @@ SPEC CHECKSUMS:
   BitmovinPlayer: 65866e13f7a8246ccbc7378607d6ca789f0f459e
   BitmovinPlayerCore: 7151c7836f0e0c906a17c897576d3bd892b51b4a
   boost: 88202336c3ba1e7a264a83c0c888784b0f360c28
-  DoubleConversion: 74cb0ce4de271b23e772567504735c87134edf0a
+  DoubleConversion: 234abba95e31cc2aada0cf3b97cdb11bc5b90575
   FBLazyVector: 33a271a7e8de0bd321e47356d8bc3b2d5fb9ddba
   FBReactNativeSpec: 55b7e93b71f300a051190f63c2afeccd839b7e9a
   fmt: 745abaaffe4da13101ae15d70dc68ec3d6a666a2
-  glog: f0ddebfc00a905e9213e37801095a0a705d2e5f6
+  glog: a2ded9bf28f0cb2fce90ad21eb419299a500ff6c
   GoogleAds-IMA-iOS-SDK: ee2a68ed7a1a17c7bb81bdb1b81590b35a3fc8f3
   hermes-engine: e7981489a718dff7c3a2dacd6302b8761375928d
   libevent: a6d75fcd7be07cbc5070300ea8dbc8d55dfab88e


### PR DESCRIPTION
## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
- Add TV sample showcasing how to set up the TV UI
- Remove the previous auto TV UI in BasicPlayback sample

I placed the TV sample as the second item so that it's easily noticeable 
<img width="370" alt="image" src="https://github.com/user-attachments/assets/e8c6b7a8-6857-4b5b-8c0e-5ccfdba63c50">

The sample will also render the TvUI on phones: 
<img width="367" alt="image" src="https://github.com/user-attachments/assets/b84f2235-bf01-494c-9b21-41b15b04a468">


## Checklist
- [ ] 🗒 `CHANGELOG` entry
