### PR TITLE
Fix tvOS simulator crash in Example app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## [Unreleased]
 
 ### Fixed
+
 - Crash when using `react-native-reanimated` along with `bitmovin-player-react-native` and playing a live stream
+- Example application crash on tvOS simulator
 
 ## [1.0.0] - 2025-08-04
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -73,12 +73,13 @@ const RootStack = createNativeStackNavigator<RootStackParamsList>();
 const isTVOS = Platform.OS === 'ios' && Platform.isTV;
 const isAndroidTV = Platform.OS === 'android' && Platform.isTV;
 const isIOSSimulator = Device.osName === 'iOS' && Device.isDevice === false;
+const isTVOSSimulator = Device.osName === 'tvOS' && Device.isDevice === false;
 
 export default function App() {
   useEffect(() => {
     // iOS audio session category must be set to `playback` first, otherwise playback
     // will have no audio when the device is silenced.
-    // This is also required to make Picture in Picture work on iOS.
+    // This is also required to make Picture in Picture work on iOS and tvOS.
     //
     // Usually it's desireable to set the audio's category only once during your app's main component
     // initialization. This way you can guarantee that your app's audio category is properly
@@ -106,10 +107,6 @@ export default function App() {
       {
         title: 'Subtitle and captions',
         routeName: 'SubtitlePlayback' as keyof RootStackParamsList,
-      },
-      {
-        title: 'Basic Picture in Picture',
-        routeName: 'BasicPictureInPicture' as keyof RootStackParamsList,
       },
       {
         title: 'Basic Ads',
@@ -145,6 +142,13 @@ export default function App() {
         routeName: 'OfflinePlayback',
       });
     }
+  }
+
+  if (!isTVOSSimulator && !isIOSSimulator) {
+    stackParams.data.push({
+      title: 'Basic Picture in Picture',
+      routeName: 'BasicPictureInPicture' as keyof RootStackParamsList,
+    });
   }
 
   if (!Platform.isTV) {
@@ -254,15 +258,17 @@ export default function App() {
             options={{ title: 'Custom playback' }}
           />
         )}
-        <RootStack.Screen
-          name="BasicPictureInPicture"
-          component={BasicPictureInPicture}
-          options={{
-            title: 'Basic Picture in Picture',
-            // eslint-disable-next-line react/no-unstable-nested-components
-            headerRight: () => <Button title="Enter PiP" />,
-          }}
-        />
+        {!isTVOSSimulator && (
+          <RootStack.Screen
+            name="BasicPictureInPicture"
+            component={BasicPictureInPicture}
+            options={{
+              title: 'Basic Picture in Picture',
+              // eslint-disable-next-line react/no-unstable-nested-components
+              headerRight: () => <Button title="Enter PiP" />,
+            }}
+          />
+        )}
         {!isTVOS && (
           <RootStack.Screen
             name="CustomHtmlUi"

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -258,7 +258,7 @@ export default function App() {
             options={{ title: 'Custom playback' }}
           />
         )}
-        {!isTVOSSimulator && (
+        {!isTVOSSimulator && !isIOSSimulator && (
           <RootStack.Screen
             name="BasicPictureInPicture"
             component={BasicPictureInPicture}

--- a/example/src/screens/OfflinePlayback.tsx
+++ b/example/src/screens/OfflinePlayback.tsx
@@ -20,10 +20,11 @@ import {
 } from 'bitmovin-player-react-native';
 import { useTVGestures } from '../hooks';
 import OfflineManagementView from '../components/OfflineManagementView';
-import * as Notifications from 'expo-notifications';
 
 export async function requestNotificationPermissionAsync() {
   if (Platform.OS === 'android') {
+    // Importing expo-notifications only on Android to avoid crash on tvOS simulator.
+    const Notifications = require('expo-notifications');
     const settings = await Notifications.getPermissionsAsync();
     if (settings.status !== 'granted') {
       const { status } = await Notifications.requestPermissionsAsync();
@@ -108,9 +109,11 @@ export default function OfflinePlayback() {
     },
   });
 
-  useFocusEffect(useCallback(() => {
-    requestNotificationPermissionAsync();
-  }, []));
+  useFocusEffect(
+    useCallback(() => {
+      requestNotificationPermissionAsync();
+    }, [])
+  );
 
   useFocusEffect(useCallback(() => () => player.destroy(), [player]));
 


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
There is a crash on startup when running the example app on tvOS simulator due to `expo-notifications` library.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Importing it only on Android where we actually use it fixes this.

## Testing
Run on tvOS using `yarn example prebuild:tv --clean` and `yarn example tvos`

## Checklist
- [x] 🗒 `CHANGELOG` entry
