### PR TITLE
Upgrade react native screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Update react-native-screens to v3.35.0 for Android SDK version compatibility
+
 ### Added
 
 - Android: `DecoderConfig.decoderPriorityProvider`, a callback interface to specify which decoder implementation the Player should use to decode the media

--- a/example/package.json
+++ b/example/package.json
@@ -22,7 +22,7 @@
     "react-native-modal": "13.0.1",
     "react-native-orientation-locker": "1.6.0",
     "react-native-safe-area-context": "4.9.0",
-    "react-native-screens": "3.29.0",
+    "react-native-screens": "3.35.0",
     "react-native-system-navigation-bar": "^2.6.4"
   },
   "devDependencies": {

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3927,10 +3927,10 @@ react-native-safe-area-context@4.9.0:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.9.0.tgz#21a570ca3594cb4259ba65f93befaa60d91bcbd0"
   integrity sha512-/OJD9Pb8IURyvn+1tWTszWPJqsbZ4hyHBU9P0xhOmk7h5owSuqL0zkfagU0pg7Vh0G2NKQkaPpUKUMMCUMDh/w==
 
-react-native-screens@3.29.0:
-  version "3.29.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.29.0.tgz#1dee0326defbc1d4ef4e68287abb32a8e6b76b29"
-  integrity sha512-yB1GoAMamFAcYf4ku94uBPn0/ani9QG7NdI98beJ5cet2YFESYYzuEIuU+kt+CNRcO8qqKeugxlfgAa3HyTqlg==
+react-native-screens@3.35.0:
+  version "3.35.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.35.0.tgz#4acf4c7d331d47d33d0214d415779540b7664e0e"
+  integrity sha512-rmkqb/M/SQIrXwygk6pXcOhgHltYAhidf1WceO7ujAxkr6XtwmgFyd1HIztsrJa568GrAuwPdQ11I7TpVk+XsA==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
## Description
Potential crashes due to react-native-screens dependency incompatibility w/ Android SDK ref - https://stackoverflow.com/questions/79139467/react-native-android-java-lang-nosuchmethoderror-no-interface-method-removelas

## Changes
Upgrade react-native-screens to 3.35.0 which is compatible w/ Android 35
## Checklist
- [x] 🗒 `CHANGELOG` entry
