### PR TITLE
Fix PiP layouting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `DebugConfig.setDebugLoggingEnabled` now also controls JS-side debug logging; `console.log` calls in the `Network` and `Drm` modules are suppressed unless debug logging is enabled
 
+### Fixed
+
+- Android: Picture in Picture fragmented rendering when resizing the PiP window
+
 ## [1.15.0] - 2026-03-27
 
 ### Added

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -651,7 +651,7 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
             val playerParentIndex: Int,
         )
 
-        private inline fun <reified T : View> View.getParent(): T? {
+        private inline fun <reified T : View> View.findParentOfType(): T? {
             var view = this
             do {
                 view = view.parent as? View ?: return null
@@ -675,9 +675,9 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
         }
 
         fun reparent() {
-            val playerParent = this@RNPlayerView.getParent<ReactViewGroup>() ?: return
+            val playerParent = this@RNPlayerView.findParentOfType<ReactViewGroup>() ?: return
             val playerParentParent = playerParent.parent as? ViewGroup ?: return
-            val reactRoot = playerParent.getParent<ReactRootView>() ?: return
+            val reactRoot = playerParent.findParentOfType<ReactRootView>() ?: return
 
             viewHolder = ViewHolder(
                 reactRoot = reactRoot,

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -170,7 +170,7 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
             requestLayout()
         }
 
-    private val reparentRestoreHelper = RNPlayerViewReparentRestoreHelper()
+    private val reparentHelper = RNPlayerViewReparentHelper()
 
     init {
         // React Native has a bug that dynamically added views sometimes aren't laid out again properly.
@@ -214,7 +214,7 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
 
         activityLifecycle?.removeObserver(activityLifecycleObserver)
         viewTreeObserver.takeIf { it.isAlive }?.removeOnGlobalLayoutListener(globalLayoutListener)
-        reparentRestoreHelper.dispose()
+        reparentHelper.dispose()
 
         // cleanup all children views explicitly,
         // so that in case react native does some view caching we are 100% the child views of this view
@@ -439,15 +439,15 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
                 playerView.enterPictureInPicture()
             }
 
-            if (!reparentRestoreHelper.isActive) {
-                reparentRestoreHelper.reparent()
+            if (!reparentHelper.isActive) {
+                reparentHelper.reparent()
             }
         } else {
             if (playerView.isPictureInPicture) {
                 playerView.exitPictureInPicture()
             }
 
-            reparentRestoreHelper.tryRestore()
+            reparentHelper.tryRestore()
         }
     }
 
@@ -643,7 +643,7 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
     // During PiP mode, we temporarily move the view higher up the hierarchy to the ReactRoot.
     // This prevents fragmented rendering when the user resizes the PiP window.
     // On PiP close, we re-arrange the view hierarchy to its original state
-    private inner class RNPlayerViewReparentRestoreHelper {
+    private inner class RNPlayerViewReparentHelper {
         private inner class ViewHolder(
             val reactRoot: ReactRootView,
             val playerParentParent: ViewGroup,

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -699,7 +699,14 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
         fun tryRestore() {
             val viewHolder = viewHolder ?: return
             viewHolder.reactRoot.removeView(viewHolder.playerParent)
-            viewHolder.playerParentParent.addView(viewHolder.playerParent, viewHolder.playerParentIndex)
+            try {
+                viewHolder.playerParentParent.addView(viewHolder.playerParent, viewHolder.playerParentIndex)
+            } catch (_: Exception) {
+                // In case the view hierarchy layout has changed an exception will be thrown while adding the view
+                // This should never happen, but we can not be sure what react-native does under the hood.
+                // As a fallback add the view without index (will be added as last view)
+                viewHolder.playerParentParent.addView(viewHolder.playerParent)
+            }
 
             dispose()
         }

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -170,7 +170,7 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
             requestLayout()
         }
 
-    private val reparentRestoreHolder = RNPlayerViewReparentRestoreHelper()
+    private val reparentRestoreHelper = RNPlayerViewReparentRestoreHelper()
 
     init {
         // React Native has a bug that dynamically added views sometimes aren't laid out again properly.
@@ -214,7 +214,7 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
 
         activityLifecycle?.removeObserver(activityLifecycleObserver)
         viewTreeObserver.takeIf { it.isAlive }?.removeOnGlobalLayoutListener(globalLayoutListener)
-        reparentRestoreHolder.dispose()
+        reparentRestoreHelper.dispose()
 
         // cleanup all children views explicitly,
         // so that in case react native does some view caching we are 100% the child views of this view
@@ -439,15 +439,15 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
                 playerView.enterPictureInPicture()
             }
 
-            if (!reparentRestoreHolder.isActive) {
-                reparentRestoreHolder.reparent()
+            if (!reparentRestoreHelper.isActive) {
+                reparentRestoreHelper.reparent()
             }
         } else {
             if (playerView.isPictureInPicture) {
                 playerView.exitPictureInPicture()
             }
 
-            reparentRestoreHolder.tryRestore()
+            reparentRestoreHelper.tryRestore()
         }
     }
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -116,7 +116,7 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
 
     private var playerInMediaSessionService: Player? = null
 
-    // This replaces the manual overwriting of the requestLayout function
+    // Setting this flag to `true` in order for React Native to re-render our view when [requestLayout] is triggered
     override val shouldUseAndroidLayout: Boolean = true
 
     private val activityLifecycleObserver = object : DefaultLifecycleObserver {

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -1,14 +1,12 @@
 package com.bitmovin.player.reactnative
 
 import android.annotation.SuppressLint
-import android.app.PictureInPictureParams
 import android.content.Context
 import android.content.res.Configuration
 import android.os.Build
-import android.util.DisplayMetrics
+import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
-import android.view.WindowManager
 import android.widget.FrameLayout
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
@@ -17,10 +15,8 @@ import com.bitmovin.player.PlayerView
 import com.bitmovin.player.SubtitleView
 import com.bitmovin.player.api.Player
 import com.bitmovin.player.api.event.Event
-import com.bitmovin.player.api.event.EventListener
 import com.bitmovin.player.api.event.PlayerEvent
 import com.bitmovin.player.api.event.SourceEvent
-import com.bitmovin.player.api.event.on
 import com.bitmovin.player.api.ui.PlayerViewConfig
 import com.bitmovin.player.api.ui.ScalingMode
 import com.bitmovin.player.api.ui.UiConfig
@@ -28,6 +24,8 @@ import com.bitmovin.player.reactnative.converter.toJson
 import com.bitmovin.player.reactnative.converter.toUserInterfaceType
 import com.bitmovin.player.reactnative.ui.RNPictureInPictureHandler
 import com.bitmovin.player.reactnative.util.NonFiniteSanitizer
+import com.facebook.react.ReactRootView
+import com.facebook.react.views.view.ReactViewGroup
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.viewevent.ViewEventCallback
@@ -117,6 +115,9 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
     private var pictureInPictureConfig: PictureInPictureConfig = PictureInPictureConfig()
 
     private var playerInMediaSessionService: Player? = null
+
+    // This replaces the manual overwriting of the requestLayout function
+    override val shouldUseAndroidLayout: Boolean = true
 
     private val activityLifecycleObserver = object : DefaultLifecycleObserver {
         override fun onStart(owner: LifecycleOwner) {
@@ -320,9 +321,7 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
 
             this.pictureInPictureConfig = playerViewConfigWrapper?.pictureInPictureConfig ?: PictureInPictureConfig()
             val isPictureInPictureEnabled = isPictureInPictureEnabledOnPlayer || pictureInPictureConfig.isEnabled
-            pictureInPictureHandler = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
-                isPictureInPictureEnabled
-            ) {
+            pictureInPictureHandler = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && isPictureInPictureEnabled) {
                 RNPictureInPictureHandler(
                     currentActivity,
                     player,
@@ -424,6 +423,7 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
         }
     }
 
+    private val reparentRestoreHolder = RNPlayerViewReparentRestoreHelper()
     private fun onPictureInPictureModeChanged(
         isInPictureInPictureMode: Boolean,
         newConfig: Configuration,
@@ -437,160 +437,15 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
                 playerView.enterPictureInPicture()
             }
 
-            // Force layout update for PiP mode and ensure proper sizing
-            playerView.requestLayout()
-            requestLayout()
-
-            // Additional PiP-specific layout handling
-            post {
-                val activity = appContext.activityProvider?.currentActivity
-                if (activity != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
-                    activity.isInPictureInPictureMode
-                ) {
-                    // Get the actual PiP window dimensions from WindowManager
-                    val windowManager = activity.getSystemService(Context.WINDOW_SERVICE) as WindowManager
-                    val pipWidth: Int
-                    val pipHeight: Int
-
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                        // Use WindowMetrics for API 30+
-                        val windowMetrics = windowManager.currentWindowMetrics
-                        val windowBounds = windowMetrics.bounds
-                        pipWidth = windowBounds.width()
-                        pipHeight = windowBounds.height()
-                    } else {
-                        // Use deprecated Display.getSize() for older APIs
-                        val displayMetrics = DisplayMetrics()
-                        @Suppress("DEPRECATION")
-                        windowManager.defaultDisplay.getMetrics(displayMetrics)
-                        pipWidth = displayMetrics.widthPixels
-                        pipHeight = displayMetrics.heightPixels
-                    }
-
-                    // Force the ExpoView to be resized to PiP dimensions
-                    // Preserve the original layout params type to avoid ClassCastException
-                    layoutParams?.let { currentParams ->
-                        currentParams.width = pipWidth
-                        currentParams.height = pipHeight
-                        // Re-assign to trigger layout update
-                        layoutParams = currentParams
-                    }
-
-                    // Ensure the ExpoView container is properly sized for PiP
-                    measure(
-                        MeasureSpec.makeMeasureSpec(pipWidth, MeasureSpec.EXACTLY),
-                        MeasureSpec.makeMeasureSpec(pipHeight, MeasureSpec.EXACTLY),
-                    )
-                    layout(left, top, left + pipWidth, top + pipHeight)
-
-                    // Ensure the intermediate container is properly sized for PiP
-                    playerContainer?.let { container ->
-                        // Preserve the original layout params type for the container
-                        container.layoutParams?.let { containerParams ->
-                            containerParams.width = pipWidth
-                            containerParams.height = pipHeight
-                            container.layoutParams = containerParams
-                        }
-                        container.measure(
-                            MeasureSpec.makeMeasureSpec(pipWidth, MeasureSpec.EXACTLY),
-                            MeasureSpec.makeMeasureSpec(pipHeight, MeasureSpec.EXACTLY),
-                        )
-                        container.layout(0, 0, pipWidth, pipHeight)
-                    }
-
-                    // Ensure the PlayerView is properly sized for PiP
-                    playerView.layoutParams = FrameLayout.LayoutParams(pipWidth, pipHeight)
-                    playerView.measure(
-                        MeasureSpec.makeMeasureSpec(pipWidth, MeasureSpec.EXACTLY),
-                        MeasureSpec.makeMeasureSpec(pipHeight, MeasureSpec.EXACTLY),
-                    )
-                    playerView.layout(0, 0, pipWidth, pipHeight)
-
-                    // Ensure the SubtitleView is properly sized for PiP
-                    subtitleView?.let { subtitleView ->
-                        subtitleView.layoutParams = FrameLayout.LayoutParams(pipWidth, pipHeight)
-                        subtitleView.measure(
-                            MeasureSpec.makeMeasureSpec(pipWidth, MeasureSpec.EXACTLY),
-                            MeasureSpec.makeMeasureSpec(pipHeight, MeasureSpec.EXACTLY),
-                        )
-                        subtitleView.layout(0, 0, pipWidth, pipHeight)
-                        subtitleView.invalidate()
-                    }
-
-                    // Try to force a redraw
-                    playerView.invalidate()
-                    playerContainer?.invalidate()
-                    invalidate()
-                }
+            if (!reparentRestoreHolder.isActive) {
+                reparentRestoreHolder.reparent()
             }
         } else {
             if (playerView.isPictureInPicture) {
                 playerView.exitPictureInPicture()
             }
 
-            // Restore full size layout when exiting PiP
-            post {
-                // Reset ExpoView to full size
-                layoutParams?.let { currentParams ->
-                    currentParams.width = LayoutParams.MATCH_PARENT
-                    currentParams.height = LayoutParams.MATCH_PARENT
-                    layoutParams = currentParams
-                }
-
-                // Reset intermediate container to full size
-                playerContainer?.let { container ->
-                    container.layoutParams?.let { containerParams ->
-                        containerParams.width = LayoutParams.MATCH_PARENT
-                        containerParams.height = LayoutParams.MATCH_PARENT
-                        container.layoutParams = containerParams
-                    }
-                }
-
-                // Reset PlayerView to full size
-                playerView.layoutParams = FrameLayout.LayoutParams(
-                    FrameLayout.LayoutParams.MATCH_PARENT,
-                    FrameLayout.LayoutParams.MATCH_PARENT,
-                )
-
-                // Reset SubtitleView to full size
-                subtitleView?.let { subtitleView ->
-                    subtitleView.layoutParams = FrameLayout.LayoutParams(
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                    )
-                }
-
-                // Force layout updates
-                measure(
-                    MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-                    MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY),
-                )
-                layout(left, top, right, bottom)
-
-                playerContainer?.let { container ->
-                    container.measure(
-                        MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-                        MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY),
-                    )
-                    container.layout(0, 0, width, height)
-                }
-
-                playerView.measure(
-                    MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-                    MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY),
-                )
-                playerView.layout(0, 0, width, height)
-
-                // Ensure SubtitleView is properly measured and laid out when exiting PiP
-                subtitleView?.let { subtitleView ->
-                    subtitleView.measure(
-                        MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-                        MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY),
-                    )
-                    subtitleView.layout(0, 0, width, height)
-                    subtitleView.invalidate()
-                }
-            }
+            reparentRestoreHolder.tryRestore()
         }
     }
 
