### PR TITLE
Fix moved tweak config on Android

### DIFF
--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -19,6 +19,7 @@ import com.bitmovin.player.api.advertising.AdQuartile
 import com.bitmovin.player.api.advertising.AdSource
 import com.bitmovin.player.api.advertising.AdSourceType
 import com.bitmovin.player.api.advertising.AdvertisingConfig
+import com.bitmovin.player.api.BandwidthMeterType
 import com.bitmovin.player.api.buffer.BufferConfig
 import com.bitmovin.player.api.buffer.BufferLevel
 import com.bitmovin.player.api.buffer.BufferMediaTypeConfig
@@ -184,7 +185,11 @@ private fun String.toForceReuseVideoCodecReason(): ForceReuseVideoCodecReason? =
  */
 fun ReadableMap.toTweaksConfig(): TweaksConfig = TweaksConfig().apply {
     withDouble("timeChangedInterval") { timeChangedInterval = it }
-    withInt("bandwidthEstimateWeightLimit") { bandwidthEstimateWeightLimit = it }
+    withInt("bandwidthEstimateWeightLimit") {
+        bandwidthMeterType = BandwidthMeterType.Default(
+            bandwidthEstimateWeightLimit = it
+        )
+    }
     withMap("devicesThatRequireSurfaceWorkaround") { devices ->
         val deviceNames = devices.withStringArray("deviceNames") {
             it.filterNotNull().map(::DeviceName)

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -5,6 +5,7 @@ import com.bitmovin.analytics.api.AnalyticsConfig
 import com.bitmovin.analytics.api.CustomData
 import com.bitmovin.analytics.api.DefaultMetadata
 import com.bitmovin.analytics.api.SourceMetadata
+import com.bitmovin.player.api.BandwidthMeterType
 import com.bitmovin.player.api.DeviceDescription.DeviceName
 import com.bitmovin.player.api.ForceReuseVideoCodecReason
 import com.bitmovin.player.api.PlaybackConfig
@@ -19,7 +20,6 @@ import com.bitmovin.player.api.advertising.AdQuartile
 import com.bitmovin.player.api.advertising.AdSource
 import com.bitmovin.player.api.advertising.AdSourceType
 import com.bitmovin.player.api.advertising.AdvertisingConfig
-import com.bitmovin.player.api.BandwidthMeterType
 import com.bitmovin.player.api.buffer.BufferConfig
 import com.bitmovin.player.api.buffer.BufferLevel
 import com.bitmovin.player.api.buffer.BufferMediaTypeConfig
@@ -187,7 +187,7 @@ fun ReadableMap.toTweaksConfig(): TweaksConfig = TweaksConfig().apply {
     withDouble("timeChangedInterval") { timeChangedInterval = it }
     withInt("bandwidthEstimateWeightLimit") {
         bandwidthMeterType = BandwidthMeterType.Default(
-            bandwidthEstimateWeightLimit = it
+            bandwidthEstimateWeightLimit = it,
         )
     }
     withMap("devicesThatRequireSurfaceWorkaround") { devices ->


### PR DESCRIPTION
## Description
In version 3.100.0 a tweak was moved which was not yet reflected in the react native wrapper.

## Changes
- **Fix bandwidthEstimateWeightLimit moved on tweaks config**


## Checklist
- [x] 🗒 `CHANGELOG` entry (internal change only)
