### PR TITLE
Replace Akamai CDN URLs with Bitmovin CDN URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,7 @@ export default (spec: TestScope) => {
     spec.it('emits TimeChanged events', async () => {
       await startPlayerTest({}, async () => {
         await loadSourceConfig({
-          url: 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+          url: 'https://cdn.bitmovin.com/content/assets/MI201109210084/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
           type: SourceType.HLS,
         });
         await callPlayerAndExpectEvents((player) => {

--- a/example/src/screens/BackgroundPlayback.tsx
+++ b/example/src/screens/BackgroundPlayback.tsx
@@ -33,12 +33,12 @@ export default function BackgroundPlayback() {
       player.load({
         url:
           Platform.OS === 'ios'
-            ? 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
-            : 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+            ? 'https://cdn.bitmovin.com/content/assets/MI201109210084/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
+            : 'https://cdn.bitmovin.com/content/assets/MI201109210084/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
         type: Platform.OS === 'ios' ? SourceType.HLS : SourceType.DASH,
         title: 'Art of Motion',
         poster:
-          'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/poster.jpg',
+          'https://cdn.bitmovin.com/content/assets/MI201109210084/poster.jpg',
         thumbnailTrack:
           'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/thumbnails/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.vtt',
         metadata: { platform: Platform.OS },

--- a/example/src/screens/BasicAds.tsx
+++ b/example/src/screens/BasicAds.tsx
@@ -73,12 +73,12 @@ export default function BasicAds() {
       player.load({
         url:
           Platform.OS === 'ios'
-            ? 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
-            : 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+            ? 'https://cdn.bitmovin.com/content/assets/MI201109210084/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
+            : 'https://cdn.bitmovin.com/content/assets/MI201109210084/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
         type: Platform.OS === 'ios' ? SourceType.HLS : SourceType.DASH,
         title: 'Art of Motion',
         poster:
-          'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/poster.jpg',
+          'https://cdn.bitmovin.com/content/assets/MI201109210084/poster.jpg',
       });
       return () => {
         player.destroy();

--- a/example/src/screens/BasicAnalytics.tsx
+++ b/example/src/screens/BasicAnalytics.tsx
@@ -37,12 +37,12 @@ export default function BasicAnalytics() {
       player.load({
         url:
           Platform.OS === 'ios'
-            ? 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
-            : 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+            ? 'https://cdn.bitmovin.com/content/assets/MI201109210084/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
+            : 'https://cdn.bitmovin.com/content/assets/MI201109210084/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
         type: Platform.OS === 'ios' ? SourceType.HLS : SourceType.DASH,
         title: 'Art of Motion',
         poster:
-          'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/poster.jpg',
+          'https://cdn.bitmovin.com/content/assets/MI201109210084/poster.jpg',
         analyticsSourceMetadata: {
           videoId: 'MyVideoId',
           title: 'Art of Motion',

--- a/example/src/screens/BasicDrmPlayback.tsx
+++ b/example/src/screens/BasicDrmPlayback.tsx
@@ -18,7 +18,7 @@ const source: SourceConfig = {
   url:
     Platform.OS === 'ios'
       ? 'https://fps.ezdrm.com/demo/video/ezdrm.m3u8'
-      : 'https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/mpds/11331.mpd',
+      : 'https://cdn.bitmovin.com/content/assets/art-of-motion_drm/mpds/11331.mpd',
   type: Platform.OS === 'ios' ? SourceType.HLS : SourceType.DASH,
   drmConfig: {
     // Android only.

--- a/example/src/screens/BasicFullscreenHandling.tsx
+++ b/example/src/screens/BasicFullscreenHandling.tsx
@@ -101,12 +101,12 @@ export default function BasicFullscreenHandling({
       player.load({
         url:
           Platform.OS === 'ios'
-            ? 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
-            : 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+            ? 'https://cdn.bitmovin.com/content/assets/MI201109210084/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
+            : 'https://cdn.bitmovin.com/content/assets/MI201109210084/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
         type: Platform.OS === 'ios' ? SourceType.HLS : SourceType.DASH,
         title: 'Art of Motion',
         poster:
-          'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/poster.jpg',
+          'https://cdn.bitmovin.com/content/assets/MI201109210084/poster.jpg',
       });
       return () => {
         player.destroy();

--- a/example/src/screens/BasicPictureInPicture.tsx
+++ b/example/src/screens/BasicPictureInPicture.tsx
@@ -54,12 +54,12 @@ export default function BasicPictureInPicture({
       player.load({
         url:
           Platform.OS === 'ios'
-            ? 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
-            : 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+            ? 'https://cdn.bitmovin.com/content/assets/MI201109210084/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
+            : 'https://cdn.bitmovin.com/content/assets/MI201109210084/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
         type: Platform.OS === 'ios' ? SourceType.HLS : SourceType.DASH,
         title: 'Art of Motion',
         poster:
-          'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/poster.jpg',
+          'https://cdn.bitmovin.com/content/assets/MI201109210084/poster.jpg',
       });
       return () => {
         player.destroy();

--- a/example/src/screens/BasicPlayback.tsx
+++ b/example/src/screens/BasicPlayback.tsx
@@ -27,12 +27,12 @@ export default function BasicPlayback() {
       player.load({
         url:
           Platform.OS === 'ios'
-            ? 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
-            : 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+            ? 'https://cdn.bitmovin.com/content/assets/MI201109210084/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
+            : 'https://cdn.bitmovin.com/content/assets/MI201109210084/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
         type: Platform.OS === 'ios' ? SourceType.HLS : SourceType.DASH,
         title: 'Art of Motion',
         poster:
-          'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/poster.jpg',
+          'https://cdn.bitmovin.com/content/assets/MI201109210084/poster.jpg',
         thumbnailTrack:
           'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/thumbnails/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.vtt',
         metadata: { platform: Platform.OS },

--- a/example/src/screens/BasicTvPlayback.tsx
+++ b/example/src/screens/BasicTvPlayback.tsx
@@ -36,12 +36,12 @@ export default function BasicTvPlayback() {
       player.load({
         url:
           Platform.OS === 'ios'
-            ? 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
-            : 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+            ? 'https://cdn.bitmovin.com/content/assets/MI201109210084/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
+            : 'https://cdn.bitmovin.com/content/assets/MI201109210084/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
         type: Platform.OS === 'ios' ? SourceType.HLS : SourceType.DASH,
         title: 'Art of Motion',
         poster:
-          'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/poster.jpg',
+          'https://cdn.bitmovin.com/content/assets/MI201109210084/poster.jpg',
         thumbnailTrack:
           'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/thumbnails/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.vtt',
         metadata: { platform: Platform.OS },

--- a/example/src/screens/Casting.tsx
+++ b/example/src/screens/Casting.tsx
@@ -29,12 +29,12 @@ export default function Casting() {
       const source = new Source({
         url:
           Platform.OS === 'ios'
-            ? 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
-            : 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+            ? 'https://cdn.bitmovin.com/content/assets/MI201109210084/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
+            : 'https://cdn.bitmovin.com/content/assets/MI201109210084/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
         type: Platform.OS === 'ios' ? SourceType.HLS : SourceType.DASH,
         title: 'Art of Motion',
         poster:
-          'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/poster.jpg',
+          'https://cdn.bitmovin.com/content/assets/MI201109210084/poster.jpg',
         thumbnailTrack:
           'https://cdn.bitmovin.com/content/assets/art-of-motion-dash-hls-progressive/thumbnails/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.vtt',
         metadata: { platform: Platform.OS },
@@ -43,7 +43,7 @@ export default function Casting() {
       // Configure playing DASH source on Chromecast, even when casting from iOS.
       source.remoteControl = {
         castSourceConfig: {
-          url: 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+          url: 'https://cdn.bitmovin.com/content/assets/MI201109210084/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
           type: SourceType.DASH,
           title: 'Art of Motion',
         },

--- a/example/src/screens/CustomHtmlUi.tsx
+++ b/example/src/screens/CustomHtmlUi.tsx
@@ -65,12 +65,12 @@ export default function CustomHtmlUi({ navigation }: CustomHtmlUiProps) {
       player.load({
         url:
           Platform.OS === 'ios'
-            ? 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
-            : 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+            ? 'https://cdn.bitmovin.com/content/assets/MI201109210084/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
+            : 'https://cdn.bitmovin.com/content/assets/MI201109210084/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
         type: Platform.OS === 'ios' ? SourceType.HLS : SourceType.DASH,
         title: 'Art of Motion',
         poster:
-          'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/poster.jpg',
+          'https://cdn.bitmovin.com/content/assets/MI201109210084/poster.jpg',
       });
       return () => {
         player.destroy();

--- a/example/src/screens/LandscapeFullscreenHandling.tsx
+++ b/example/src/screens/LandscapeFullscreenHandling.tsx
@@ -108,12 +108,12 @@ export default function LandscapeFullscreenHandling({
       player.load({
         url:
           Platform.OS === 'ios'
-            ? 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
-            : 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+            ? 'https://cdn.bitmovin.com/content/assets/MI201109210084/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8'
+            : 'https://cdn.bitmovin.com/content/assets/MI201109210084/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
         type: Platform.OS === 'ios' ? SourceType.HLS : SourceType.DASH,
         title: 'Art of Motion',
         poster:
-          'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/poster.jpg',
+          'https://cdn.bitmovin.com/content/assets/MI201109210084/poster.jpg',
       });
       return () => {
         player.destroy();

--- a/example/src/screens/OfflinePlayback.tsx
+++ b/example/src/screens/OfflinePlayback.tsx
@@ -48,10 +48,10 @@ const initialDownloadRequest: OfflineDownloadRequest = {
 
 const STABLE_CONTENT_IDENTIFIER = 'sintel-content-id';
 const sourceConfig: SourceConfig = {
-  url: 'https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
+  url: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
   type: SourceType.HLS,
   title: 'Sintel',
-  poster: 'https://bitmovin-a.akamaihd.net/content/sintel/poster.png',
+  poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png',
 };
 
 export default function OfflinePlayback() {

--- a/example/src/screens/ProgrammaticTrackSelection.tsx
+++ b/example/src/screens/ProgrammaticTrackSelection.tsx
@@ -46,10 +46,10 @@ export default function ProgrammaticTrackSelection() {
       player.load({
         url:
           Platform.OS === 'ios'
-            ? 'https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8'
-            : 'https://bitmovin-a.akamaihd.net/content/sintel/sintel.mpd',
+            ? 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8'
+            : 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
         type: Platform.OS === 'ios' ? SourceType.HLS : SourceType.DASH,
-        poster: 'https://bitmovin-a.akamaihd.net/content/sintel/poster.png',
+        poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png',
       });
       return () => {
         player.destroy();

--- a/example/src/screens/SubtitlePlayback.tsx
+++ b/example/src/screens/SubtitlePlayback.tsx
@@ -28,22 +28,22 @@ export default function SubtitlePlayback() {
       player.load({
         url:
           Platform.OS === 'ios'
-            ? 'https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8'
-            : 'https://bitmovin-a.akamaihd.net/content/sintel/sintel.mpd',
+            ? 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8'
+            : 'https://cdn.bitmovin.com/content/assets/sintel/sintel.mpd',
         type: Platform.OS === 'ios' ? SourceType.HLS : SourceType.DASH,
-        poster: 'https://bitmovin-a.akamaihd.net/content/sintel/poster.png',
+        poster: 'https://cdn.bitmovin.com/content/assets/sintel/poster.png',
         // External subtitle tracks to be added to the source.
         subtitleTracks: [
           // Add custom english subtitles. You can select 'Custom English (WebVTT)' in the subtitles menu.
           {
-            url: 'https://bitdash-a.akamaihd.net/content/sintel/subtitles/subtitles_en.vtt',
+            url: 'https://cdn.bitmovin.com/content/assets/sintel/subtitles/subtitles_en.vtt',
             label: 'Custom English (WebVTT)',
             language: 'en',
             format: SubtitleFormat.VTT,
           },
           // Add custom english subtitles. You can select 'Custom English (SRT)' in the subtitles menu.
           {
-            url: 'https://bitdash-a.akamaihd.net/content/sintel/subtitles/subtitles_en.srt',
+            url: 'https://cdn.bitmovin.com/content/assets/sintel/subtitles/subtitles_en.srt',
             label: 'Custom English (SRT)',
             language: 'en',
             format: SubtitleFormat.SRT,

--- a/example/src/screens/SystemUi.tsx
+++ b/example/src/screens/SystemUi.tsx
@@ -30,7 +30,7 @@ export default function SystemUI() {
   useFocusEffect(
     useCallback(() => {
       player.load({
-        url: 'https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
+        url: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
         type: SourceType.HLS,
         title: 'Sintel',
       });

--- a/integration_test/playertesting/PlayerTesting.ts
+++ b/integration_test/playertesting/PlayerTesting.ts
@@ -183,7 +183,7 @@ export const callPlayerAndExpectEvents = async (
  * @example
  * ```typescript
  * await loadSourceConfig({
- *   url: 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+ *   url: 'https://cdn.bitmovin.com/content/assets/MI201109210084/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
  *   type: SourceType.HLS,
  * });
  * ```

--- a/integration_test/tests/helper/Ads.ts
+++ b/integration_test/tests/helper/Ads.ts
@@ -15,6 +15,6 @@ export const AdTags = {
     'https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpost&cmsid=496&vid=short_onecue&correlator='
   ),
   progressive:
-    'https://bitmovin-a.akamaihd.net/content/testing/ads/testad2s.mp4',
+    'https://cdn.bitmovin.com/content/assets/testing/ads/testad2s.mp4',
   error: withCorrelator('https://mock.codes/404?correlator='),
 };

--- a/integration_test/tests/helper/Sources.ts
+++ b/integration_test/tests/helper/Sources.ts
@@ -2,12 +2,12 @@ import { SourceConfig, SourceType } from 'bitmovin-player-react-native';
 
 export const Sources = {
   artOfMotionHls: {
-    url: 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+    url: 'https://cdn.bitmovin.com/content/assets/MI201109210084/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
     type: SourceType.HLS,
   } as SourceConfig,
 
   artOfMotionDash: {
-    url: 'https://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
+    url: 'https://cdn.bitmovin.com/content/assets/MI201109210084/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd',
     type: SourceType.DASH,
   } as SourceConfig,
 
@@ -17,7 +17,7 @@ export const Sources = {
   } as SourceConfig,
 
   sintel: {
-    url: 'https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
+    url: 'https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8',
     type: SourceType.HLS,
   } as SourceConfig,
 };


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
We are moving away from Akamai CDN in favor of Bitmovin CDN.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Updated URLs to use the same assets from the Bitmovin CDN.

## Checklist
- [x] 🗒 `CHANGELOG` entry - not needed