@@ -762,19 +617,62 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
         }
     }
 
-    /**
-     * Try to measure and update this view layout as much as possible to
-     * avoid layout problems related to React or old layout values present
-     * in `playerView` due to being previously attached to a different parent.
-     */
-    override fun requestLayout() {
-        super.requestLayout()
-        post {
-            measure(
-                MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-                MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY),
+    private inner class RNPlayerViewReparentRestoreHelper {
+        private var reactRoot: ReactRootView? = null
+        private var playerParentParent: ViewGroup? = null
+        private var playerParent: ReactViewGroup? = null
+        private var playerParentIndex: Int? = null
+
+        val isActive: Boolean
+            get() = playerParentParent != null && playerParent != null && playerParentIndex != null
+
+        private val globalLayoutListener = ViewTreeObserver.OnGlobalLayoutListener {
+            val reactRoot = this@RNPlayerViewReparentRestoreHelper.reactRoot ?: return@OnGlobalLayoutListener
+            val view = this@RNPlayerView
+            view.measure(
+                MeasureSpec.makeMeasureSpec(reactRoot.width, MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(reactRoot.height, MeasureSpec.EXACTLY),
             )
-            layout(left, top, right, bottom)
+            view.layout(0, 0, view.measuredWidth, view.measuredHeight)
         }
+
+        fun reparent() {
+            val playerParent = this@RNPlayerView.getParent<ReactViewGroup>() ?: return
+            val playerParentParent = playerParent.parent as? ViewGroup ?: return
+            val reactRoot = playerParent.getParent<ReactRootView>() ?: return
+
+            this@RNPlayerViewReparentRestoreHelper.reactRoot = reactRoot
+            this@RNPlayerViewReparentRestoreHelper.playerParentParent = playerParentParent
+            this@RNPlayerViewReparentRestoreHelper.playerParent = playerParent
+            playerParentIndex = playerParentParent.indexOfChild(playerParent)
+
+            playerParentParent.removeView(playerParent)
+            reactRoot.addView(playerParent)
+
+            playerParent.viewTreeObserver.addOnGlobalLayoutListener(globalLayoutListener)
+        }
+
+        fun tryRestore() {
+            val reactRoot = this@RNPlayerViewReparentRestoreHelper.reactRoot ?: return
+            val playerParentParent = this@RNPlayerViewReparentRestoreHelper.playerParentParent ?: return
+            val playerParent = this@RNPlayerViewReparentRestoreHelper.playerParent ?: return
+            val playerParentIndex = this@RNPlayerViewReparentRestoreHelper.playerParentIndex ?: return
+
+            reactRoot.removeView(playerParent)
+            playerParentParent.addView(playerParent, playerParentIndex)
+
+            playerParent.viewTreeObserver.removeOnGlobalLayoutListener(globalLayoutListener)
+            this.playerParentParent = null
+            this.playerParent = null
+            this.playerParentIndex = null
+        }
+    }
+
+    private inline fun <reified T : View> View.getParent(): T? {
+        var view = this
+        do {
+            view = view.parent as? View ?: return null
+        } while (view !is T)
+        return view
     }
 }

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -689,6 +689,10 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
             playerParentParent.removeView(playerParent)
             reactRoot.addView(playerParent)
 
+            // We attach the global layout listener to a playerParent,
+            // but inside the callback we are measuring reach root.
+            // This is because the root is the first view layer that gets transformed in PiP mode.
+            // Measuring and layouting this should cascade down the viewHierarchy.
             playerParent.viewTreeObserver.addOnGlobalLayoutListener(globalLayoutListener)
         }
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -625,6 +625,14 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
             var playerParentIndex: Int,
         )
 
