### PR TITLE
Lint `console.log` usages and prompt to use the project logger instead

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,13 @@ module.exports = {
   rules: {
     '@typescript-eslint/no-floating-promises': 'error',
     'prettier/prettier': 'error',
+    'no-restricted-properties': [
+      'error',
+      {
+        object: 'console',
+        property: 'log',
+        message: 'Use the project logger `DebugConfig.log` instead.',
+      },
+    ],
   },
 };

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -59,6 +59,7 @@ export class DebugConfig {
    */
   static log(...args: unknown[]): void {
     if (DebugConfig._isDebugEnabled) {
+      // eslint-disable-next-line no-restricted-properties
       console.log(...args);
     }
   }


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->

Since we now have a JS logger since #885, I've added a lint rule flagging `console.log` usages and instead prompts to use our logger

Example lint error:

```
./bitmovin-player-react-native/worktrees/modern/src/debug.ts
  62:7  error  'console.log' is restricted from being used. Use the project logger `DebugConfig.log` instead  no-restricted-properties
```


## Checklist
- [x] 🗒 `CHANGELOG` entry - no need
