### PR TITLE
Android JsonConverter crash - fix infinity duration conversion

### DIFF
--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -245,7 +245,7 @@ fun String.toSourceType(): SourceType? = when (this) {
 }
 
 fun Source.toJson(): Map<String, Any> = mapOf(
-    "duration" to duration,
+    "duration" to if (duration.isInfinite() || duration.isNaN()) 0 else duration,
     "isActive" to isActive,
     "isAttachedToPlayer" to isAttachedToPlayer,
     "loadingState" to loadingState.ordinal,


### PR DESCRIPTION
## Description
When loading a livestream via Android, I came across this error after initiating play.

_Your app just crashed. See the error below.
java.lang.RuntimeException: folly::toJson: JSON object value was an INF when serializing value at "source"->"duration"_

Accordingly, the JsonConverter caused a crash when trying to convert a INF value.

## Changes
Updated JsonConverter code to convert INF values to a 0.

## Checklist
- [ ] 🗒 `CHANGELOG` entry
