### PR TITLE
feat: optimize iOS/tvOS CI with aggressive caching strategy

### DIFF
--- a/.github/actions/setup-environment-no-prebuild/action.yml
+++ b/.github/actions/setup-environment-no-prebuild/action.yml
@@ -1,0 +1,59 @@
+name: Setup project environment (no prebuild)
+description: Setup the project environment without prebuild steps
+
+inputs:
+  node:
+    description: Setup node and install root node modules
+    default: false
+    required: false
+  brew:
+    description: Setup Homebrew
+    default: false
+    required: false
+  ios:
+    description: Setup xcode and install dependencies (overrides `brew` input)
+    default: false
+    required: false
+  java:
+    description: Setup Java and Gradle cache
+    default: false
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Java
+      if: ${{ inputs.java == 'true' }}
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'zulu'
+        java-version: '17'
+
+    - name: Set up Gradle cache
+      if: ${{ inputs.java == 'true' }}
+      uses: gradle/gradle-build-action@v2
+      with:
+        cache-read-only: ${{ github.ref != 'refs/heads/development' }}
+
+    - name: Setup node and npm registry
+      if: ${{ inputs.node == 'true' }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: '20'
+        registry-url: 'https://registry.npmjs.org/'
+        cache: 'yarn'
+
+    - name: Install node_modules
+      if: ${{ inputs.node == 'true' }}
+      shell: bash
+      run: yarn install --frozen-lockfile
+
+    - uses: maxim-lobanov/setup-xcode@v1
+      if: ${{ inputs.ios == 'true' }}
+      with:
+        xcode-version: '16.4'
+
+    - name: Install dependencies
+      if: ${{ inputs.ios == 'true' || inputs.brew == 'true' }}
+      shell: bash
+      run: brew bundle install

--- a/.github/workflows/ci-ios-tvos.yml
+++ b/.github/workflows/ci-ios-tvos.yml
@@ -31,76 +31,373 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  code-style-ios:
-    name: Code style iOS
+  # Combined job for prebuild and code style check
+  prebuild-and-lint:
+    name: Prebuild & Code Style Check
     runs-on: macOS-15
+    outputs:
+      expo-cache-hit: ${{ steps.expo-cache.outputs.cache-hit }}
+      pods-cache-hit: ${{ steps.pods-cache.outputs.cache-hit }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
+      # Cache Homebrew dependencies
+      - name: Cache Homebrew
+        uses: actions/cache@v4
         with:
-          ios: true
-          node: true
+          path: |
+            ~/Library/Caches/Homebrew
+            /opt/homebrew/Cellar/swiftlint
+            /opt/homebrew/Cellar/xcbeautify
+          key: ${{ runner.os }}-brew-${{ hashFiles('Brewfile') }}
+          restore-keys: |
+            ${{ runner.os }}-brew-
 
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment-no-prebuild
+        with:
+          node: true
+          ios: true
+
+      # Run code style check early while other setup continues
       - name: Check code style
         run: yarn lint:ios
 
+      # Cache Expo Prebuild artifacts
+      - name: Cache Expo Prebuild
+        id: expo-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            example/ios
+            integration_test/ios
+          key: ${{ runner.os }}-expo-prebuild-${{ hashFiles('example/yarn.lock', 'example/app.json', 'example/package.json', 'plugin/**', 'ios/**') }}
+          restore-keys: |
+            ${{ runner.os }}-expo-prebuild-
+
+      # Install subproject dependencies
+      - name: Install subproject dependencies
+        run: |
+          yarn install --cwd example
+          cp example/.env.example example/.env
+          yarn install --cwd integration_test
+          cp integration_test/.env.example integration_test/.env
+
+      # Conditional prebuild - only if cache miss
+      - name: Check if prebuild needed
+        id: check-prebuild
+        run: |
+          if [ "${{ steps.expo-cache.outputs.cache-hit }}" == "true" ] && [ -d "example/ios" ] && [ -d "integration_test/ios" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "✅ Using cached prebuild artifacts"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "🔨 Prebuild needed - cache miss or directories missing"
+          fi
+
+      - name: Generate native projects
+        if: steps.check-prebuild.outputs.skip == 'false'
+        run: |
+          yarn example prebuild --clean
+          yarn integration-test prebuild --clean
+        env:
+          NSUnbufferedIO: YES
+
+      # Cache CocoaPods
+      - name: Cache CocoaPods
+        id: pods-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            example/ios/Pods
+            integration_test/ios/Pods
+            ~/Library/Caches/CocoaPods
+          key: ${{ runner.os }}-pods-${{ hashFiles('example/ios/Podfile.lock', 'integration_test/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      # Conditional pod install
+      - name: Install CocoaPods if needed
+        if: steps.pods-cache.outputs.cache-hit != 'true' || steps.expo-cache.outputs.cache-hit != 'true'
+        run: |
+          cd example/ios && pod install --repo-update
+          cd ../../integration_test/ios && pod install --repo-update
+
   test-build-ios:
     name: Build iOS Example App
+    needs: prebuild-and-lint
     runs-on: macOS-15
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Restore Homebrew cache
+      - name: Restore Homebrew Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/Homebrew
+            /opt/homebrew/Cellar/swiftlint
+            /opt/homebrew/Cellar/xcbeautify
+          key: ${{ runner.os }}-brew-${{ hashFiles('Brewfile') }}
+          restore-keys: |
+            ${{ runner.os }}-brew-
+
       - name: Setup Environment
-        uses: ./.github/actions/setup-environment
+        uses: ./.github/actions/setup-environment-no-prebuild
         with:
           node: true
-          subprojects: true
           ios: true
 
+      # Restore Expo prebuild cache
+      - name: Restore Expo Prebuild
+        uses: actions/cache@v4
+        with:
+          path: |
+            example/ios
+            integration_test/ios
+          key: ${{ runner.os }}-expo-prebuild-${{ hashFiles('example/yarn.lock', 'example/app.json', 'example/package.json', 'plugin/**', 'ios/**') }}
+          restore-keys: |
+            ${{ runner.os }}-expo-prebuild-
+
+      # Restore CocoaPods cache
+      - name: Restore CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            example/ios/Pods
+            integration_test/ios/Pods
+            ~/Library/Caches/CocoaPods
+          key: ${{ runner.os }}-pods-${{ hashFiles('example/ios/Podfile.lock', 'integration_test/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      # Cache Xcode Derived Data
+      - name: Cache Xcode Derived Data
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-xcode-derived-ios-example-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-derived-ios-example-
+
+      # Install example dependencies
+      - name: Install example dependencies
+        run: |
+          yarn install --cwd example
+          cp example/.env.example example/.env
+
+      # Build iOS example with optimized settings
       - name: Build iOS example
-        run: yarn example build:ios --renderer github-actions
+        run: |
+          set -o pipefail
+          cd example/ios
+          xcodebuild \
+            -workspace BitmovinPlayerReactNativeExample.xcworkspace \
+            -scheme BitmovinPlayerReactNativeExample \
+            -configuration Release \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            SWIFT_COMPILATION_MODE=wholemodule \
+            DEBUG_INFORMATION_FORMAT=dwarf \
+            ENABLE_TESTABILITY=NO \
+            | xcbeautify -q --renderer github-actions
         env:
           NSUnbufferedIO: YES
 
   test-build-ios-integration-tests:
     name: Build iOS Integration Tests
+    needs: prebuild-and-lint
     runs-on: macOS-15
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Restore Homebrew cache
+      - name: Restore Homebrew Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/Homebrew
+            /opt/homebrew/Cellar/swiftlint
+            /opt/homebrew/Cellar/xcbeautify
+          key: ${{ runner.os }}-brew-${{ hashFiles('Brewfile') }}
+          restore-keys: |
+            ${{ runner.os }}-brew-
+
       - name: Setup Environment
-        uses: ./.github/actions/setup-environment
+        uses: ./.github/actions/setup-environment-no-prebuild
         with:
           node: true
-          subprojects: true
           ios: true
 
+      # Restore Expo prebuild cache
+      - name: Restore Expo Prebuild
+        uses: actions/cache@v4
+        with:
+          path: |
+            example/ios
+            integration_test/ios
+          key: ${{ runner.os }}-expo-prebuild-${{ hashFiles('example/yarn.lock', 'example/app.json', 'example/package.json', 'plugin/**', 'ios/**') }}
+          restore-keys: |
+            ${{ runner.os }}-expo-prebuild-
+
+      # Restore CocoaPods cache
+      - name: Restore CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            example/ios/Pods
+            integration_test/ios/Pods
+            ~/Library/Caches/CocoaPods
+          key: ${{ runner.os }}-pods-${{ hashFiles('example/ios/Podfile.lock', 'integration_test/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      # Cache Xcode Derived Data
+      - name: Cache Xcode Derived Data
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-xcode-derived-ios-integration-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-derived-ios-integration-
+
+      # Install integration test dependencies
+      - name: Install integration test dependencies
+        run: |
+          yarn install --cwd integration_test
+          cp integration_test/.env.example integration_test/.env
+
+      # Build iOS integration test host app with optimized settings
       - name: Build iOS integration test host app
-        run: yarn integration-test build:ios --renderer github-actions
+        run: |
+          set -o pipefail
+          cd integration_test/ios
+          xcodebuild \
+            -workspace BitmovinPlayerReactNativeIntegrationTest.xcworkspace \
+            -scheme BitmovinPlayerReactNativeIntegrationTest \
+            -configuration Release \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            SWIFT_COMPILATION_MODE=wholemodule \
+            DEBUG_INFORMATION_FORMAT=dwarf \
+            ENABLE_TESTABILITY=NO \
+            | xcbeautify -q --renderer github-actions
         env:
           NSUnbufferedIO: YES
 
   test-build-tvos:
     name: Build tvOS Example App
     runs-on: macOS-15
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Cache Homebrew dependencies
+      - name: Cache Homebrew
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/Homebrew
+            /opt/homebrew/Cellar/swiftlint
+            /opt/homebrew/Cellar/xcbeautify
+          key: ${{ runner.os }}-brew-${{ hashFiles('Brewfile') }}
+          restore-keys: |
+            ${{ runner.os }}-brew-
+
       - name: Setup Environment
-        uses: ./.github/actions/setup-environment
+        uses: ./.github/actions/setup-environment-no-prebuild
         with:
           node: true
-          subprojects: true
           ios: true
-          tv: true
 
+      # Cache Expo Prebuild for tvOS
+      - name: Cache Expo Prebuild tvOS
+        id: expo-cache-tv
+        uses: actions/cache@v4
+        with:
+          path: |
+            example/ios
+          key: ${{ runner.os }}-expo-prebuild-tv-${{ hashFiles('example/yarn.lock', 'example/app.json', 'example/package.json', 'plugin/**', 'ios/**') }}
+          restore-keys: |
+            ${{ runner.os }}-expo-prebuild-tv-
+
+      # Install example dependencies
+      - name: Install example dependencies
+        run: |
+          yarn install --cwd example
+          cp example/.env.example example/.env
+
+      # Check if tvOS prebuild needed
+      - name: Check if tvOS prebuild needed
+        id: check-prebuild-tv
+        run: |
+          if [ "${{ steps.expo-cache-tv.outputs.cache-hit }}" == "true" ] && [ -d "example/ios" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "✅ Using cached tvOS prebuild artifacts"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "🔨 tvOS prebuild needed - cache miss or directory missing"
+          fi
+
+      # Generate tvOS native project
+      - name: Generate tvOS native project
+        if: steps.check-prebuild-tv.outputs.skip == 'false'
+        run: yarn example prebuild:tv --clean
+        env:
+          NSUnbufferedIO: YES
+
+      # Cache CocoaPods for tvOS
+      - name: Cache CocoaPods tvOS
+        id: pods-cache-tv
+        uses: actions/cache@v4
+        with:
+          path: |
+            example/ios/Pods
+            ~/Library/Caches/CocoaPods
+          key: ${{ runner.os }}-pods-tv-${{ hashFiles('example/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-tv-
+
+      # Install CocoaPods for tvOS if needed
+      - name: Install CocoaPods for tvOS if needed
+        if: steps.pods-cache-tv.outputs.cache-hit != 'true' || steps.expo-cache-tv.outputs.cache-hit != 'true'
+        run: cd example/ios && pod install --repo-update
+
+      # Cache Xcode Derived Data for tvOS
+      - name: Cache Xcode Derived Data tvOS
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-xcode-derived-tvos-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-derived-tvos-
+
+      # Build tvOS example with optimized settings
       - name: Build tvOS example
-        run: yarn example build:tvos --renderer github-actions
+        run: |
+          set -o pipefail
+          cd example/ios
+          xcodebuild \
+            -workspace BitmovinPlayerReactNativeExample.xcworkspace \
+            -scheme BitmovinPlayerReactNativeExample-tvOS \
+            -configuration Release \
+            -sdk appletvsimulator \
+            -destination 'platform=tvOS Simulator,name=Apple TV' \
+            -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            SWIFT_COMPILATION_MODE=wholemodule \
+            DEBUG_INFORMATION_FORMAT=dwarf \
+            ENABLE_TESTABILITY=NO \
+            | xcbeautify -q --renderer github-actions
         env:
           NSUnbufferedIO: YES


### PR DESCRIPTION
## Summary

Implements **Option 1 (Aggressive Caching Strategy)** from `.docs/speed-up-ios-ci.md` to achieve **60-70% time savings** in iOS/tvOS CI workflows.

**Expected improvement: 40 minutes → 12-16 minutes**

## Key Optimizations

### 🚀 Caching Strategy
- **Expo Prebuild Artifacts**: Cache `example/ios` and `integration_test/ios` directories
- **CocoaPods**: Cache `Pods/` directories and CocoaPods global cache
- **Xcode Derived Data**: Cache build artifacts for faster compilation
- **Homebrew Dependencies**: Cache `swiftlint` and `xcbeautify` installations

### ⚡ Smart Conditional Logic
- **Conditional Prebuild**: Only runs `expo prebuild` on cache miss
- **Conditional Pod Install**: Only runs `pod install` when needed
- **Cache Hit Detection**: Logs cache status for debugging

### 🏗️ Job Structure Optimization
- **Combined Job**: `prebuild-and-lint` combines setup and code style checking
- **Dependency Chain**: Build jobs depend on prebuild job to avoid duplication
- **Extended Timeouts**: 30-minute timeouts for testing phase

### 🛠️ Xcode Build Optimizations
- `COMPILER_INDEX_STORE_ENABLE=NO` - Disable index store for CI
- `SWIFT_COMPILATION_MODE=wholemodule` - Optimize Swift compilation
- `DEBUG_INFORMATION_FORMAT=dwarf` - Faster debug info generation
- `ENABLE_TESTABILITY=NO` - Disable testability for release builds

## Test Plan

- [ ] Monitor cache hit rates in CI logs
- [ ] Measure actual build time improvements
- [ ] Verify all builds still pass successfully
- [ ] Check for any cache-related issues

## Files Changed

- `.github/workflows/ci-ios-tvos.yml` - Main workflow with aggressive caching
- `.github/actions/setup-environment-no-prebuild/` - New action without prebuild steps

## Cache Strategy Details

### Cache Keys
- Expo: `${{ hashFiles('example/yarn.lock', 'example/app.json', 'example/package.json', 'plugin/**', 'ios/**') }}`
- Pods: `${{ hashFiles('example/ios/Podfile.lock', 'integration_test/ios/Podfile.lock') }}`
- Xcode: `${{ github.sha }}` with project-specific prefixes
- Homebrew: `${{ hashFiles('Brewfile') }}`

### Cache Invalidation
- Expo cache invalidates on dependency or plugin changes
- Pods cache invalidates on `Podfile.lock` changes  
- Xcode cache uses SHA for per-commit isolation
- Homebrew cache invalidates on `Brewfile` changes

This is a **TESTING PR** - please monitor CI run times and cache behavior closely.