+        private inline fun <reified T : View> View.getParent(): T? {
+            var view = this
+            do {
+                view = view.parent as? View ?: return null
+            } while (view !is T)
+            return view
+        }
+
         private var viewHolder: ViewHolder? = null
 
         val isActive: Boolean
@@ -666,13 +674,5 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
             viewHolder.playerParent.viewTreeObserver.removeOnGlobalLayoutListener(globalLayoutListener)
             this.viewHolder = null
         }
-    }
-
-    private inline fun <reified T : View> View.getParent(): T? {
-        var view = this
-        do {
-            view = view.parent as? View ?: return null
-        } while (view !is T)
-        return view
     }
 }

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -645,10 +645,10 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
     // On PiP close, we re-arrange the view hierarchy to its original state
     private inner class RNPlayerViewReparentRestoreHelper {
         private inner class ViewHolder(
-            var reactRoot: ReactRootView,
-            var playerParentParent: ViewGroup,
-            var playerParent: ReactViewGroup,
-            var playerParentIndex: Int,
+            val reactRoot: ReactRootView,
+            val playerParentParent: ViewGroup,
+            val playerParent: ReactViewGroup,
+            val playerParentIndex: Int,
         )
 
         private inline fun <reified T : View> View.getParent(): T? {

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -170,6 +170,8 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
             requestLayout()
         }
 
+    private val reparentRestoreHolder = RNPlayerViewReparentRestoreHelper()
+
     init {
         // React Native has a bug that dynamically added views sometimes aren't laid out again properly.
         // Since we dynamically add and remove SurfaceView under the hood this caused the player
@@ -212,6 +214,7 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
 
         activityLifecycle?.removeObserver(activityLifecycleObserver)
         viewTreeObserver.takeIf { it.isAlive }?.removeOnGlobalLayoutListener(globalLayoutListener)
+        reparentRestoreHolder.dispose()
 
         // cleanup all children views explicitly,
         // so that in case react native does some view caching we are 100% the child views of this view
@@ -423,7 +426,6 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
         }
     }
 
