### PR TITLE
Support git worktrees

### DIFF
--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -3,8 +3,8 @@
 # Setup git pre-commit hooks for the project
 echo "Setting up pre-commit hooks..."
 
-# Check if .git directory exists
-if [ ! -d ".git" ]; then
+# Check if .git directory or file exists (supports both regular repos and worktrees)
+if [ ! -d ".git" ] && [ ! -f ".git" ]; then
     echo "Error: Not a git repository. Please run this from the root of the project."
     exit 1
 fi

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -4,7 +4,7 @@
 echo "Setting up pre-commit hooks..."
 
 # Check if .git directory or file exists (supports both regular repos and worktrees)
-if [ ! -d ".git" ] && [ ! -f ".git" ]; then
+if [ ! -e ".git" ]; then
     echo "Error: Not a git repository. Please run this from the root of the project."
     exit 1
 fi


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->

Setting up on worktrees gets you:

```
Error: Not a git repository. Please run this from the root of the project.
```

The problem is that we check for a .git directory `([ ! -d ".git" ])`, but in Git worktrees, `.git` is a file that points to the actual Git directory, not a directory itself.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->

- Check for  .git directory or **file** exist instead of only checking the directory

## Checklist
- [x] 🗒 `CHANGELOG` entry - `no need since it is build tooling`
