### PR TITLE
Null safe check if `isBackgroundPlaybackEnabled` property is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Error where setting `PlaybackConfig.isAutoplayEnabled = true` causes the player view creation to fail on Android
+
 ## [0.31.0] - 2024-11-07
 
 ### Added

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewManager.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewManager.kt
@@ -248,7 +248,7 @@ class RNPlayerViewManager(private val context: ReactApplicationContext) : Simple
             val playbackConfig = playerConfig?.getMap("playbackConfig")
             val isPictureInPictureEnabled = view.config?.pictureInPictureConfig?.isEnabled == true ||
                 playbackConfig?.getBooleanOrNull("isPictureInPictureEnabled") == true
-            view.enableBackgroundPlayback = playbackConfig?.getBoolean("isBackgroundPlaybackEnabled") ?: false
+            view.enableBackgroundPlayback = playbackConfig?.getBooleanOrNull("isBackgroundPlaybackEnabled") == true
 
             val rnStyleConfigWrapper = playerConfig?.toRNStyleConfigWrapperFromPlayerConfig()
             val configuredPlayerViewConfig = view.config?.playerViewConfig ?: PlayerViewConfig()


### PR DESCRIPTION
## Description
`isBackgroundPlaybackEnabled` was checked in an unsafe way which caused attaching a player to a view to crash if  `isBackgroundPlaybackEnabled` was not set.

## Changes
- make `isBackgroundPlaybackEnabled` check null safe

## Checklist
- [x] 🗒 `CHANGELOG` entry