-    private val reparentRestoreHolder = RNPlayerViewReparentRestoreHelper()
     private fun onPictureInPictureModeChanged(
         isInPictureInPictureMode: Boolean,
         newConfig: Configuration,
@@ -671,7 +673,11 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
             viewHolder.reactRoot.removeView(viewHolder.playerParent)
             viewHolder.playerParentParent.addView(viewHolder.playerParent, viewHolder.playerParentIndex)
 
-            viewHolder.playerParent.viewTreeObserver.removeOnGlobalLayoutListener(globalLayoutListener)
+            dispose()
+        }
+
+        fun dispose() {
+            viewHolder?.playerParent?.viewTreeObserver?.removeOnGlobalLayoutListener(globalLayoutListener)
             this.viewHolder = null
         }
     }

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -690,7 +690,7 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
             reactRoot.addView(playerParent)
 
             // We attach the global layout listener to a playerParent,
-            // but inside the callback we are measuring reach root.
+            // but inside the callback we are measuring each root.
             // This is because the root is the first view layer that gets transformed in PiP mode.
             // Measuring and layouting this should cascade down the viewHierarchy.
             playerParent.viewTreeObserver.addOnGlobalLayoutListener(globalLayoutListener)

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -618,16 +618,20 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
     }
 
     private inner class RNPlayerViewReparentRestoreHelper {
-        private var reactRoot: ReactRootView? = null
-        private var playerParentParent: ViewGroup? = null
-        private var playerParent: ReactViewGroup? = null
-        private var playerParentIndex: Int? = null
+        private inner class ViewHolder(
+            var reactRoot: ReactRootView,
+            var playerParentParent: ViewGroup,
+            var playerParent: ReactViewGroup,
+            var playerParentIndex: Int,
+        )
+
+        private var viewHolder: ViewHolder? = null
 
         val isActive: Boolean
-            get() = playerParentParent != null && playerParent != null && playerParentIndex != null
+            get() = viewHolder != null
 
         private val globalLayoutListener = ViewTreeObserver.OnGlobalLayoutListener {
-            val reactRoot = this@RNPlayerViewReparentRestoreHelper.reactRoot ?: return@OnGlobalLayoutListener
+            val reactRoot = viewHolder?.reactRoot ?: return@OnGlobalLayoutListener
             val view = this@RNPlayerView
             view.measure(
                 MeasureSpec.makeMeasureSpec(reactRoot.width, MeasureSpec.EXACTLY),
@@ -641,10 +645,12 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
             val playerParentParent = playerParent.parent as? ViewGroup ?: return
             val reactRoot = playerParent.getParent<ReactRootView>() ?: return
 
-            this@RNPlayerViewReparentRestoreHelper.reactRoot = reactRoot
-            this@RNPlayerViewReparentRestoreHelper.playerParentParent = playerParentParent
-            this@RNPlayerViewReparentRestoreHelper.playerParent = playerParent
-            playerParentIndex = playerParentParent.indexOfChild(playerParent)
+            viewHolder = ViewHolder(
+                reactRoot = reactRoot,
+                playerParentParent = playerParentParent,
+                playerParent = playerParent,
+                playerParentIndex = playerParentParent.indexOfChild(playerParent),
+            )
 
             playerParentParent.removeView(playerParent)
             reactRoot.addView(playerParent)
@@ -653,18 +659,12 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
         }
 
         fun tryRestore() {
-            val reactRoot = this@RNPlayerViewReparentRestoreHelper.reactRoot ?: return
-            val playerParentParent = this@RNPlayerViewReparentRestoreHelper.playerParentParent ?: return
-            val playerParent = this@RNPlayerViewReparentRestoreHelper.playerParent ?: return
-            val playerParentIndex = this@RNPlayerViewReparentRestoreHelper.playerParentIndex ?: return
+            val viewHolder = viewHolder ?: return
+            viewHolder.reactRoot.removeView(viewHolder.playerParent)
+            viewHolder.playerParentParent.addView(viewHolder.playerParent, viewHolder.playerParentIndex)
 
-            reactRoot.removeView(playerParent)
-            playerParentParent.addView(playerParent, playerParentIndex)
-
-            playerParent.viewTreeObserver.removeOnGlobalLayoutListener(globalLayoutListener)
-            this.playerParentParent = null
-            this.playerParent = null
-            this.playerParentIndex = null
+            viewHolder.playerParent.viewTreeObserver.removeOnGlobalLayoutListener(globalLayoutListener)
+            this.viewHolder = null
         }
     }
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -619,6 +619,10 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
         }
     }
 
