### PR TITLE
Fix UninitializedPropertyAccessException when destroying the Player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Android: App crashes when `mediaControlConfig.isEnabled` is set to `false` and the player gets destroyed
+
 ## [0.36.0] - 2024-12-20
 
 ### Changed

--- a/android/src/main/java/com/bitmovin/player/reactnative/MediaSessionPlaybackManager.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/MediaSessionPlaybackManager.kt
@@ -12,7 +12,7 @@ import com.facebook.react.bridge.*
 
 class MediaSessionPlaybackManager(val context: ReactApplicationContext) {
     private var serviceBinder: MediaSessionPlaybackService.ServiceBinder? = null
-    private lateinit var playerId: NativeId
+    private var playerId: NativeId? = null
     val player: Player?
         get() = serviceBinder?.player
 
@@ -24,7 +24,9 @@ class MediaSessionPlaybackManager(val context: ReactApplicationContext) {
         }
 
         override fun onServiceDisconnected(name: ComponentName) {
-            destroy(playerId)
+            playerId?.let {
+                destroy(it)
+            }
         }
     }
 
@@ -38,13 +40,16 @@ class MediaSessionPlaybackManager(val context: ReactApplicationContext) {
     }
 
     fun destroy(nativeId: NativeId) {
-        if (nativeId != playerId) { return }
+        if (nativeId != playerId) {
+            return
+        }
         serviceBinder?.player = null
         serviceBinder = null
     }
 
     private fun getPlayer(
-        nativeId: NativeId = playerId,
+        nativeId: NativeId? = playerId,
         playerModule: PlayerModule? = context.playerModule,
-    ): Player = playerModule?.getPlayerOrNull(nativeId) ?: throw IllegalArgumentException("Invalid PlayerId $nativeId")
+    ): Player = nativeId?.let { playerModule?.getPlayerOrNull(nativeId) }
+        ?: throw IllegalArgumentException("Invalid PlayerId $nativeId")
 }

--- a/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
@@ -97,9 +97,7 @@ class PlayerModule(context: ReactApplicationContext) : BitmovinBaseModule(contex
         }
 
         if (enableMediaSession) {
-            promise.unit.resolveOnUiThread {
-                mediaSessionPlaybackManager.setupMediaSessionPlayback(nativeId)
-            }
+            mediaSessionPlaybackManager.setupMediaSessionPlayback(nativeId)
         }
     }
 


### PR DESCRIPTION
## Description
When a player with the config `mediaControlConfig.isEnabled = false` is created and the player gets destroyed, it will throw an `UninitializedPropertyAccessException` while trying to destroy the `MediaSessionPlaybackManager`

## Changes
- Change `MediaSessionPlaybackManager.playerId` from `lateinit` to nullable.
- Remove unnecessary `resolveOnUiThread` call

## Checklist
- [x] 🗒 `CHANGELOG` entry
