### PR TITLE
Use concurrent hash map to avoid potential infinite stall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Potential infinite stall when using `NetworkConfig.preprocessHttpRequest` and `NetworkConfig.preprocessHttpResponse` on Android
+
 ## [0.31.0] - 2024-11-07
 
 ### Added


### PR DESCRIPTION
## Description
An infinite stall was reported when playing back DRM content with `preprocessHttpRequest` network config configured.
`preprocessHttpRequest` is an API that is being called on multiple threads and hence must be treated in a thread safe way. However, the map used for the in-flight preprocessing is NOT thread safe and hence could cause infinite blocking preprocessing calls.

## Changes
- Use concurrent hash map to avoid infinite stalls
- Add error log in case a completer can not be found as this should never happen

## Checklist
- [x] 🗒 `CHANGELOG` entry
