### PR TITLE
Align IMA dependency with Android player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Update IMA SDK dependency on Android to `3.35.1`
+
 ## [0.40.0] - 2025-03-20
 
 ### Changed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     implementation "androidx.concurrent:concurrent-futures-ktx:1.1.0"
 
     // Bitmovin
-    implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.33.0'
+    implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.35.1'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
     implementation 'com.bitmovin.player:player:3.104.2+jason'
     implementation 'com.bitmovin.player:player-media-session:3.104.2+jason'


### PR DESCRIPTION
## Description
The Android Player 3.104.2 uses IMA 3.35.1 but RN was still using an old version.

https://github.com/bitmovin-engineering/player-android/blob/3.104.2/gradle/libs.versions.toml#L9

## Changes
Update dependency

## Checklist
- [x] 🗒 `CHANGELOG` entry
