### PR TITLE
Fix null safety errors in React Native 0.77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Update Bitmovin's native Android SDK version to `3.117.0`
 - Update Bitmovin's native iOS SDK version to `3.93.0`
+- Add null safety checks to ReadableMap calls in JsonConverter.kt
 
 ## [0.43.0] - 2025-06-30
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -272,7 +272,7 @@ fun ReadableMap.toSourceConfig(): SourceConfig? {
         withBoolean("isPosterPersistent") { isPosterPersistent = it }
         withArray("subtitleTracks") { subtitleTracks ->
             for (i in 0 until subtitleTracks.size()) {
-                subtitleTracks.getMap(i).toSubtitleTrack()?.let {
+                subtitleTracks.getMap(i)?.toSubtitleTrack()?.let {
                     addSubtitleTrack(it)
                 }
             }
@@ -990,7 +990,7 @@ fun ReadableArray.toMediaCodecInfoList(): List<MediaCodecInfo> {
     }
     val mediaCodecInfoList = mutableListOf<MediaCodecInfo>()
     (0 until size()).forEach {
-        val info = getMap(it).toMediaCodecInfo() ?: return@forEach
+        val info = getMap(it)?.toMediaCodecInfo() ?: return@forEach
         mediaCodecInfoList.add(info)
     }
     return mediaCodecInfoList


### PR DESCRIPTION
React Native 0.77 compatibility fix

## Description
I work with Sinclair Broadcasting. We use Bitmovin's React Native Library in our news apps. I'm working on upgrading our apps from react-native 0.76 to 0.77 and doing so is causing errors trying to build for Android in the Bitmovin library. The errors say that only safe calls (?.) or non-null asserted (!!.) are allowed on ReadableMap. There are two places in JsonConverter.kt where `getMap` is called with no safety. This must've been allowed previously but now causes an error in 0.77. Editing the node_modules file directly to add ? to these calls fixes the build issue.

## Changes
Add null safety to getMap calls in JsonConverter.kt

## Checklist
- [ ] 🗒 `CHANGELOG` entry
