### PR TITLE
Feature/ima dai integration

### DIFF
--- a/android/src/main/java/com/bitmovin/player/reactnative/IMAAdsWrapper.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/IMAAdsWrapper.kt
@@ -207,7 +207,7 @@ class IMAAdsWrapper(
                 String.format("Event: %s\n", adEvent.type),
             )
             AdEventType.TAPPED -> {
-                // Tap on non-clickthrough portion of ad (e.g. video area) — toggle play/pause like iOS.
+                // Tap on non-clickthrough portion of ad (e.g. video area) — toggle play/pause
                 if (videoPlayer.isPlaying) {
                     videoPlayer.pause()
                     playerCallbacks.forEach { it.onPause() }

--- a/android/src/main/java/com/bitmovin/player/reactnative/IMAAdsWrapper.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/IMAAdsWrapper.kt
@@ -1,0 +1,250 @@
+package com.bitmovin.player.reactnative
+
+import android.util.Log
+import android.view.ViewGroup
+import com.bitmovin.player.api.Player
+import com.bitmovin.player.api.event.PlayerEvent
+import com.bitmovin.player.api.metadata.id3.TextInformationFrame
+import com.bitmovin.player.api.source.SourceConfig
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.ReadableMap
+import com.google.ads.interactivemedia.v3.api.AdErrorEvent
+import com.google.ads.interactivemedia.v3.api.AdErrorEvent.AdErrorListener
+import com.google.ads.interactivemedia.v3.api.AdEvent
+import com.google.ads.interactivemedia.v3.api.AdEvent.AdEventListener
+import com.google.ads.interactivemedia.v3.api.AdEvent.AdEventType
+import com.google.ads.interactivemedia.v3.api.AdsLoader
+import com.google.ads.interactivemedia.v3.api.AdsLoader.AdsLoadedListener
+import com.google.ads.interactivemedia.v3.api.AdsManagerLoadedEvent
+import com.google.ads.interactivemedia.v3.api.ImaSdkFactory
+import com.google.ads.interactivemedia.v3.api.StreamManager
+import com.google.ads.interactivemedia.v3.api.StreamRequest
+import com.google.ads.interactivemedia.v3.api.player.VideoProgressUpdate
+import com.google.ads.interactivemedia.v3.api.player.VideoStreamPlayer
+import com.google.ads.interactivemedia.v3.api.player.VideoStreamPlayer.VideoStreamPlayerCallback
+
+class IMAAdsWrapper(
+    private val context: ReactContext,
+    private val videoPlayer: Player,
+) : AdEventListener, AdErrorListener, AdsLoadedListener {
+    private var pendingRequestedAssetId: String? = null
+    private var adUiContainer: ViewGroup? = null
+
+    private val LOG_TAG = "Bitmovin IMAAdsWrapper"
+    private val sdkFactory = ImaSdkFactory.getInstance()
+    private var adsLoader: AdsLoader? = null
+    var streamManager: StreamManager? = null
+    var playerCallbacks: MutableList<VideoStreamPlayerCallback> =
+        ArrayList()
+
+    private var fallbackUrl: String? = null
+    private var adTagParams: ReadableMap? = null
+
+    init {
+        // Listen for ID3 metadata and use callbacks
+        videoPlayer.on(
+            PlayerEvent.Metadata::class,
+            ::onMetadataEvent,
+        )
+        videoPlayer.on(
+            PlayerEvent.PlaybackFinished::class,
+            ::onPlaybackFinished,
+        )
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    private fun onPlaybackFinished(event: PlayerEvent.PlaybackFinished) {
+        playerCallbacks.forEach {
+            it.onContentComplete()
+        }
+    }
+
+    internal fun setAdUiContainer(adUiContainer: ViewGroup?) {
+        // Match iOS: only initialize once; repeated calls (e.g. from layout + attachPlayer) must not create a new AdsLoader.
+        if (adsLoader != null) {
+            return
+        }
+        this.adUiContainer = adUiContainer
+        createAdsLoader()
+    }
+
+    private fun createAdsLoader() {
+        if (adsLoader != null) {
+            Log.w(LOG_TAG, "AdsLoader already created, skipping initialization")
+            return
+        }
+        val settings = sdkFactory.createImaSdkSettings()
+        val videoStreamPlayer = createVideoStreamPlayer()
+        val adUiContainer = adUiContainer
+            ?: run {
+                Log.e(LOG_TAG, "Ad UI container is not available")
+                return
+            }
+        val displayContainer =
+            ImaSdkFactory.createStreamDisplayContainer(adUiContainer, videoStreamPlayer)
+
+        val adsLoader = sdkFactory.createAdsLoader(context, settings, displayContainer)
+        adsLoader.addAdErrorListener(this)
+        adsLoader.addAdsLoadedListener(this)
+        this.adsLoader = adsLoader
+
+        pendingRequestedAssetId?.let { assetId ->
+            pendingRequestedAssetId = null
+            requestAndLoadStream(assetId)
+        }
+    }
+
+    fun requestAndLoadStream(assetId: String) {
+        createAdsLoader()
+        val adsLoader = this.adsLoader ?: run {
+            Log.e(LOG_TAG, "AdsLoader is not initialized")
+            pendingRequestedAssetId = assetId
+            return@requestAndLoadStream
+        }
+        pendingRequestedAssetId = null
+        adsLoader.requestStream(buildStreamRequest(assetId))
+    }
+
+    fun onMetadataEvent(metadata: PlayerEvent.Metadata) {
+        val metadataEntriesCount = metadata.metadata.length()
+        if (metadataEntriesCount == 0) {
+            Log.w(LOG_TAG, "No metadata entries found")
+            return
+        }
+        for (i in 0 until metadataEntriesCount) {
+            val entry = metadata.metadata[i]
+            if (entry is TextInformationFrame) {
+                if ("TXXX" == entry.id) {
+                    playerCallbacks.forEach {
+                        it.onUserTextReceived(entry.value)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun buildStreamRequest(assetId: String): StreamRequest {
+        // To support VOD through IMA, create different stream requests here
+        // based on video type
+        val request = sdkFactory.createLiveStreamRequest(assetId, null)
+        request.setAdTagParameters(toMap(adTagParams))
+        return request
+    }
+
+    private fun createVideoStreamPlayer(): VideoStreamPlayer {
+        val player: VideoStreamPlayer = object : VideoStreamPlayer {
+            override fun addCallback(videoStreamPlayerCallback: VideoStreamPlayerCallback) {
+                playerCallbacks.add(videoStreamPlayerCallback)
+            }
+
+            @Suppress("UNUSED_PARAMETER")
+            override fun loadUrl(url: String, headers: List<HashMap<String, String>>) {
+                videoPlayer.load(SourceConfig.fromUrl(url))
+                Log.i(LOG_TAG, "Loading IMA DAI URL")
+            }
+
+            override fun onAdBreakEnded() {
+                // TODO: emit event?
+            }
+
+            override fun onAdBreakStarted() {
+                // TODO: emit event?
+            }
+
+            override fun onAdPeriodEnded() {
+                // TODO: emit event?
+            }
+
+            override fun onAdPeriodStarted() {
+                // TODO: emit event?
+            }
+
+            override fun resume() {
+                videoPlayer.play()
+            }
+
+            override fun seek(l: Long) {
+                // IMA passes position in milliseconds; Bitmovin seek() expects seconds.
+                videoPlayer.seek(l / 1000.0)
+            }
+
+            override fun pause() {
+                videoPlayer.pause()
+            }
+
+            override fun removeCallback(videoStreamPlayerCallback: VideoStreamPlayerCallback) {
+                playerCallbacks.remove(videoStreamPlayerCallback)
+            }
+
+            override fun getContentProgress(): VideoProgressUpdate {
+                // Bitmovin currentTime/duration are in seconds; IMA VideoProgressUpdate expects milliseconds.
+                return VideoProgressUpdate(
+                    (videoPlayer.currentTime * 1000).toLong(),
+                    (videoPlayer.duration * 1000).toLong(),
+                )
+            }
+
+            override fun getVolume(): Int {
+                return videoPlayer.volume
+            }
+        }
+        return player
+    }
+
+    override fun onAdError(adErrorEvent: AdErrorEvent) {
+        fallbackUrl?.let { videoPlayer.load(SourceConfig.fromUrl(it)) } ?: run {
+            Log.e(LOG_TAG, "IMA Ad Error: ${adErrorEvent.error.message}")
+            return@onAdError
+        }
+        videoPlayer.play()
+    }
+
+    override fun onAdEvent(adEvent: AdEvent) {
+        when (adEvent.type) {
+            AdEventType.AD_PROGRESS -> {}
+            AdEventType.AD_BREAK_STARTED, AdEventType.AD_BREAK_ENDED -> Log.i(
+                LOG_TAG,
+                String.format("Event: %s\n", adEvent.type),
+            )
+            AdEventType.TAPPED -> {
+                // Tap on non-clickthrough portion of ad (e.g. video area) — toggle play/pause like iOS.
+                if (videoPlayer.isPlaying) {
+                    videoPlayer.pause()
+                    playerCallbacks.forEach { it.onPause() }
+                } else {
+                    videoPlayer.play()
+                    playerCallbacks.forEach { it.onResume() }
+                }
+            }
+            else -> {}
+        }
+    }
+
+    override fun onAdsManagerLoaded(adsManagerLoadedEvent: AdsManagerLoadedEvent) {
+        val streamManager = adsManagerLoadedEvent.streamManager
+        this.streamManager = streamManager
+        streamManager.addAdErrorListener(this)
+        streamManager.addAdEventListener(this)
+        streamManager.init()
+    }
+
+    fun setFallbackUrl(url: String?) {
+        fallbackUrl = url
+    }
+
+    fun setAdTagParams(params: ReadableMap?) {
+        adTagParams = params
+    }
+
+    fun toMap(readableMap: ReadableMap?): Map<String, String> {
+        val map = mutableMapOf<String, String>()
+        if (readableMap != null) {
+            val iterator = readableMap.keySetIterator()
+            while (iterator.hasNextKey()) {
+                val key = iterator.nextKey()
+                map[key] = readableMap.getString(key) ?: "" // assumes all values are strings
+            }
+        }
+        return map
+    }
+}

--- a/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
@@ -1,5 +1,6 @@
 package com.bitmovin.player.reactnative
 
+import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import com.bitmovin.analytics.api.DefaultMetadata
 import com.bitmovin.player.api.Player
@@ -16,6 +17,8 @@ import com.bitmovin.player.reactnative.converter.toMap
 import com.bitmovin.player.reactnative.converter.toMediaControlConfig
 import com.bitmovin.player.reactnative.converter.toPlayerConfig
 import com.bitmovin.player.reactnative.extensions.getMap
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.ReadableMap
 import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -24,6 +27,7 @@ class PlayerModule : Module() {
 
     val mediaSessionPlaybackManager by lazy { MediaSessionPlaybackManager(appContext) }
     private val imaSettingsWaiter = ResultWaiter<Map<String, Any?>>()
+    private val adsWrappers: Registry<IMAAdsWrapper> = mutableMapOf()
 
     override fun definition() = ModuleDefinition {
         Name("PlayerModule")
@@ -43,6 +47,7 @@ class PlayerModule : Module() {
             }
             imaSettingsWaiter.clear()
             PlayerRegistry.clear()
+            adsWrappers.clear()
         }
 
         Events("onImaBeforeInitialization")
@@ -50,11 +55,17 @@ class PlayerModule : Module() {
         AsyncFunction("play") { nativeId: NativeId ->
             val player = PlayerRegistry.getPlayer(nativeId)
             player?.play()
+            adsWrappers[nativeId]?.playerCallbacks?.forEach {
+                it.onResume()
+            }
         }.runOnQueue(Queues.MAIN)
 
         AsyncFunction("pause") { nativeId: NativeId ->
             val player = PlayerRegistry.getPlayer(nativeId)
             player?.pause()
+            adsWrappers[nativeId]?.playerCallbacks?.forEach {
+                it.onPause()
+            }
         }.runOnQueue(Queues.MAIN)
 
         AsyncFunction("mute") { nativeId: NativeId ->
@@ -85,11 +96,15 @@ class PlayerModule : Module() {
                 player.destroy()
                 PlayerRegistry.unregister(nativeId)
             }
+            adsWrappers.remove(nativeId)
         }.runOnQueue(Queues.MAIN)
 
         AsyncFunction("setVolume") { nativeId: NativeId, volume: Double ->
             val player = PlayerRegistry.getPlayer(nativeId)
             player?.volume = volume.toInt()
+            adsWrappers[nativeId]?.playerCallbacks?.forEach {
+                it.onVolumeChanged(volume.toInt())
+            }
         }.runOnQueue(Queues.MAIN)
 
         AsyncFunction("getVolume") { nativeId: NativeId ->
@@ -130,6 +145,20 @@ class PlayerModule : Module() {
         AsyncFunction("unload") { nativeId: NativeId ->
             val player = PlayerRegistry.getPlayer(nativeId)
             player?.unload()
+        }.runOnQueue(Queues.MAIN)
+
+        AsyncFunction("assignAdContainer") { nativeId: NativeId, adUiContainer: ViewGroup ->
+            val adsWrapper = adsWrappers[nativeId]
+                ?: throw IllegalStateException("IMAAdsWrapper not found for Player with id $nativeId")
+            adsWrapper.setAdUiContainer(adUiContainer)
+        }.runOnQueue(Queues.MAIN)
+
+        AsyncFunction("loadDaiStream") { nativeId: NativeId, assetId: String, fallbackUrl: String, adTagParams: ReadableMap ->
+            val adsWrapper = adsWrappers[nativeId]
+                ?: throw IllegalStateException("IMAAdsWrapper not found for Player with id $nativeId")
+            adsWrapper.setAdTagParams(adTagParams)
+            adsWrapper.setFallbackUrl(fallbackUrl)
+            adsWrapper.requestAndLoadStream(assetId)
         }.runOnQueue(Queues.MAIN)
 
         AsyncFunction("getTimeShift") { nativeId: NativeId ->
@@ -356,6 +385,11 @@ class PlayerModule : Module() {
         if (enableMediaSession) {
             mediaSessionPlaybackManager.setupMediaSessionPlayback(nativeId)
         }
+
+        adsWrappers[nativeId] = IMAAdsWrapper(
+            appContext.reactContext as ReactContext,
+            player,
+        )
     }
 
     private fun setupImaBeforeInitialization(
@@ -391,4 +425,10 @@ class PlayerModule : Module() {
 
     // CRITICAL: This method must remain available for cross-module access
     fun getPlayerOrNull(nativeId: NativeId): Player? = PlayerRegistry.getPlayer(nativeId)
+
+    fun assignAdContainer(nativeId: NativeId, adUiContainer: ViewGroup) {
+        val adsWrapper = adsWrappers[nativeId]
+            ?: throw IllegalStateException("IMAAdsWrapper not found for Player with id $nativeId")
+        adsWrapper.setAdUiContainer(adUiContainer)
+    }
 }

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -40,6 +40,8 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
     private var pictureInPictureHandler: RNPictureInPictureHandler? = null
     private var subtitleView: SubtitleView? = null
     private var playerContainer: FrameLayout? = null
+    /** Sits above [PlayerView] so IMA ad UI is not occluded by the video [android.view.SurfaceView]. */
+    private var imaAdContainer: FrameLayout? = null
     var enableBackgroundPlayback: Boolean = false
     private var scalingMode: ScalingMode? = null
     private var requestedFullscreenValue: Boolean? = null
@@ -209,6 +211,7 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
             (container.parent as? ViewGroup)?.removeView(container)
         }
         playerContainer = null
+        imaAdContainer = null
 
         activityLifecycle?.removeObserver(activityLifecycleObserver)
         viewTreeObserver.takeIf { it.isAlive }?.removeOnGlobalLayoutListener(globalLayoutListener)
@@ -217,6 +220,30 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
         // so that in case react native does some view caching we are 100% the child views of this view
         // are cleaned up from the view hierarchy
         removeAllViews()
+    }
+
+    /**
+     * IMA injects WebViews into this layer for Learn More, countdown, etc. It must be a sibling **above**
+     * [PlayerView] in z-order; using [PlayerView] as the IMA container hides UI behind the video SurfaceView.
+     */
+    private fun ensureImaAdOverlay(container: FrameLayout): FrameLayout {
+        val existing = imaAdContainer
+        if (existing != null && existing.parent === container) {
+            existing.bringToFront()
+            return existing
+        }
+        existing?.let { (it.parent as? ViewGroup)?.removeView(it) }
+        val overlay = FrameLayout(context).apply {
+            layoutParams = FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
+            )
+            elevation = 1f
+        }
+        container.addView(overlay)
+        overlay.bringToFront()
+        imaAdContainer = overlay
+        return overlay
     }
 
     private fun setPlayerView(playerView: PlayerView) {
@@ -233,6 +260,7 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
         playerContainer?.let { oldContainer ->
             (oldContainer.parent as? ViewGroup)?.removeView(oldContainer)
         }
+        imaAdContainer = null
 
         // Create new container for the PlayerView
         val newContainer = FrameLayout(context).apply {
@@ -251,6 +279,8 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
                 FrameLayout.LayoutParams.MATCH_PARENT,
             ),
         )
+
+        ensureImaAdOverlay(newContainer)
 
         // Add container to the ExpoView with correct layout parameters
         val containerLayoutParams = generateDefaultLayoutParams()
@@ -299,7 +329,10 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
         attachPlayerListeners(player)
         if (playerView != null) {
             playerView?.player = player
-            playerModule.assignAdContainer(playerId, playerView as ViewGroup)
+            playerContainer?.let { container ->
+                val adContainer = ensureImaAdOverlay(container)
+                playerModule.assignAdContainer(playerId, adContainer)
+            }
             onBmpAdContainerReady(emptyMap())
         } else {
             this.enableBackgroundPlayback = enableBackgroundPlayback
@@ -335,9 +368,9 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
                 null
             }
             newPlayerView.setPictureInPictureHandler(pictureInPictureHandler)
-            playerModule.assignAdContainer(playerId, newPlayerView as ViewGroup)
-            onBmpAdContainerReady(emptyMap())
             setPlayerView(newPlayerView)
+            imaAdContainer?.let { playerModule.assignAdContainer(playerId, it) }
+            onBmpAdContainerReady(emptyMap())
             attachPlayerViewListeners(newPlayerView)
 
             val playerConfig = player.config
@@ -400,6 +433,8 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
             )
             container.addView(subtitleView, layoutParams)
             subtitleView.bringToFront() // Ensure proper z-ordering
+            // IMA ad chrome must stay above subtitles during DAI ad breaks
+            imaAdContainer?.bringToFront()
         }
     }
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -113,6 +113,7 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
     private val onBmpPictureInPictureAvailabilityChanged by EventDispatcher()
     private val onBmpPictureInPictureEnter by EventDispatcher()
     private val onBmpPictureInPictureExit by EventDispatcher()
+    private val onBmpAdContainerReady by EventDispatcher()
 
     private var pictureInPictureConfig: PictureInPictureConfig = PictureInPictureConfig()
 
@@ -282,10 +283,10 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
         isPictureInPictureEnabledOnPlayer: Boolean,
         userInterfaceTypeName: String?,
     ) {
-        val playerModule = appContext.registry.getModule<PlayerModule>()
+        val playerModule = appContext.registry.getModule<PlayerModule>() ?: return
         // Player might not be initialized yet, this is a timing issue
         // Return early without throwing to avoid crash
-        val player = playerModule?.getPlayerOrNull(playerId) ?: return
+        val player = playerModule.getPlayerOrNull(playerId) ?: return
 
         if (playerView?.player == player) {
             // Player is already attached to the PlayerView
@@ -298,6 +299,8 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
         attachPlayerListeners(player)
         if (playerView != null) {
             playerView?.player = player
+            playerModule.assignAdContainer(playerId, playerView as ViewGroup)
+            onBmpAdContainerReady(emptyMap())
         } else {
             this.enableBackgroundPlayback = enableBackgroundPlayback
             val userInterfaceType = userInterfaceTypeName?.toUserInterfaceType() ?: UserInterfaceType.Bitmovin
@@ -332,6 +335,8 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
                 null
             }
             newPlayerView.setPictureInPictureHandler(pictureInPictureHandler)
+            playerModule.assignAdContainer(playerId, newPlayerView as ViewGroup)
+            onBmpAdContainerReady(emptyMap())
             setPlayerView(newPlayerView)
             attachPlayerViewListeners(newPlayerView)
 

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewManager.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerViewManager.kt
@@ -95,6 +95,7 @@ class RNPlayerViewManager : Module() {
             }
 
             Events(
+                "onBmpAdContainerReady",
                 "onBmpEvent",
                 "onBmpPlayerError",
                 "onBmpPlayerWarning",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,38 +1,34 @@
-import { NavigationContainer } from '@react-navigation/native';
-import {
-  createNativeStackNavigator,
-  type NativeStackNavigationProp,
-} from '@react-navigation/native-stack';
-import { AudioSession, type SourceType } from 'bitmovin-player-react-native';
 import React, { useEffect } from 'react';
-import { Button, Platform } from 'react-native';
+import { Platform, Button } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { AudioSession, SourceType } from 'bitmovin-player-react-native';
+import ExamplesList from './screens/ExamplesList';
 import BasicAds from './screens/BasicAds';
 import BasicAnalytics from './screens/BasicAnalytics';
-import BasicDrmPlayback from './screens/BasicDrmPlayback';
-import BasicFullscreenHandling from './screens/BasicFullscreenHandling';
 import BasicMetadata from './screens/BasicMetadata';
-import BasicPictureInPicture from './screens/BasicPictureInPicture';
 import BasicPlayback from './screens/BasicPlayback';
 import BasicTvPlayback from './screens/BasicTvPlayback';
-import CustomHtmlUi from './screens/CustomHtmlUi';
-import CustomPlayback from './screens/CustomPlayback';
-import CustomPlaybackForm from './screens/CustomPlaybackForm';
-import ExamplesList from './screens/ExamplesList';
-import ProgrammaticTrackSelection from './screens/ProgrammaticTrackSelection';
+import BasicDrmPlayback from './screens/BasicDrmPlayback';
 import SubtitlePlayback from './screens/SubtitlePlayback';
-
+import ProgrammaticTrackSelection from './screens/ProgrammaticTrackSelection';
+import CustomPlaybackForm from './screens/CustomPlaybackForm';
+import CustomPlayback from './screens/CustomPlayback';
+import BasicPictureInPicture from './screens/BasicPictureInPicture';
+import CustomHtmlUi from './screens/CustomHtmlUi';
+import BasicFullscreenHandling from './screens/BasicFullscreenHandling';
 // Import LandscapeFullscreenHandling only on non-TV platforms
 const LandscapeFullscreenHandling = Platform.isTV
   ? () => null
   : require('./screens/LandscapeFullscreenHandling').default;
-
-import * as Device from 'expo-device';
-import AudioFocusHandling from './screens/AudioFocusHandling';
-import BackgroundPlayback from './screens/BackgroundPlayback';
-import Casting from './screens/Casting';
-import MidrollIMAAds from './screens/MidrollIMAAds';
-import OfflinePlayback from './screens/OfflinePlayback';
 import SystemUI from './screens/SystemUi';
+import OfflinePlayback from './screens/OfflinePlayback';
+import Casting from './screens/Casting';
+import BackgroundPlayback from './screens/BackgroundPlayback';
+import AudioFocusHandling from './screens/AudioFocusHandling';
+import MidrollIMAAds from './screens/MidrollIMAAds';
+import * as Device from 'expo-device';
 
 export type RootStackParamsList = {
   ExamplesList: {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,33 +1,38 @@
-import React, { useEffect } from 'react';
-import { Platform, Button } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { AudioSession, SourceType } from 'bitmovin-player-react-native';
-import ExamplesList from './screens/ExamplesList';
+import {
+  createNativeStackNavigator,
+  type NativeStackNavigationProp,
+} from '@react-navigation/native-stack';
+import { AudioSession, type SourceType } from 'bitmovin-player-react-native';
+import React, { useEffect } from 'react';
+import { Button, Platform } from 'react-native';
 import BasicAds from './screens/BasicAds';
 import BasicAnalytics from './screens/BasicAnalytics';
+import BasicDrmPlayback from './screens/BasicDrmPlayback';
+import BasicFullscreenHandling from './screens/BasicFullscreenHandling';
 import BasicMetadata from './screens/BasicMetadata';
+import BasicPictureInPicture from './screens/BasicPictureInPicture';
 import BasicPlayback from './screens/BasicPlayback';
 import BasicTvPlayback from './screens/BasicTvPlayback';
-import BasicDrmPlayback from './screens/BasicDrmPlayback';
-import SubtitlePlayback from './screens/SubtitlePlayback';
-import ProgrammaticTrackSelection from './screens/ProgrammaticTrackSelection';
-import CustomPlaybackForm from './screens/CustomPlaybackForm';
-import CustomPlayback from './screens/CustomPlayback';
-import BasicPictureInPicture from './screens/BasicPictureInPicture';
 import CustomHtmlUi from './screens/CustomHtmlUi';
-import BasicFullscreenHandling from './screens/BasicFullscreenHandling';
+import CustomPlayback from './screens/CustomPlayback';
+import CustomPlaybackForm from './screens/CustomPlaybackForm';
+import ExamplesList from './screens/ExamplesList';
+import ProgrammaticTrackSelection from './screens/ProgrammaticTrackSelection';
+import SubtitlePlayback from './screens/SubtitlePlayback';
+
 // Import LandscapeFullscreenHandling only on non-TV platforms
 const LandscapeFullscreenHandling = Platform.isTV
   ? () => null
   : require('./screens/LandscapeFullscreenHandling').default;
-import SystemUI from './screens/SystemUi';
-import OfflinePlayback from './screens/OfflinePlayback';
-import Casting from './screens/Casting';
-import BackgroundPlayback from './screens/BackgroundPlayback';
-import AudioFocusHandling from './screens/AudioFocusHandling';
+
 import * as Device from 'expo-device';
+import AudioFocusHandling from './screens/AudioFocusHandling';
+import BackgroundPlayback from './screens/BackgroundPlayback';
+import Casting from './screens/Casting';
+import MidrollIMAAds from './screens/MidrollIMAAds';
+import OfflinePlayback from './screens/OfflinePlayback';
+import SystemUI from './screens/SystemUi';
 
 export type RootStackParamsList = {
   ExamplesList: {
@@ -70,6 +75,7 @@ export type RootStackParamsList = {
   SystemUI: undefined;
   BackgroundPlayback: undefined;
   AudioFocusHandling: undefined;
+  MidrollIMAAds: undefined;
 };
 
 const RootStack = createNativeStackNavigator<RootStackParamsList>();
@@ -127,6 +133,10 @@ export default function App() {
       {
         title: 'Background Playback',
         routeName: 'BackgroundPlayback' as keyof RootStackParamsList,
+      },
+      {
+        title: 'Midroll IMA Ads',
+        routeName: 'MidrollIMAAds' as keyof RootStackParamsList,
       },
     ],
   };
@@ -329,6 +339,11 @@ export default function App() {
           name="AudioFocusHandling"
           component={AudioFocusHandling}
           options={{ title: 'Audio Focus Handling' }}
+        />
+        <RootStack.Screen
+          name="MidrollIMAAds"
+          component={MidrollIMAAds}
+          options={{ title: 'Midroll IMA Ads' }}
         />
       </RootStack.Navigator>
     </NavigationContainer>

--- a/example/src/screens/MidrollIMAAds.tsx
+++ b/example/src/screens/MidrollIMAAds.tsx
@@ -1,0 +1,81 @@
+import { useFocusEffect } from '@react-navigation/native';
+import {
+  type Event,
+  PlayerView,
+  usePlayer,
+} from 'bitmovin-player-react-native';
+import React, { useCallback } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTVGestures } from '../hooks';
+
+function prettyPrint(header: string, obj: any) {
+  console.log(header, JSON.stringify(obj, null, 2));
+}
+
+export default function BasicPlayback() {
+  useTVGestures();
+
+  const player = usePlayer({
+    remoteControlConfig: {
+      isCastEnabled: false,
+    },
+  });
+
+  useFocusEffect(
+    useCallback(() => {
+      return () => {
+        player.destroy();
+      };
+    }, [player])
+  );
+  const onAdContainerReady = useCallback(() => {
+    player.loadDaiStream({
+      assetId: 'c-rArva4ShKVIAkNfy6HUQ',
+      fallbackUrl:
+        'https://cdn.bitmovin.com/content/internal/assets/MI201109210084/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8',
+      adTagParams: {},
+    });
+  }, [player]);
+
+  const onReady = useCallback((event: Event) => {
+    prettyPrint(`EVENT [${event.name}]`, event);
+  }, []);
+
+  const onEvent = useCallback((event: Event) => {
+    prettyPrint(`EVENT [${event.name}]`, event);
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <PlayerView
+        player={player}
+        style={styles.player}
+        onAdContainerReady={onAdContainerReady}
+        onPlay={onEvent}
+        onPlaying={onEvent}
+        onPaused={onEvent}
+        onReady={onReady}
+        onSourceLoaded={onEvent}
+        onSeek={onEvent}
+        onSeeked={onEvent}
+        onStallStarted={onEvent}
+        onStallEnded={onEvent}
+        onVideoPlaybackQualityChanged={onEvent}
+        onAudioAdded={onEvent}
+        onAudioChanged={onEvent}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'black',
+  },
+  player: {
+    flex: 1,
+  },
+});

--- a/example/src/screens/MidrollIMAAds.tsx
+++ b/example/src/screens/MidrollIMAAds.tsx
@@ -8,11 +8,11 @@ import React, { useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTVGestures } from '../hooks';
 
-function prettyPrint(header: string, obj: any) {
+function prettyPrint(header: string, obj: unknown) {
   console.log(header, JSON.stringify(obj, null, 2));
 }
 
-export default function BasicPlayback() {
+export default function MidrollIMAAds() {
   useTVGestures();
 
   const player = usePlayer({

--- a/ios/BitmovinVideoDisplay.swift
+++ b/ios/BitmovinVideoDisplay.swift
@@ -1,0 +1,228 @@
+#if canImport(GoogleInteractiveMediaAds) && os(iOS)
+import AVFoundation
+import BitmovinPlayer
+import GoogleInteractiveMediaAds
+import UIKit
+
+/// Bridges Bitmovin Player to the Google IMA SDK's IMAVideoDisplay protocol for DAI (Dynamic Ad Insertion).
+/// Forwards player events to the IMA delegate so the SDK can control and monitor playback.
+internal final class BitmovinVideoDisplay: NSObject, IMAVideoDisplay {
+    weak var delegate: IMAVideoDisplayDelegate?
+    private weak var player: Player?
+    private let eventForwarder: IMAEventForwarder
+    /// Tracks whether we've sent videoDisplayDidStart for the current stream.
+    /// IMA expects didStart only on first play, didResume on resume after pause.
+    private var hasReportedStart = false
+
+    init(player: Player) {
+        self.player = player
+        self.eventForwarder = IMAEventForwarder()
+        super.init()
+        eventForwarder.videoDisplay = self
+        player.add(listener: eventForwarder)
+    }
+
+    deinit {
+        player?.remove(listener: eventForwarder)
+    }
+
+    // MARK: - IMAVideoDisplay
+
+    func loadStream(_ streamURL: URL, withSubtitles subtitles: [[String: String]]) {
+        hasReportedStart = false
+        // IMA DAI returns HLS; fallback to .hls type for compatibility
+        let sourceConfig = SourceConfig(url: streamURL, type: .hls)
+        player?.load(sourceConfig: sourceConfig)
+    }
+
+    func play() {
+        player?.play()
+    }
+
+    func pause() {
+        player?.pause()
+    }
+
+    func reset() {
+        hasReportedStart = false
+        player?.unload()
+    }
+
+    func seekStream(toTime time: TimeInterval) {
+        guard let player else { return }
+        if player.isLive {
+            // Bitmovin: timeShift is 0 at live edge, negative going backward. IMA passes absolute stream time.
+            // Live edge absolute time = current absolute time - current timeShift.
+            let liveEdgeAbsoluteTime = player.currentTime(.absoluteTime) - player.timeShift
+            player.timeShift = time - liveEdgeAbsoluteTime
+        } else {
+            player.seek(time: time)
+        }
+    }
+
+    // MARK: - Volume
+
+    var volume: Float {
+        get {
+            guard let player else { return 1.0 }
+            return Float(player.volume) / 100.0
+        }
+        set {
+            player?.volume = Int(newValue * 100)
+            delegate?.videoDisplay(self, volumeChangedTo: NSNumber(value: newValue))
+        }
+    }
+
+    // MARK: - IMAAdPlaybackInfo
+
+    /// Use absolute time so IMA gets the same timeline as didProgressWithMediaTime (live streams use UTC).
+    var currentMediaTime: TimeInterval {
+        player?.currentTime(.absoluteTime) ?? 0
+    }
+
+    var totalMediaTime: TimeInterval {
+        guard let player else { return 0 }
+        return player.isLive ? 0 : player.duration
+    }
+
+    /// IMA expects bufferedMediaTime on the same absolute timeline as currentMediaTime.
+    /// forwardDuration is relative (e.g. 5.0 sec); convert to absolute: currentAbsolute + forwardBuffer.
+    var bufferedMediaTime: TimeInterval {
+        guard let player else { return 0 }
+        let currentAbsolute = player.currentTime(.absoluteTime)
+        let forwardBuffer = player.buffer.getLevel(.forwardDuration).level ?? 0
+        return currentAbsolute + forwardBuffer
+    }
+
+    var isPlaying: Bool {
+        player?.isPlaying ?? false
+    }
+
+    // MARK: - Internal callbacks from event forwarder
+
+    fileprivate func onReady() {
+        // Only report loaded/ready here. Per IMA semantics, videoDisplayDidStart = "starts playing for the first time";
+        // we report that in onPlay() when playback actually starts.
+        delegate?.videoDisplayDidLoad(self)
+        delegate?.videoDisplayIsPlaybackReady?(self)
+    }
+
+    fileprivate func onTimeChanged() {
+        guard let player else { return }
+        delegate?.videoDisplay(
+            self,
+            didProgressWithMediaTime: player.currentTime(.absoluteTime),
+            totalTime: player.isLive ? 0 : player.duration
+        )
+    }
+
+    fileprivate func onPlaybackFinished() {
+        delegate?.videoDisplayDidComplete(self)
+    }
+
+    fileprivate func onPaused() {
+        delegate?.videoDisplayDidPause(self)
+    }
+
+    fileprivate func onPlay() {
+        if !hasReportedStart {
+            hasReportedStart = true
+            delegate?.videoDisplayDidStart(self)
+        } else {
+            delegate?.videoDisplayDidResume(self)
+        }
+    }
+
+    fileprivate func onStallStarted() {
+        delegate?.videoDisplayDidStartBuffering?(self)
+    }
+
+    fileprivate func onStallEnded() {
+        delegate?.videoDisplayIsPlaybackReady?(self)
+    }
+
+    fileprivate func onError(_ error: NSError) {
+        delegate?.videoDisplay(self, didReceiveError: error)
+    }
+
+    fileprivate func onMetadata(_ metadata: [String: String]) {
+        delegate?.videoDisplay(self, didReceiveTimedMetadata: metadata)
+    }
+}
+
+// MARK: - PlayerListener that forwards events to IMA delegate
+
+private final class IMAEventForwarder: NSObject, PlayerListener {
+    weak var videoDisplay: BitmovinVideoDisplay?
+
+    func onReady(_ event: ReadyEvent, player: Player) {
+        videoDisplay?.onReady()
+    }
+
+    func onTimeChanged(_ event: TimeChangedEvent, player: Player) {
+        videoDisplay?.onTimeChanged()
+    }
+
+    func onPlaybackFinished(_ event: PlaybackFinishedEvent, player: Player) {
+        videoDisplay?.onPlaybackFinished()
+    }
+
+    func onPaused(_ event: PausedEvent, player: Player) {
+        videoDisplay?.onPaused()
+    }
+
+    func onPlay(_ event: PlayEvent, player: Player) {
+        videoDisplay?.onPlay()
+    }
+
+    func onStallStarted(_ event: StallStartedEvent, player: Player) {
+        videoDisplay?.onStallStarted()
+    }
+
+    func onStallEnded(_ event: StallEndedEvent, player: Player) {
+        videoDisplay?.onStallEnded()
+    }
+
+    func onSourceError(_ event: SourceErrorEvent, player: Player) {
+        let error = NSError(
+            domain: "BitmovinPlayerSourceError",
+            code: event.code.rawValue,
+            userInfo: [NSLocalizedDescriptionKey: event.message]
+        )
+        videoDisplay?.onError(error)
+    }
+
+    func onPlayerError(_ event: PlayerErrorEvent, player: Player) {
+        let error = NSError(
+            domain: "BitmovinPlayerPlayerError",
+            code: event.code.rawValue,
+            userInfo: [NSLocalizedDescriptionKey: event.message]
+        )
+        videoDisplay?.onError(error)
+    }
+
+    func onMetadata(_ event: MetadataEvent, player: Player) {
+        guard event.metadataType == .ID3 else {
+            return
+        }
+        let metadata: [String: String] = metadataDict(from: event)
+        if !metadata.isEmpty {
+            videoDisplay?.onMetadata(metadata)
+        }
+    }
+}
+
+// MARK: - MetadataEvent → [String: String] for IMA DAI (ID3 TXXX cue points)
+
+private func metadataDict(from event: MetadataEvent) -> [String: String] {
+    event.metadata.entries
+        .compactMap { $0 as? AVMetadataItem }
+        .reduce(into: [:]) { partialResult, entry in
+            guard let key = entry.key,
+                  let value = entry.value else {
+                return
+            }
+            partialResult["\(key)"] = "\(value)"
+        }
+}
+#endif

--- a/ios/IMAAdsWrapper.swift
+++ b/ios/IMAAdsWrapper.swift
@@ -1,0 +1,225 @@
+#if canImport(GoogleInteractiveMediaAds) && os(iOS)
+import BitmovinPlayer
+import GoogleInteractiveMediaAds
+import UIKit
+
+/// Wraps the Google IMA DAI (Dynamic Ad Insertion) flow for a Bitmovin Player.
+/// Requests the stream from IMA, bridges playback via BitmovinVideoDisplay, and falls back to fallbackUrl on error.
+internal final class IMAAdsWrapper: NSObject {
+    private var streamManager: IMAStreamManager?
+    private var adsLoader: IMAAdsLoader?
+    private var pendingRequestedAssetId: String?
+    private var adDisplayContainer: IMAAdDisplayContainer?
+    private var fallbackUrl: String?
+    private var adTagParams: [String: String]?
+    private weak var player: Player?
+    private var bitmovinVideoDisplay: BitmovinVideoDisplay?
+
+    init(player: Player) {
+        self.player = player
+        super.init()
+    }
+
+    func setAdUiContainer(_ adUiContainer: UIView) {
+        guard adDisplayContainer == nil else {
+            return
+        }
+
+        guard adUiContainer.window != nil else {
+            // View not in window yet (e.g. attachPlayer ran before layout). RNPlayerView will
+            // call assignAdContainer again from layoutSubviews when the view has a window.
+            return
+        }
+
+        guard let viewController = Self.findViewController(for: adUiContainer) else {
+            print("[Bitmovin IMA] Unable to determine view controller for ad UI container")
+            return
+        }
+
+        adDisplayContainer = IMAAdDisplayContainer(
+            adContainer: adUiContainer,
+            viewController: viewController,
+            companionSlots: nil
+        )
+
+        createAdsLoader()
+
+        if let assetId = pendingRequestedAssetId {
+            pendingRequestedAssetId = nil
+            requestAndLoadStream(assetId)
+        }
+    }
+
+    func requestAndLoadStream(_ assetId: String) {
+        guard let adsLoader else {
+            print("[Bitmovin IMA] AdsLoader is not initialized, storing assetId for later")
+            pendingRequestedAssetId = assetId
+            return
+        }
+
+        pendingRequestedAssetId = nil
+        guard let streamRequest = buildStreamRequest(assetId: assetId) else {
+            loadFallbackUrl()
+            return
+        }
+        adsLoader.requestStream(with: streamRequest)
+    }
+
+    func setFallbackUrl(_ url: String?) {
+        fallbackUrl = url
+    }
+
+    func setAdTagParams(_ params: [String: Any]?) {
+        guard let params else {
+            adTagParams = nil
+            return
+        }
+        adTagParams = params.compactMapValues { $0 as? String }
+    }
+}
+
+// MARK: - Private helpers
+
+private extension IMAAdsWrapper {
+    func loadFallbackUrl() {
+        guard let player,
+              let fallbackUrl,
+              let url = URL(string: fallbackUrl) else {
+            return
+        }
+        print("[Bitmovin IMA] Loading fallback URL: \(url)")
+        let sourceConfig = SourceConfig(url: url, type: .hls)
+        player.load(sourceConfig: sourceConfig)
+    }
+
+    func createAdsLoader() {
+        guard adsLoader == nil else {
+            print("[Bitmovin IMA] AdsLoader already created, skipping")
+            return
+        }
+        guard let adDisplayContainer else {
+            print("[Bitmovin IMA] Ad display container is not available")
+            return
+        }
+        guard let player else {
+            print("[Bitmovin IMA] Player is not available")
+            return
+        }
+        print("Bitmovin IMA: createAdsLoader")
+
+        let settings = IMASettings()
+        bitmovinVideoDisplay = BitmovinVideoDisplay(player: player)
+        adsLoader = IMAAdsLoader(settings: settings)
+        adsLoader?.delegate = self
+    }
+
+    func buildStreamRequest(assetId: String) -> IMAStreamRequest? {
+        guard let adDisplayContainer,
+              let bitmovinVideoDisplay else {
+            print("[Bitmovin IMA] Ad display container or video display not available, falling back to content URL")
+            return nil
+        }
+        print("Bitmovin IMA: buildStreamRequest")
+        let request = IMALiveStreamRequest(
+            assetKey: assetId,
+            adDisplayContainer: adDisplayContainer,
+            videoDisplay: bitmovinVideoDisplay,
+            userContext: nil
+        )
+        if let adTagParams, !adTagParams.isEmpty {
+            request.adTagParameters = adTagParams
+        }
+        return request
+    }
+}
+
+// MARK: - IMAAdsLoaderDelegate
+
+extension IMAAdsWrapper: IMAAdsLoaderDelegate {
+    func adsLoader(_ loader: IMAAdsLoader, adsLoadedWith adsLoadedData: IMAAdsLoadedData) {
+        streamManager = adsLoadedData.streamManager
+        streamManager?.delegate = self
+        let adsRenderingSettings = IMAAdsRenderingSettings()
+        streamManager?.initialize(with: adsRenderingSettings)
+    }
+
+    func adsLoader(_ loader: IMAAdsLoader, failedWith adErrorData: IMAAdLoadingErrorData) {
+        print("[Bitmovin IMA] Ad load error: \(adErrorData.adError.message ?? "Unknown")")
+        loadFallbackUrl()
+    }
+}
+
+// MARK: - IMAStreamManagerDelegate
+
+extension IMAAdsWrapper: IMAStreamManagerDelegate {
+    func streamManager(_ streamManager: IMAStreamManager, didReceive event: IMAAdEvent) {
+        switch event.type {
+        case .AD_BREAK_STARTED:
+            print("[Bitmovin IMA] Event: AD_BREAK_STARTED")
+        case .AD_BREAK_ENDED:
+            print("[Bitmovin IMA] Event: AD_BREAK_ENDED")
+        case .TAPPED:
+            guard let player else { return }
+            if player.isPlaying {
+                player.pause()
+            } else {
+                player.play()
+            }
+        default:
+            break
+        }
+    }
+
+    func streamManager(_ streamManager: IMAStreamManager, didReceive error: IMAAdError) {
+        print("[Bitmovin IMA] Stream manager error: \(error.message ?? "Unknown")")
+        loadFallbackUrl()
+    }
+}
+
+// MARK: - View controller resolution
+
+private extension IMAAdsWrapper {
+    static func findViewController(for view: UIView) -> UIViewController? {
+        if let nearest = view.nearestViewController {
+            return topViewController(from: nearest)
+        }
+        let window: UIWindow? = view.window
+            ?? UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .filter { $0.activationState == .foregroundActive }
+                .flatMap { $0.windows }
+                .first { $0.isKeyWindow }
+        guard let root = window?.rootViewController else { return nil }
+        return topViewController(from: root)
+    }
+
+    static func topViewController(from root: UIViewController?) -> UIViewController? {
+        guard var current = root else { return nil }
+        while true {
+            if let presented = current.presentedViewController {
+                current = presented
+            } else if let nav = current as? UINavigationController, let visible = nav.visibleViewController {
+                current = visible
+            } else if let tab = current as? UITabBarController, let selected = tab.selectedViewController {
+                current = selected
+            } else if let page = current as? UIPageViewController, let first = page.viewControllers?.first {
+                current = first
+            } else {
+                break
+            }
+        }
+        return current
+    }
+}
+
+private extension UIView {
+    var nearestViewController: UIViewController? {
+        var responder: UIResponder? = self
+        while let current = responder {
+            if let controller = current as? UIViewController { return controller }
+            responder = current.next
+        }
+        return nil
+    }
+}
+#endif

--- a/ios/PlayerModule.swift
+++ b/ios/PlayerModule.swift
@@ -1,23 +1,33 @@
 import BitmovinPlayer
 import ExpoModulesCore
+#if canImport(GoogleInteractiveMediaAds) && os(iOS)
+import UIKit
+#endif
 
 // swiftlint:disable:next type_body_length
 public class PlayerModule: Module {
     private let imaSettingsWaiter = ResultWaiter<[String: Any]>()
 
-    // swiftlint:disable:next function_body_length
+    #if canImport(GoogleInteractiveMediaAds) && os(iOS)
+    private var adsWrappers: [String: IMAAdsWrapper] = [:]
+    #endif
+
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     public func definition() -> ModuleDefinition {
         Name("PlayerModule")
         OnCreate {}
-        OnDestroy {
+        OnDestroy { [weak self] in
+            self?.imaSettingsWaiter.removeAll()
             // Destroy all players on the main thread when the module is deallocated.
             // This is necessary when the IMA SDK is present in the app,
             // as it may crash if the players are destroyed on a background thread.
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak self] in
                 PlayerRegistry.getAllPlayers().forEach { $0.destroy() }
                 PlayerRegistry.clear()
+                #if canImport(GoogleInteractiveMediaAds) && os(iOS)
+                self?.adsWrappers.removeAll()
+                #endif
             }
-            imaSettingsWaiter.removeAll()
         }
         Events("onImaBeforeInitialization")
         AsyncFunction("play") { (nativeId: NativeId) in
@@ -38,11 +48,14 @@ public class PlayerModule: Module {
         AsyncFunction("timeShift") { (nativeId: NativeId, offset: Double) in
             PlayerRegistry.getPlayer(nativeId: nativeId)?.timeShift = offset
         }.runOnQueue(.main)
-        AsyncFunction("destroy") { (nativeId: NativeId) in
+        AsyncFunction("destroy") { [weak self] (nativeId: NativeId) in
             if let player = PlayerRegistry.getPlayer(nativeId: nativeId) {
                 player.destroy()
                 PlayerRegistry.unregister(nativeId: nativeId)
             }
+            #if canImport(GoogleInteractiveMediaAds) && os(iOS)
+            self?.adsWrappers[nativeId] = nil
+            #endif
         }.runOnQueue(.main)
         AsyncFunction("setVolume") { (nativeId: NativeId, volume: Int) in
             PlayerRegistry.getPlayer(nativeId: nativeId)?.volume = volume
@@ -192,6 +205,9 @@ public class PlayerModule: Module {
             self?.setupImaBeforeInitialization(nativeId: nativeId, config: config, playerConfig: playerConfig)
             let player = PlayerFactory.create(playerConfig: playerConfig)
             PlayerRegistry.register(player: player, nativeId: nativeId)
+            #if canImport(GoogleInteractiveMediaAds) && os(iOS)
+            self?.adsWrappers[nativeId] = IMAAdsWrapper(player: player)
+            #endif
         }.runOnQueue(.main)
         AsyncFunction(
             "initializeWithAnalyticsConfig"
@@ -213,6 +229,24 @@ public class PlayerModule: Module {
                 defaultMetadata: defaultMetadata ?? DefaultMetadata()
             )
             PlayerRegistry.register(player: player, nativeId: nativeId)
+            #if canImport(GoogleInteractiveMediaAds) && os(iOS)
+            self?.adsWrappers[nativeId] = IMAAdsWrapper(player: player)
+            #endif
+        }.runOnQueue(.main)
+        // swiftlint:disable:next line_length
+        AsyncFunction("loadDaiStream") { [weak self] (nativeId: NativeId, assetId: String, fallbackUrl: String, adTagParams: [String: Any]?) in
+            guard let player = PlayerRegistry.getPlayer(nativeId: nativeId) else { return }
+            #if canImport(GoogleInteractiveMediaAds) && os(iOS)
+            if let adsWrapper = self?.adsWrappers[nativeId] {
+                adsWrapper.setFallbackUrl(fallbackUrl)
+                adsWrapper.setAdTagParams(adTagParams)
+                adsWrapper.requestAndLoadStream(assetId)
+            } else {
+                self?.loadFallbackUrl(player: player, fallbackUrl: fallbackUrl)
+            }
+            #else
+            self?.loadFallbackUrl(player: player, fallbackUrl: fallbackUrl)
+            #endif
         }.runOnQueue(.main)
         AsyncFunction("loadSource") { [weak self] (nativeId: NativeId, sourceNativeId: NativeId) in
             guard let player = PlayerRegistry.getPlayer(nativeId: nativeId),
@@ -227,6 +261,13 @@ public class PlayerModule: Module {
     public func retrieve(_ nativeId: NativeId) -> Player? {
         PlayerRegistry.getPlayer(nativeId: nativeId)
     }
+
+    #if canImport(GoogleInteractiveMediaAds) && os(iOS)
+    /// Assigns the ad container view for IMA DAI. Call from the player view when the native view is attached.
+    public func assignAdContainer(nativeId: NativeId, adUiContainer: UIView) {
+        adsWrappers[nativeId]?.setAdUiContainer(adUiContainer)
+    }
+    #endif
 
     private func setupRemoteControlConfig(_ remoteControlConfig: RemoteControlConfig) {
         remoteControlConfig.prepareSource = { [weak self] _, sourceConfig in
@@ -275,5 +316,12 @@ public class PlayerModule: Module {
             guard let updated = wait() else { return }
             RCTConvert.applyImaSettings(settings, from: updated)
         }
+    }
+
+    /// Loads the fallback URL into the player (e.g. when IMA is unavailable or not configured).
+    private func loadFallbackUrl(player: Player, fallbackUrl: String) {
+        guard let url = URL(string: fallbackUrl) else { return }
+        let sourceConfig = SourceConfig(url: url, type: .hls)
+        player.load(sourceConfig: sourceConfig)
     }
 }

--- a/ios/RNPlayerView.swift
+++ b/ios/RNPlayerView.swift
@@ -1,6 +1,9 @@
 // swiftlint:disable file_length
 import BitmovinPlayer
 import ExpoModulesCore
+#if canImport(GoogleInteractiveMediaAds) && os(iOS)
+import UIKit
+#endif
 
 public class RNPlayerView: ExpoView {
     var playerView: PlayerView? {
@@ -113,6 +116,7 @@ public class RNPlayerView: ExpoView {
     let onBmpMetadata = EventDispatcher()
     let onBmpMetadataParsed = EventDispatcher()
     let onBmpFairplayLicenseAcquired = EventDispatcher()
+    let onBmpAdContainerReady = EventDispatcher()
 
     required init(appContext: AppContext? = nil) {
         super.init(appContext: appContext)
@@ -122,6 +126,17 @@ public class RNPlayerView: ExpoView {
     override public func layoutSubviews() {
         super.layoutSubviews()
         maybeFixAVPlayerViewControllerVisibility()
+        #if canImport(GoogleInteractiveMediaAds) && os(iOS)
+        // IMA needs the ad container to be in a window. assignAdContainer may have been
+        // called from attachPlayer before the view was in the hierarchy; retry when we have a window.
+        if let playerId, let playerView, playerView.window != nil {
+            self.appContext?.moduleRegistry.get(PlayerModule.self)?.assignAdContainer(
+                nativeId: playerId,
+                adUiContainer: playerView
+            )
+            onBmpAdContainerReady([:])
+        }
+        #endif
     }
 
     internal func attachPlayer(
@@ -162,6 +177,16 @@ public class RNPlayerView: ExpoView {
 
         player.add(listener: self)
         playerView?.add(listener: self)
+
+        #if canImport(GoogleInteractiveMediaAds) && os(iOS)
+        if let playerView {
+            self.appContext?.moduleRegistry.get(PlayerModule.self)?.assignAdContainer(
+                nativeId: playerId,
+                adUiContainer: playerView
+            )
+            onBmpAdContainerReady([:])
+        }
+        #endif
 
         self.maybeEmitPictureInPictureAvailabilityEvent(
             previousState: previousPictureInPictureAvailableValue

--- a/ios/RNPlayerViewManager.swift
+++ b/ios/RNPlayerViewManager.swift
@@ -73,6 +73,7 @@ public class RNPlayerViewManager: Module {
                 "onBmpPictureInPictureExited",
                 "onBmpAdBreakFinished",
                 "onBmpAdBreakStarted",
+                "onBmpAdContainerReady",
                 "onBmpAdClicked",
                 "onBmpAdError",
                 "onBmpAdFinished",

--- a/src/components/PlayerView/events.ts
+++ b/src/components/PlayerView/events.ts
@@ -77,6 +77,11 @@ import {
  */
 export type PlayerViewEvents = {
   /**
+   * Event emitted when the native ad container has been assigned (IMA DAI).
+   * Safe to call `Player.loadDaiStream` after this.
+   */
+  onAdContainerReady?: () => void;
+  /**
    * Event emitted when an ad break has finished.
    */
   onAdBreakFinished?: (event: AdBreakFinishedEvent) => void;

--- a/src/components/PlayerView/index.tsx
+++ b/src/components/PlayerView/index.tsx
@@ -135,6 +135,11 @@ export function PlayerView({
       isPictureInPictureRequested={isPictureInPictureRequested}
       scalingMode={scalingMode}
       fullscreenBridgeId={fullscreenBridge.current?.nativeId}
+      onBmpAdContainerReady={
+        props.onAdContainerReady
+          ? (_event) => props.onAdContainerReady?.()
+          : undefined
+      }
       onBmpAdBreakFinished={proxy(props.onAdBreakFinished)}
       onBmpAdBreakStarted={proxy(props.onAdBreakStarted)}
       onBmpAdClicked={proxy(props.onAdClicked)}

--- a/src/components/PlayerView/nativeEvents.ts
+++ b/src/components/PlayerView/nativeEvents.ts
@@ -74,6 +74,13 @@ import {
  */
 export type NativePlayerViewEvents = {
   /**
+   * Event emitted when the native ad container has been assigned (IMA DAI).
+   * Safe to call `Player.loadDaiStream` after this.
+   */
+  onBmpAdContainerReady?: (event: {
+    nativeEvent: Record<string, unknown>;
+  }) => void;
+  /**
    * Event emitted when an ad break has finished.
    */
   onBmpAdBreakFinished?: (event: { nativeEvent: AdBreakFinishedEvent }) => void;

--- a/src/modules/PlayerModule.ts
+++ b/src/modules/PlayerModule.ts
@@ -200,6 +200,20 @@ declare class PlayerModule extends NativeModule<PlayerModuleEvents> {
   loadSource(nativeId: string, sourceNativeId: string): Promise<void>;
 
   /**
+   * Load a DAI (Dynamic Ad Insertion) stream via IMA SSAI.
+   * @param nativeId - Player native id
+   * @param assetId - IMA asset key / stream asset ID
+   * @param fallbackUrl - HLS URL to load if IMA fails
+   * @param adTagParams - Optional key-value params for the ad tag (e.g. for targeting)
+   */
+  loadDaiStream(
+    nativeId: string,
+    assetId: string,
+    fallbackUrl: string,
+    adTagParams: Record<string, string>
+  ): Promise<void>;
+
+  /**
    * Load offline content into the player.
    */
   loadOfflineContent(

--- a/src/player.ts
+++ b/src/player.ts
@@ -1,19 +1,19 @@
-import type { EventSubscription } from 'expo-modules-core';
+import { EventSubscription } from 'expo-modules-core';
 import { Platform } from 'react-native';
-import type { AdItem, ImaSettings } from './advertising';
-import { AnalyticsApi } from './analytics/player';
-import type { AudioTrack } from './audioTrack';
-import { BufferApi } from './bufferApi';
-import { DecoderConfigBridge } from './decoder';
-import type { VideoQuality } from './media';
 import PlayerModule from './modules/PlayerModule';
 import NativeInstance from './nativeInstance';
+import { Source, SourceConfig } from './source';
+import { AudioTrack } from './audioTrack';
+import { SubtitleTrack } from './subtitleTrack';
+import { OfflineContentManager, OfflineSourceOptions } from './offline';
+import { Thumbnail } from './thumbnail';
+import { AnalyticsApi } from './analytics/player';
+import { PlayerConfig } from './playerConfig';
+import { AdItem, ImaSettings } from './advertising';
+import { BufferApi } from './bufferApi';
+import { VideoQuality } from './media';
 import { Network } from './network';
-import type { OfflineContentManager, OfflineSourceOptions } from './offline';
-import type { PlayerConfig } from './playerConfig';
-import { Source, type SourceConfig } from './source';
-import type { SubtitleTrack } from './subtitleTrack';
-import type { Thumbnail } from './thumbnail';
+import { DecoderConfigBridge } from './decoder';
 
 /**
  * Loads, controls and renders audio and video content represented through {@link Source}s. A player

--- a/src/player.ts
+++ b/src/player.ts
@@ -110,6 +110,26 @@ export class Player extends NativeInstance<PlayerConfig> {
   };
 
   /**
+   * Loads a DAI stream from an IMA asset id (SSAI). Wait for `onAdContainerReady` on the attached
+   * `PlayerView` before calling.
+   * @param assetId - IMA asset key / stream asset ID
+   * @param fallbackUrl - Stream URL to load if IMA fails
+   * @param adTagParams - Key-value params for the ad tag (e.g. targeting)
+   */
+  loadDaiStream = (
+    assetId: string,
+    fallbackUrl: string,
+    adTagParams: Record<string, string>
+  ) => {
+    void PlayerModule.loadDaiStream(
+      this.nativeId,
+      assetId,
+      fallbackUrl,
+      adTagParams
+    );
+  };
+
+  /**
    * Loads the downloaded content from {@link OfflineContentManager} into the player.
    */
   loadOfflineContent = (

--- a/src/player.ts
+++ b/src/player.ts
@@ -1,19 +1,19 @@
-import { EventSubscription } from 'expo-modules-core';
+import type { EventSubscription } from 'expo-modules-core';
 import { Platform } from 'react-native';
+import type { AdItem, ImaSettings } from './advertising';
+import { AnalyticsApi } from './analytics/player';
+import type { AudioTrack } from './audioTrack';
+import { BufferApi } from './bufferApi';
+import { DecoderConfigBridge } from './decoder';
+import type { VideoQuality } from './media';
 import PlayerModule from './modules/PlayerModule';
 import NativeInstance from './nativeInstance';
-import { Source, SourceConfig } from './source';
-import { AudioTrack } from './audioTrack';
-import { SubtitleTrack } from './subtitleTrack';
-import { OfflineContentManager, OfflineSourceOptions } from './offline';
-import { Thumbnail } from './thumbnail';
-import { AnalyticsApi } from './analytics/player';
-import { PlayerConfig } from './playerConfig';
-import { AdItem, ImaSettings } from './advertising';
-import { BufferApi } from './bufferApi';
-import { VideoQuality } from './media';
 import { Network } from './network';
-import { DecoderConfigBridge } from './decoder';
+import type { OfflineContentManager, OfflineSourceOptions } from './offline';
+import type { PlayerConfig } from './playerConfig';
+import { Source, type SourceConfig } from './source';
+import type { SubtitleTrack } from './subtitleTrack';
+import type { Thumbnail } from './thumbnail';
 
 /**
  * Loads, controls and renders audio and video content represented through {@link Source}s. A player
@@ -116,11 +116,15 @@ export class Player extends NativeInstance<PlayerConfig> {
    * @param fallbackUrl - Stream URL to load if IMA fails
    * @param adTagParams - Key-value params for the ad tag (e.g. targeting)
    */
-  loadDaiStream = (
-    assetId: string,
-    fallbackUrl: string,
-    adTagParams: Record<string, string>
-  ) => {
+  loadDaiStream = ({
+    assetId,
+    fallbackUrl,
+    adTagParams,
+  }: {
+    assetId: string;
+    fallbackUrl: string;
+    adTagParams: Record<string, string>;
+  }) => {
     void PlayerModule.loadDaiStream(
       this.nativeId,
       assetId,


### PR DESCRIPTION
## Description
This addition enables the use of Google IMA server-side dynamic ad insertion. The user passes an asset id which the IMA SDK uses to insert midroll ads into a live stream video and loads that new video file with ads into the Bitmovin Player.

An IMAAdsWrapper instance is created along with the Bitmovin player.

RNPlayerView attaches an adContainer to the Player which allows the ads to be played and metadata reported, plus it shows the Learn More link and ad timer.

There are callbacks which detect ad events and report back to Google to log ad visibility. There are also events exposed to allow the user to take actions on ad events, though many of these are currently not implemented.

In React Native, the user passes an assetId, a fallbackUrl, and adTagParams to a new function in player.ts called `loadDaiStream`. This calls a corresponding method in the PlayerModule which sets some properties in the IMAAdsWrapper and uses the IMA functionality of `requestAndLoadStream` to stitch the ads and load the new video.

One quirk is I've had to ad a `onBmpAdContainerReady` event that tells the JS side when the container is ready. This has to be true before `loadDaiStream` can be called to kick off the actual stream request. Right now the user has to utilize this callback to load the video in React Native instead of calling `player.load()` in a regular useEffect. Perhaps there's a better way to do this natively.

It also adds an sample screen to the example app with a Big Buck Bunny sample stream assetId from Google, and the Bitmovin sample video as a fallback. If the Bitmovin video plays, it means there was a problem with the IMA flow.

## Changes
Many changes are noted above. The largest changes are the new files added like `IMAAdsWrapper`, `BitmovinVideoDisplay.swift` on the iOS side which helps the IMA stream communicate with the base Bitmovin player, and the changes to the creation of the player itself to also create the ad container and get things ready for an IMA DAI stream.

TBH it's been a while since I implemented the Android side, and recently I implemented the iOS side with lots of help from Cursor and this POC from the Bitmovin team on an older version of the library: https://github.com/bitmovin/bitmovin-player-react-native/pull/679/changes#diff-b8e2561e633a82b40ce1931673d42270e00645bcdeb76b21d69ff2c77e1dcde0

Documentation from Google on IMA integration found here: https://developers.google.com/ad-manager/dynamic-ad-insertion/sdk/android/get-started?service=full

## Checklist
- [ ] 🗒 `CHANGELOG` entry
