### PR TITLE
PRN-164 - Add `CueEnterEvent.image` and `CueExitEvent.image`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `CueEnterEvent.imageUri` and `CueExitEvent.imageUri` to expose the Base64 encoded image data URI of the cue when available
+- `CueEnterEvent.image` and `CueExitEvent.image` to expose the Base64 encoded image data URI of the cue when available
 
 ## [0.38.0] - 2025-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+
+- `CueEnterEvent.imageUri` and `CueExitEvent.imageUri` to expose the Base64 encoded image data URI of the cue when available
 
 ## [0.38.0] - 2025-02-28
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -508,14 +508,14 @@ fun PlayerEvent.toJson(): WritableMap {
             json.putDouble("start", start)
             json.putDouble("end", end)
             json.putString("text", text)
-            json.putString("imageUri", image?.toBase64DataUri())
+            json.putString("image", image?.toBase64DataUri())
         }
 
         is PlayerEvent.CueExit -> {
             json.putDouble("start", start)
             json.putDouble("end", end)
             json.putString("text", text)
-            json.putString("imageUri", image?.toBase64DataUri())
+            json.putString("image", image?.toBase64DataUri())
         }
 
         else -> {

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -69,6 +69,7 @@ import com.bitmovin.player.reactnative.extensions.putBoolean
 import com.bitmovin.player.reactnative.extensions.putDouble
 import com.bitmovin.player.reactnative.extensions.putInt
 import com.bitmovin.player.reactnative.extensions.set
+import com.bitmovin.player.reactnative.extensions.toBase64DataUri
 import com.bitmovin.player.reactnative.extensions.toMap
 import com.bitmovin.player.reactnative.extensions.toMapList
 import com.bitmovin.player.reactnative.extensions.toReadableMap
@@ -507,12 +508,14 @@ fun PlayerEvent.toJson(): WritableMap {
             json.putDouble("start", start)
             json.putDouble("end", end)
             json.putString("text", text)
+            json.putString("imageUri", image?.toBase64DataUri())
         }
 
         is PlayerEvent.CueExit -> {
             json.putDouble("start", start)
             json.putDouble("end", end)
             json.putString("text", text)
+            json.putString("imageUri", image?.toBase64DataUri())
         }
 
         else -> {

--- a/android/src/main/java/com/bitmovin/player/reactnative/extensions/Bitmap.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/extensions/Bitmap.kt
@@ -8,4 +8,5 @@ fun Bitmap.toBase64DataUri(): String {
     val byteArrayOutputStream = ByteArrayOutputStream()
     this.compress(Bitmap.CompressFormat.PNG, 100, byteArrayOutputStream)
     val byteArray = byteArrayOutputStream.toByteArray()
-    return "data:image/png;base64," + Base64.encodeToString(byteArray, Base64.NO_WRAP)}
+    return "data:image/png;base64," + Base64.encodeToString(byteArray, Base64.NO_WRAP)
+}

--- a/android/src/main/java/com/bitmovin/player/reactnative/extensions/Bitmap.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/extensions/Bitmap.kt
@@ -1,0 +1,11 @@
+package com.bitmovin.player.reactnative.extensions
+
+import android.graphics.Bitmap
+import android.util.Base64
+import java.io.ByteArrayOutputStream
+
+fun Bitmap.toBase64DataUri(): String {
+    val byteArrayOutputStream = ByteArrayOutputStream()
+    this.compress(Bitmap.CompressFormat.PNG, 100, byteArrayOutputStream)
+    val byteArray = byteArrayOutputStream.toByteArray()
+    return "data:image/png;base64," + Base64.encodeToString(byteArray, Base64.NO_WRAP)}

--- a/ios/Event+JSON.swift
+++ b/ios/Event+JSON.swift
@@ -433,11 +433,15 @@ extension CueEnterEvent: JsonConvertible {
 extension CueExitEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
         toEventJSON {
-            [
+            var json: [AnyHashable: Any] = [
                 "start": startTime,
                 "end": endTime,
-                "text": text
+                "text": text,
             ]
+            if let imagePngData = image?.pngData() {
+                json["image"] = "data:image/png;base64,\(imagePngData.base64EncodedString())"
+            }
+            return json
         }
     }
 }

--- a/ios/Event+JSON.swift
+++ b/ios/Event+JSON.swift
@@ -417,11 +417,15 @@ extension PlaybackSpeedChangedEvent: JsonConvertible {
 extension CueEnterEvent: JsonConvertible {
     func toJSON() -> [AnyHashable: Any] {
         toEventJSON {
-            [
+            var json: [AnyHashable: Any] = [
                 "start": startTime,
                 "end": endTime,
-                "text": text
+                "text": text,
             ]
+            if let imagePngData = image?.pngData() {
+                json["imageUri"] = "data:image/png;base64,\(imagePngData.base64EncodedString())"
+            }
+            return json
         }
     }
 }

--- a/ios/Event+JSON.swift
+++ b/ios/Event+JSON.swift
@@ -423,7 +423,7 @@ extension CueEnterEvent: JsonConvertible {
                 "text": text,
             ]
             if let imagePngData = image?.pngData() {
-                json["imageUri"] = "data:image/png;base64,\(imagePngData.base64EncodedString())"
+                json["image"] = "data:image/png;base64,\(imagePngData.base64EncodedString())"
             }
             return json
         }

--- a/src/events.ts
+++ b/src/events.ts
@@ -736,7 +736,7 @@ export interface CueEnterEvent extends Event {
   /**
    * Data URI for image data of this subtitle.
    */
-  imageUri?: string;
+  image?: string;
 }
 
 /**

--- a/src/events.ts
+++ b/src/events.ts
@@ -733,6 +733,10 @@ export interface CueEnterEvent extends Event {
    * The textual content of this subtitle.
    */
   text?: string;
+  /**
+   * Data URI for image data of this subtitle.
+   */
+  imageUri?: string;
 }
 
 /**
@@ -751,4 +755,8 @@ export interface CueExitEvent extends Event {
    * The textual content of this subtitle.
    */
   text?: string;
+  /**
+   * Base64 encoded PNG image data for the subtitle.
+   */
+  image?: string;
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -756,7 +756,7 @@ export interface CueExitEvent extends Event {
    */
   text?: string;
   /**
-   * Base64 encoded PNG image data for the subtitle.
+   * Data URI for image data of this subtitle.
    */
   image?: string;
 }


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
We don't expose the image from the cues with subtitle related events.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Added support for exposing the `image` property from the native `CueEnterEvent` and `CueExitEvent`.

## Checklist
- [x] 🗒 `CHANGELOG` entry
