### PR TITLE
Adjust DebugConfig for JS console.log calls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- `DebugConfig.setDebugLoggingEnabled` now also controls JS-side debug logging; `console.log` calls in the `Network` and `Drm` modules are suppressed unless debug logging is enabled
+
 ## [1.14.0] - 2026-03-20
 
 ### Added

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -51,4 +51,15 @@ export class DebugConfig {
     DebugConfig._isDebugEnabled = value;
     await DebugModule.setDebugLoggingEnabled(value);
   }
+
+  /**
+   * Logs a message to the console if debug logging is enabled.
+   *
+   * @param args - Arguments to pass to `console.log`.
+   */
+  static log(...args: unknown[]): void {
+    if (DebugConfig._isDebugEnabled) {
+      console.log(...args);
+    }
+  }
 }

--- a/src/drm/index.ts
+++ b/src/drm/index.ts
@@ -5,6 +5,7 @@ import { FairplayConfig } from './fairplayConfig';
 import { WidevineConfig } from './widevineConfig';
 import { FairplayDrmApi } from './fairplayDrmApi';
 import DrmModule from './drmModule';
+import { DebugConfig } from '../debug';
 
 // Export config types and API classes from DRM module.
 export { FairplayConfig, WidevineConfig, FairplayDrmApi };
@@ -276,7 +277,7 @@ export class Drm extends NativeInstance<DrmConfig> {
    * @param contentId - The extracted contentId string.
    */
   private onPrepareContentId = (id: string, contentId: string) => {
-    console.log('onPrepareContentId', contentId);
+    DebugConfig.log('onPrepareContentId', contentId);
     if (this.config?.fairplay?.prepareContentId) {
       const result = this.config?.fairplay?.prepareContentId?.(contentId);
       DrmModule.setPreparedContentId(id, result);

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -1,6 +1,7 @@
 import { EventSubscription } from 'expo-modules-core';
 import NativeInstance from '../nativeInstance';
 import NetworkModule from './networkModule';
+import { DebugConfig } from '../debug';
 import {
   HttpRequestType,
   HttpRequest,
@@ -32,12 +33,12 @@ export class Network extends NativeInstance<NetworkConfig> {
    */
   initialize = async () => {
     if (!this.isInitialized) {
-      console.log('Initializing Network config:', this.nativeId);
+      DebugConfig.log('Initializing Network config:', this.nativeId);
       // Set up event listeners for HTTP request/response preprocessing
       this.onPreprocessHttpRequestSubscription = NetworkModule.addListener(
         'onPreprocessHttpRequest',
         ({ nativeId, requestId, type, request }) => {
-          console.log(`Received HTTP Request [${type}]:`, request);
+          DebugConfig.log(`Received HTTP Request [${type}]:`, request);
           if (nativeId !== this.nativeId) {
             return;
           }
@@ -48,7 +49,7 @@ export class Network extends NativeInstance<NetworkConfig> {
       this.onPreprocessHttpResponseSubscription = NetworkModule.addListener(
         'onPreprocessHttpResponse',
         ({ nativeId, responseId, type, response }) => {
-          console.log(`Received HTTP Response [${type}]:`, response);
+          DebugConfig.log(`Received HTTP Response [${type}]:`, response);
           if (nativeId !== this.nativeId) {
             return;
           }


### PR DESCRIPTION
## Description
There were a set of unguarded `console.log` calls for every HTTP request/response, they were triggered in production/release mode. On Android, together with perf. monitoring it is causing performance issues and slowness during the playback.

## Changes
DebugConfig class was adjusted to support logging on JS side same way it supports it on IOS/Android.

## Checklist
- [x] 🗒 `CHANGELOG` entry
