### PR TITLE
Fix multiple issues with version 1.16 and 1.17 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,38 +1,25 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Update Bitmovin's native iOS SDK version to `3.111.1`
+
 ## [1.17.0] - 2026-04-17
 
 ### Changed
 
 - Update Bitmovin's native Android SDK version to `3.149.0+jason`
 - Update Expo SDK version to `54.0.33` and React Native version to `0.81.5`
-- Minimum supported Expo SDK version is now `54`
-- Minimum supported React Native version is now `0.81.5`
-
-## [1.16.0] - 2026-04-10
-
-## [1.16.0] - 2026-04-10
-
-### Changed
-
-- Update Bitmovin's native Android SDK version to `3.149.0+jason`
-- Update Expo SDK version to `54.0.33` and React Native version to `0.81.5`
-- Minimum supported Expo SDK version is now `54`
-- Minimum supported React Native version is now `0.81.5`
-
-### Changed
-
-- Update Bitmovin's native iOS SDK version to `3.111.1`
+  - Minimum supported Expo SDK version is now `54`
+  - Minimum supported React Native version is now `0.81.5`
 
 ## [1.16.0] - 2026-04-10
 
 ### Added
 
 - Android: `PlayerView.isPictureInPictureEnabled` to enable or disable Picture in Picture availability dynamically after player initialization
-
-### Fixed
-
-- Android: `OfflineDownloadRequest.minimumBitrate` not correctly parsed from React Native for offline rendition selection
 
 ### Changed
 
@@ -41,6 +28,7 @@
 
 ### Fixed
 
+- Android: `OfflineDownloadRequest.minimumBitrate` not correctly parsed from React Native for offline rendition selection
 - Android: Picture in Picture fragmented rendering when resizing the PiP window
 
 ## [1.15.0] - 2026-03-27


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->

The changelog has some issues on the recent versions. This PR:
- adds the missing Unreleased section, and move the new iOS `3.111.1` SDK update there
- Removes duplicated `1.16.0` section
- Removes wrong and duplicated entries about Expo/RN update being under `1.16.0` section instead of `1.17.0`
- Nests the Expo/RN minimum requirements under the same expo update bullet point to group them better

## Checklist
- [x] 🗒 `CHANGELOG` entry - `n/a`
