### PR TITLE
iOS: Warn on `playerView` reparenting due to native IMA limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 - Android: TweaksConfig option `enableDrmLicenseRenewRetry` to retry renewing a DRM license when the first renewal attempt fails
 
+### Known Issues
+
+- iOS: Moving a live `PlayerView` between different React Native view trees while using IMA ads in the same source is unsupported and can result in a black screen during playback
+  - A native warning log is now emitted when a rebind of this type is detected
+
 ## [1.9.0] - 2026-02-13
 
 ### Changed

--- a/ios/RNPlayerView.swift
+++ b/ios/RNPlayerView.swift
@@ -328,7 +328,8 @@ private extension RNPlayerView {
 
         NSLog(
             """
-            [RNPlayerView][Warning][playerId=\(playerId)] Detected this player attached to multiple RNPlayerView hosts. \
+            [RNPlayerView] [Warning] [playerId=\(playerId)] Detected this player attached \
+            to multiple RNPlayerView hosts. \
             Re-parenting a live PlayerView is unsupported and can cause black screens when paired with IMA ads. \
             Keep one stable PlayerView host for the session.
             """

--- a/ios/RNPlayerView.swift
+++ b/ios/RNPlayerView.swift
@@ -3,6 +3,15 @@ import BitmovinPlayer
 import ExpoModulesCore
 
 public class RNPlayerView: ExpoView {
+    private final class WeakViewReference {
+        weak var value: RNPlayerView?
+        init(_ value: RNPlayerView) {
+            self.value = value
+        }
+    }
+
+    private static var playerHostRegistry: [NativeId: WeakViewReference] = [:]
+
     var playerView: PlayerView? {
         willSet {
             playerView?.removeFromSuperview()
@@ -114,6 +123,10 @@ public class RNPlayerView: ExpoView {
         clipsToBounds = true
     }
 
+    deinit {
+        unregisterPlayerHost(for: playerId)
+    }
+
     override public func layoutSubviews() {
         super.layoutSubviews()
         maybeFixAVPlayerViewControllerVisibility()
@@ -124,6 +137,9 @@ public class RNPlayerView: ExpoView {
         playerViewConfigWrapper: RNPlayerViewConfig?,
         customMessageHandlerBridgeId: NativeId?
     ) {
+        if self.playerId != playerId {
+            unregisterPlayerHost(for: self.playerId)
+        }
         self.playerId = playerId
         guard let playerId else {
             detachCurrentPlayer()
@@ -132,6 +148,10 @@ public class RNPlayerView: ExpoView {
         guard let player = self.appContext?.moduleRegistry.get(PlayerModule.self)?.retrieve(playerId) else {
             return
         }
+
+        maybeWarnAboutPlayerRebind(playerId: playerId, player: player)
+        registerPlayerHost(for: playerId)
+
         if let playerView, let currentPlayer = playerView.player, currentPlayer === player {
             // Player is already attached to the PlayerView
             return
@@ -264,6 +284,44 @@ private extension RNPlayerView {
 
         // Force a fresh PlayerView on next attach.
         self.playerView = nil
+    }
+
+    func registerPlayerHost(for playerId: NativeId?) {
+        guard let playerId else {
+            return
+        }
+        Self.playerHostRegistry[playerId] = WeakViewReference(self)
+    }
+
+    func unregisterPlayerHost(for playerId: NativeId?) {
+        guard let playerId else {
+            return
+        }
+        guard let current = Self.playerHostRegistry[playerId]?.value else {
+            Self.playerHostRegistry.removeValue(forKey: playerId)
+            return
+        }
+        if current === self {
+            Self.playerHostRegistry.removeValue(forKey: playerId)
+        }
+    }
+
+    func maybeWarnAboutPlayerRebind(playerId: NativeId, player: Player) {
+        guard let existingHost = Self.playerHostRegistry[playerId]?.value else {
+            Self.playerHostRegistry.removeValue(forKey: playerId)
+            return
+        }
+        guard existingHost !== self else {
+            return
+        }
+
+        NSLog(
+            """
+            [RNPlayerView][Warning][playerId=\(playerId)] Detected this player attached to multiple RNPlayerView hosts. \
+            Re-parenting a live PlayerView is unsupported and can cause black screens when paired with IMA ads. \
+            Keep one stable PlayerView host for the session.
+            """
+        )
     }
 }
 


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->

Re-Parenting the PlayerView is not a pattern we currently support natively on iOS. When using IMA ads, and the player view is re-parented, the ad video could show up as a black screen, hearing only the audio.

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->

- Detect re-parenting of the playerView, and emit a warning log message

## Testing

Apply [reparentWarning.patch](https://github.com/user-attachments/files/25549593/reparentWarning.patch):
- Landscape Fullscreen sample has ads added now: play it and look at Xcode logs - nothing should appear
- Open new sample `Modal Re-Parenting`: play it until the mid-roll at ~10 starts - log should appear in Xcode console

## Checklist
- [x] 🗒 `CHANGELOG` entry
