### PR TITLE
Refactor/readme update windows

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -31,6 +31,13 @@ cd bitmovin-player-react-native # Go to library's root directory
 yarn bootstrap # Install all dependencies
 ```
 
+Note: Windows users should instead run:
+```cmd
+cd bitmovin-player-react-native # Go to library's root directory
+yarn install # Install root project dependencies
+yarn example install # Install example folder dependencies
+```
+
 ## Configuring your license key
 
 Before running the application, make sure to set up your Bitmovin's license key in the native metadata file of each platform:

--- a/example/README.md
+++ b/example/README.md
@@ -31,8 +31,8 @@ cd bitmovin-player-react-native # Go to library's root directory
 yarn bootstrap # Install all dependencies
 ```
 
-Note: Windows users should instead run:
-```cmd
+Note that Windows users should instead run:
+```powershell
 cd bitmovin-player-react-native # Go to library's root directory
 yarn install # Install root project dependencies
 yarn example install # Install example folder dependencies


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
`yarn bootstrap` fails on Windows due to incompatible shell syntax with scripts:
```
...
    "pods": "yarn pods-install || yarn pods-update",
    "pods-install": "[ \"$(uname)\" != Darwin ] || NO_FLIPPER=1 yarn pod-install",
    "pods-update": "[ \"$(uname)\" != Darwin ] || cd ios && NO_FLIPPER=1 pod update --silent"
...
```
with error
```
$ [ "$(uname)" != Darwin ] || NO_FLIPPER=1 yarn pod-install
'[' is not recognized as an internal or external command,
operable program or batch file.
'NO_FLIPPER' is not recognized as an internal or external command,
operable program or batch file.
error Command failed with exit code 1.
```

<!-- Include any information that may help to review the PR -->

## Changes
<!-- Describe your changes as detailed as possible  -->
Workaround instructions to run the project even on Windows
<!-- Include any information that may help to review the PR -->

## Checklist
- [ ] 🗒 `CHANGELOG` entry -> Is it necessary?
