### PR TITLE
Expose `TweaksConfig.forceReuseVideoCodecReasons` from Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- exposed `TweaksConfig.forceReuseVideoCodecReasons`
+
 ### Fixed
 
 - Error where setting `PlaybackConfig.isAutoplayEnabled = true` causes the player view creation to fail on Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- exposed `TweaksConfig.forceReuseVideoCodecReasons`
+- Android: `TweaksConfig.forceReuseVideoCodecReasons` that allows to force the reuse of the video codec despite a configuration change. This flag should be set only, if it is known that the codec can handle the given configuration change
 
 ### Changed
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -6,6 +6,7 @@ import com.bitmovin.analytics.api.CustomData
 import com.bitmovin.analytics.api.DefaultMetadata
 import com.bitmovin.analytics.api.SourceMetadata
 import com.bitmovin.player.api.DeviceDescription.DeviceName
+import com.bitmovin.player.api.ForceReuseVideoCodecReason
 import com.bitmovin.player.api.PlaybackConfig
 import com.bitmovin.player.api.PlayerConfig
 import com.bitmovin.player.api.TweaksConfig
@@ -168,6 +169,16 @@ fun ReadableMap.toStyleConfig(): StyleConfig = StyleConfig().apply {
 }
 
 /**
+ * Converts any JS string into an `AdSourceType` enum value.
+ */
+private fun String.forceReuseVideoCodecReason(): ForceReuseVideoCodecReason? = when (this) {
+    "ColorInfoMismatch" -> ForceReuseVideoCodecReason.ColorInfoMismatch
+    "MaxInputSizeExceeded" -> ForceReuseVideoCodecReason.MaxInputSizeExceeded
+    "MaxResolutionExceeded" -> ForceReuseVideoCodecReason.MaxResolutionExceeded
+    else -> null
+}
+
+/**
  * Converts any JS object into a `TweaksConfig` object.
  */
 fun ReadableMap.toTweaksConfig(): TweaksConfig = TweaksConfig().apply {
@@ -189,6 +200,16 @@ fun ReadableMap.toTweaksConfig(): TweaksConfig = TweaksConfig().apply {
     withBoolean("useDrmSessionForClearSources") { useDrmSessionForClearSources = it }
     withBoolean("useFiletypeExtractorFallbackForHls") { useFiletypeExtractorFallbackForHls = it }
     withBoolean("preferSoftwareDecodingForAds") { preferSoftwareDecodingForAds = it }
+    withStringArray("forceReuseVideoCodecReasons") {
+        val mutableSet = mutableSetOf<ForceReuseVideoCodecReason>()
+        for (item in it) {
+            val reason = item?.forceReuseVideoCodecReason()
+            if (reason != null) {
+                mutableSet.add(reason)
+            }
+        }
+        forceReuseVideoCodecReasons = mutableSet
+    }
 }
 
 /**

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -169,9 +169,9 @@ fun ReadableMap.toStyleConfig(): StyleConfig = StyleConfig().apply {
 }
 
 /**
- * Converts any JS string into an `AdSourceType` enum value.
+ * Converts any JS string into an `ForceReuseVideoCodecReason` enum value.
  */
-private fun String.forceReuseVideoCodecReason(): ForceReuseVideoCodecReason? = when (this) {
+private fun String.toForceReuseVideoCodecReason(): ForceReuseVideoCodecReason? = when (this) {
     "ColorInfoMismatch" -> ForceReuseVideoCodecReason.ColorInfoMismatch
     "MaxInputSizeExceeded" -> ForceReuseVideoCodecReason.MaxInputSizeExceeded
     "MaxResolutionExceeded" -> ForceReuseVideoCodecReason.MaxResolutionExceeded
@@ -201,14 +201,10 @@ fun ReadableMap.toTweaksConfig(): TweaksConfig = TweaksConfig().apply {
     withBoolean("useFiletypeExtractorFallbackForHls") { useFiletypeExtractorFallbackForHls = it }
     withBoolean("preferSoftwareDecodingForAds") { preferSoftwareDecodingForAds = it }
     withStringArray("forceReuseVideoCodecReasons") {
-        val mutableSet = mutableSetOf<ForceReuseVideoCodecReason>()
-        for (item in it) {
-            val reason = item?.forceReuseVideoCodecReason()
-            if (reason != null) {
-                mutableSet.add(reason)
-            }
-        }
-        forceReuseVideoCodecReasons = mutableSet
+        forceReuseVideoCodecReasons = it
+            .filterNotNull()
+            .mapNotNull(String::toForceReuseVideoCodecReason)
+            .toSet()
     }
 }
 

--- a/src/tweaksConfig.ts
+++ b/src/tweaksConfig.ts
@@ -193,7 +193,7 @@ export interface TweaksConfig {
    * When switching between video formats (eg: adapting between video qualities) the codec might be recreated due to several reasons.
    * This behaviour can cause brief black screens when switching between video qualities as codec recreation can be slow.
    *
-   * Default is `[]` i.e not set
+   * Default is `null` i.e not set
    *
    * @platform Android
    */

--- a/src/tweaksConfig.ts
+++ b/src/tweaksConfig.ts
@@ -1,5 +1,11 @@
 /**
- * The different reasons when the video codec should be reused.
+ * When switching the video quality, the video decoder's configuration might change
+ * as the player can't always know if the codec supports such configuration change, it destroys and recreates it.
+ * This behaviour can cause brief black screens when switching between video qualities as codec recreation can be slow.
+ *
+ * If a codec is know to support a given configuration change without issues,
+ * the configuration can be added to the `TweaksConfig.forceReuseVideoCodecReasons`
+ * to always reuse the video codec and avoid the black screen.
  */
 export enum ForceReuseVideoCodecReason {
   /**
@@ -190,8 +196,13 @@ export interface TweaksConfig {
   updatesNowPlayingInfoCenter?: boolean;
 
   /**
-   * When switching between video formats (eg: adapting between video qualities) the codec might be recreated due to several reasons.
-   * This behaviour can cause brief black screens when switching between video qualities as codec recreation can be slow.
+   * When switching between video formats (eg: adapting between video qualities)
+   * the codec might be recreated due to several reasons.
+   * This behaviour can cause brief black screens when switching between video qualities as codec recreation can be
+   * slow.
+   *
+   * If a device is know to support video format changes and keep the current decoder without issues,
+   * this set can be filled with multiple `ForceReuseVideoCodecReason` and avoid the black screen.
    *
    * Default is `null` i.e not set
    *

--- a/src/tweaksConfig.ts
+++ b/src/tweaksConfig.ts
@@ -1,4 +1,22 @@
 /**
+ * The different reasons when the video codec should be reused.
+ */
+export enum ForceReuseVideoCodecReason {
+  /**
+   * The new video quality color information is not compatible.
+   */
+  ColorInfoMismatch = 'ColorInfoMismatch',
+  /**
+   * The new video quality exceed the decoder's configured maximum sample size.
+   */
+  MaxInputSizeExceeded = 'MaxInputSizeExceeded',
+  /**
+   * The new video quality exceed the decoder's configured maximum resolution.
+   */
+  MaxResolutionExceeded = 'MaxResolutionExceeded',
+}
+
+/**
  * This configuration is used as an incubator for experimental features. Tweaks are not officially
  * supported and are not guaranteed to be stable, i.e. their naming, functionality and API can
  * change at any time within the tweaks or when being promoted to an official feature and moved
@@ -170,4 +188,14 @@ export interface TweaksConfig {
    * @platform iOS
    */
   updatesNowPlayingInfoCenter?: boolean;
+
+  /**
+   * When switching between video formats (eg: adapting between video qualities) the codec might be recreated due to several reasons.
+   * This behaviour can cause brief black screens when switching between video qualities as codec recreation can be slow.
+   *
+   * Default is `[]` i.e not set
+   *
+   * @platform Android
+   */
+  forceReuseVideoCodecReasons?: Array<ForceReuseVideoCodecReason>;
 }


### PR DESCRIPTION
## Description
Expose Android SDKs TweaksConfig.forceReuseVideoCodecReasons
## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->

## Checklist
- [x] 🗒 `CHANGELOG` entry