+    // React Native doesn't properly handle PiP layout transitions.
+    // During PiP mode, we temporarily move the view higher up the hierarchy to the ReactRoot.
+    // This prevents fragmented rendering when the user resizes the PiP window.
+    // On PiP close, we re-arrange the view hierarchy to its original state
     private inner class RNPlayerViewReparentRestoreHelper {
         private inner class ViewHolder(
             var reactRoot: ReactRootView,

--- a/android/src/main/java/com/bitmovin/player/reactnative/ui/RNPictureInPictureHandler.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/ui/RNPictureInPictureHandler.kt
@@ -88,7 +88,7 @@ class RNPictureInPictureHandler(
         player.off<PlayerEvent.AdBreakFinished>(setPlayerIsNotPlaying)
     }
 
-    private fun getPiPAspectRation() = player.playbackVideoData
+    private fun getPiPAspectRatio() = player.playbackVideoData
         ?.let { Rational(it.width, it.height) }
         ?: Rational(16, 9)
 
@@ -119,7 +119,7 @@ class RNPictureInPictureHandler(
     private fun buildPictureInPictureParams(
         autoEnterEnabled: Boolean = pictureInPictureConfig.isAutoPipEnabled && playerIsPlaying,
     ) = PictureInPictureParams.Builder()
-        .setAspectRatio(getPiPAspectRation())
+        .setAspectRatio(getPiPAspectRatio())
         .setActions(pictureInPictureActionHandler.buildRemoteActions())
         .apply {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {


### PR DESCRIPTION
## Description
When in PiP mode the video is sometimes cropped. (this happens mostly when resizing the window)

## Changes
- Remove old layouting / measuring logic
- Add helper to re-parent the playerView parent to the root view and manually measure + layout the playerView in PiP layout changes
- Overwrite `shouldUseAndroidLayout` + remove overwritten `requestLayout` function (when the mentioned flag returns true, internally it does the same as we did when overwriting)

## Checklist
- [x] 🗒 `CHANGELOG` entry
