### PR TITLE
Add missing version replacement command for mediasession module

### DIFF
--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -82,6 +82,7 @@ jobs:
         if: ${{ inputs.sdk_name == 'android' }}
         run: |
           sed -i '' "s/com.bitmovin.player:player:.*/com.bitmovin.player:player:${{ inputs.version_number }}'/g" android/build.gradle
+          sed -i '' "s/com.bitmovin.player:player-media-session:.*/com.bitmovin.player:player-media-session:${{ inputs.version_number }}'/g" android/build.gradle
 
       - name: Commit version bump
         run: |


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->

The SDK update task does not update the new mediasession module

## Checklist
- [x] 🗒 `CHANGELOG` entry `no need since it is internal`
