### PR TITLE
Feature/fix live stream crash react native reanimated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Crash when using `react-native-reanimated` along with `bitmovin-player-react-native` and playing a live stream
+
 ## [1.0.0] - 2025-08-04
 
 ### Breaking Change

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -22,6 +22,7 @@ import com.bitmovin.player.api.ui.UiConfig
 import com.bitmovin.player.reactnative.converter.toJson
 import com.bitmovin.player.reactnative.converter.toUserInterfaceType
 import com.bitmovin.player.reactnative.ui.RNPictureInPictureHandler
+import com.bitmovin.player.reactnative.util.NonFiniteSanitizer
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.viewevent.ViewEventCallback
@@ -615,8 +616,9 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
     }
 
     private fun onEvent(dispatcher: ViewEventCallback<Map<String, Any>>, eventData: Map<String, Any>) {
-        dispatcher(eventData)
-        onBmpEvent(eventData)
+        val sanitized = NonFiniteSanitizer.sanitizeEventData(eventData)
+        dispatcher(sanitized)
+        onBmpEvent(sanitized)
     }
 
     fun setFullscreen(isFullscreen: Boolean) {

--- a/android/src/main/java/com/bitmovin/player/reactnative/util/NonFiniteSanitizer.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/util/NonFiniteSanitizer.kt
@@ -1,0 +1,35 @@
+package com.bitmovin.player.reactnative.util
+
+object NonFiniteSanitizer {
+  fun sanitize(value: Any?): Any? = when (value) {
+    null -> null
+    is Double -> if (value.isFinite()) value else toSentinel(value)
+    is Float -> {
+      val d = value.toDouble()
+      if (d.isFinite()) d else toSentinel(d)
+    }
+    is Map<*, *> -> value.entries.associate { (k, v) -> k.toString() to sanitize(v) }
+    is List<*> -> value.map { sanitize(it) }
+    is Array<*> -> value.map { sanitize(it) }
+    is Number -> value // Int/Long/Short/Byte
+    else -> value
+  }
+
+  /**
+   * Type-safe method specifically for event data maps.
+   * Sanitizes event data while preserving type safety and handling null filtering.
+   */
+  fun sanitizeEventData(eventData: Map<String, Any>): Map<String, Any> {
+    val sanitized = mutableMapOf<String, Any>()
+    for ((key, value) in eventData) {
+      sanitize(value)?.let { sanitized[key] = it }
+    }
+    return sanitized
+  }
+
+  private fun toSentinel(d: Double): String = when {
+    d == Double.POSITIVE_INFINITY -> "Infinity"
+    d == Double.NEGATIVE_INFINITY -> "-Infinity"
+    else -> "NaN"
+  }
+}

--- a/ios/NonFiniteSanitizer.swift
+++ b/ios/NonFiniteSanitizer.swift
@@ -4,19 +4,19 @@ enum NonFiniteSanitizer {
   // Keep existing generic method for backward compatibility
   static func sanitize(_ value: Any) -> Any {
     switch value {
-    case let d as Double:
-      if d.isFinite { return d }
-      return toSentinel(d)
-    case let f as Float:
-      let d = Double(f)
-      if d.isFinite { return d }
-      return toSentinel(d)
+    case let doubleValue as Double:
+      if doubleValue.isFinite { return doubleValue }
+      return toSentinel(doubleValue)
+    case let floatValue as Float:
+      let doubleValue = Double(floatValue)
+      if doubleValue.isFinite { return doubleValue }
+      return toSentinel(doubleValue)
     case let dict as [AnyHashable: Any]:
       var out: [AnyHashable: Any] = [:]
-      for (k, v) in dict { out[k] = sanitize(v) }
+      for (ket, value) in dict { out[ket] = sanitize(value) }
       return out
-    case let arr as [Any]:
-      return arr.map { sanitize($0) }
+    case let array as [Any]:
+      return array.map { sanitize($0) }
     default:
       return value
     }

--- a/ios/NonFiniteSanitizer.swift
+++ b/ios/NonFiniteSanitizer.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+enum NonFiniteSanitizer {
+  // Keep existing generic method for backward compatibility
+  static func sanitize(_ value: Any) -> Any {
+    switch value {
+    case let d as Double:
+      if d.isFinite { return d }
+      return toSentinel(d)
+    case let f as Float:
+      let d = Double(f)
+      if d.isFinite { return d }
+      return toSentinel(d)
+    case let dict as [AnyHashable: Any]:
+      var out: [AnyHashable: Any] = [:]
+      for (k, v) in dict { out[k] = sanitize(v) }
+      return out
+    case let arr as [Any]:
+      return arr.map { sanitize($0) }
+    default:
+      return value
+    }
+  }
+  
+  /// Type-safe method specifically for event data dictionaries.
+  /// Sanitizes event data while preserving type safety.
+  static func sanitizeEventData(_ eventData: [String: Any]) -> [String: Any] {
+    var sanitized: [String: Any] = [:]
+    for (key, value) in eventData {
+      sanitized[key] = sanitize(value)
+    }
+    return sanitized
+  }
+  
+  /// Generic method for sanitizing dictionaries with type preservation
+  static func sanitizeDictionary<Key: Hashable, Value>(_ dict: [Key: Value]) -> [Key: Any] {
+    var result: [Key: Any] = [:]
+    for (key, value) in dict {
+      result[key] = sanitize(value)
+    }
+    return result
+  }
+  
+  // Helper to convert non-finite doubles to sentinel strings
+  private static func toSentinel(_ d: Double) -> String {
+    switch d {
+    case .infinity:
+      return "Infinity"
+    case -.infinity:
+      return "-Infinity"
+    default:
+      return "NaN"
+    }
+  }
+}

--- a/ios/RNPlayerView.swift
+++ b/ios/RNPlayerView.swift
@@ -237,7 +237,7 @@ private extension Event {
                 result[key] = pair.value
             }
         }
-        return stringKeyedPayload
+        return NonFiniteSanitizer.sanitizeEventData(stringKeyedPayload)
     }
 }
 

--- a/src/hooks/useProxy.ts
+++ b/src/hooks/useProxy.ts
@@ -1,6 +1,7 @@
 import { RefObject, useCallback } from 'react';
 import { Event } from '../events';
 import { findNodeHandle } from 'react-native';
+import { normalizeNonFinite } from '../utils/normalizeNonFinite';
 
 /**
  * A function that takes a generic event as argument.
@@ -26,7 +27,8 @@ export function useProxy(
           return;
         }
         const { target, ...eventWithoutTarget } = event.nativeEvent as any;
-        callback?.(eventWithoutTarget as E);
+        const sanitized = normalizeNonFinite(eventWithoutTarget);
+        callback?.(sanitized as E);
       },
     [viewRef]
   );

--- a/src/utils/normalizeNonFinite.ts
+++ b/src/utils/normalizeNonFinite.ts
@@ -1,0 +1,13 @@
+export function normalizeNonFinite<T>(input: T): T {
+  function walk(v: any): any {
+    if (v === 'Infinity') return Infinity;
+    if (v === '-Infinity') return -Infinity;
+    if (v === 'NaN') return NaN;
+    if (Array.isArray(v)) return v.map(walk);
+    if (v && typeof v === 'object') {
+      for (const k of Object.keys(v)) (v as any)[k] = walk((v as any)[k]);
+    }
+    return v;
+  }
+  return walk(input);
+}


### PR DESCRIPTION
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
When using `react-native-reanimated` along with our library, crashes happen during JSON serialization due to an infinite value for duration.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Introduced sanitation JSON event payload values to avoid crashes.

## Checklist
- [x] 🗒 `CHANGELOG` entry
