### PR TITLE
Expose Android shouldPlayAdBreak callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Android: `AdvertisingConfig.shouldPlayAdBreak` callback to decide at runtime whether a scheduled ad break should play
+
 ## [1.18.0] - 2026-05-01
 
 ### Added

--- a/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
@@ -24,6 +24,7 @@ class PlayerModule : Module() {
 
     val mediaSessionPlaybackManager by lazy { MediaSessionPlaybackManager(appContext) }
     private val shouldLoadAdItemWaiter = ResultWaiter<Boolean>()
+    private val shouldPlayAdBreakWaiter = ResultWaiter<Boolean>()
     private val imaSettingsWaiter = ResultWaiter<Map<String, Any?>>()
 
     override fun definition() = ModuleDefinition {
@@ -43,11 +44,12 @@ class PlayerModule : Module() {
                 }
             }
             shouldLoadAdItemWaiter.clear()
+            shouldPlayAdBreakWaiter.clear()
             imaSettingsWaiter.clear()
             PlayerRegistry.clear()
         }
 
-        Events("onShouldLoadAdItem", "onImaBeforeInitialization")
+        Events("onShouldLoadAdItem", "onShouldPlayAdBreak", "onImaBeforeInitialization")
 
         AsyncFunction("play") { nativeId: NativeId ->
             val player = PlayerRegistry.getPlayer(nativeId)
@@ -285,6 +287,10 @@ class PlayerModule : Module() {
             shouldLoadAdItemWaiter.complete(id, shouldLoad)
         }
 
+        AsyncFunction("setShouldPlayAdBreak") { id: Int, shouldPlay: Boolean ->
+            shouldPlayAdBreakWaiter.complete(id, shouldPlay)
+        }
+
         AsyncFunction("initializeWithConfig") { nativeId: NativeId, config: Map<String, Any>?,
             networkNativeId: NativeId?, decoderNativeId: NativeId?, ->
             initializePlayer(nativeId, config, networkNativeId, decoderNativeId, null)
@@ -325,6 +331,7 @@ class PlayerModule : Module() {
         @Suppress("UNCHECKED_CAST")
         val configJson = config as? Map<String, Any?>
         setupShouldLoadAdItem(nativeId, configJson, playerConfig)
+        setupShouldPlayAdBreak(nativeId, configJson, playerConfig)
         setupImaBeforeInitialization(nativeId, configJson, playerConfig)
         val enableMediaSession = config?.getMap("mediaControlConfig")
             ?.toMediaControlConfig()?.isEnabled ?: true
@@ -400,6 +407,32 @@ class PlayerModule : Module() {
                         "nativeId" to nativeId,
                         "id" to id,
                         "adItem" to adItem.toJson(),
+                    ),
+                )
+                wait() ?: true
+            },
+        )
+    }
+
+    private fun setupShouldPlayAdBreak(
+        nativeId: NativeId,
+        configJson: Map<String, Any?>?,
+        playerConfig: PlayerConfig,
+    ) {
+        val advertisingConfigJson = configJson?.getMap("advertisingConfig") ?: return
+        if (!advertisingConfigJson.containsKey("shouldPlayAdBreak")) {
+            return
+        }
+        val advertisingConfig = playerConfig.advertisingConfig ?: AdvertisingConfig()
+        playerConfig.advertisingConfig = advertisingConfig.copy(
+            shouldPlayAdBreak = { adBreak ->
+                val (id, wait) = shouldPlayAdBreakWaiter.make(250)
+                sendEvent(
+                    "onShouldPlayAdBreak",
+                    bundleOf(
+                        "nativeId" to nativeId,
+                        "id" to id,
+                        "adBreak" to adBreak.toJson(),
                     ),
                 )
                 wait() ?: true

--- a/integration_test/tests/advertisingTest.ts
+++ b/integration_test/tests/advertisingTest.ts
@@ -191,6 +191,49 @@ export default (spec: TestScope) => {
         });
       }
     );
+
+    spec.describe(
+      `filtering scheduled ${name} ad breaks via shouldPlayAdBreak`,
+      () => {
+        spec.it('skips ad break when callback returns false', async () => {
+          if (currentPlatform !== 'android') {
+            return;
+          }
+
+          let callbackInvocationCount = 0;
+          const advertisingConfig: AdvertisingConfig = {
+            schedule: adItems,
+            shouldPlayAdBreak: () => {
+              callbackInvocationCount += 1;
+              return false;
+            },
+          };
+          const playbackConfig: PlaybackConfig = {
+            isAutoplayEnabled: true,
+          };
+
+          await startPlayerTest(
+            { playbackConfig, advertisingConfig },
+            async () => {
+              await callPlayerAndExpectEvent(
+                (player) => {
+                  player.load(Sources.artOfMotionHls);
+                },
+                FilteredEvent<TimeChangedEvent>(
+                  EventType.TimeChanged,
+                  (event) => event.currentTime > 0.25
+                )
+              );
+
+              expect(callbackInvocationCount).toBeGreaterThan(0);
+              await callPlayer(async (player) => {
+                expect(await player.isAd()).toBeFalsy();
+              });
+            }
+          );
+        });
+      }
+    );
   }
 
   const adScenarios: AdScenario[] = [
@@ -281,54 +324,6 @@ export default (spec: TestScope) => {
   adScenarios
     .filter(({ enabledOn }) => isEnabledForCurrentPlatform(enabledOn))
     .forEach(commonAdvertisingTests);
-
-  spec.describe('filtering ad breaks via shouldPlayAdBreak', () => {
-    spec.it(
-      'skips preroll ad break on Android when callback returns false',
-      async () => {
-        if (currentPlatform !== 'android') {
-          return;
-        }
-
-        let callbackInvocationCount = 0;
-        const advertisingConfig: AdvertisingConfig = {
-          schedule: [
-            {
-              sources: [{ tag: AdTags.vastSkippable, type: AdSourceType.IMA }],
-              position: 'pre',
-            },
-          ],
-          shouldPlayAdBreak: () => {
-            callbackInvocationCount += 1;
-            return false;
-          },
-        };
-        const playbackConfig: PlaybackConfig = {
-          isAutoplayEnabled: true,
-        };
-
-        await startPlayerTest(
-          { playbackConfig, advertisingConfig },
-          async () => {
-            await callPlayerAndExpectEvent(
-              (player) => {
-                player.load(Sources.artOfMotionHls);
-              },
-              FilteredEvent<TimeChangedEvent>(
-                EventType.TimeChanged,
-                (event) => event.currentTime > 0.25
-              )
-            );
-
-            expect(callbackInvocationCount).toBeGreaterThan(0);
-            await callPlayer(async (player) => {
-              expect(await player.isAd()).toBeFalsy();
-            });
-          }
-        );
-      }
-    );
-  });
 
   type AdErrorScenario = {
     adItem: AdItem;

--- a/integration_test/tests/advertisingTest.ts
+++ b/integration_test/tests/advertisingTest.ts
@@ -282,6 +282,54 @@ export default (spec: TestScope) => {
     .filter(({ enabledOn }) => isEnabledForCurrentPlatform(enabledOn))
     .forEach(commonAdvertisingTests);
 
+  spec.describe('filtering ad breaks via shouldPlayAdBreak', () => {
+    spec.it(
+      'skips preroll ad break on Android when callback returns false',
+      async () => {
+        if (currentPlatform !== 'android') {
+          return;
+        }
+
+        let callbackInvocationCount = 0;
+        const advertisingConfig: AdvertisingConfig = {
+          schedule: [
+            {
+              sources: [{ tag: AdTags.vastSkippable, type: AdSourceType.IMA }],
+              position: 'pre',
+            },
+          ],
+          shouldPlayAdBreak: () => {
+            callbackInvocationCount += 1;
+            return false;
+          },
+        };
+        const playbackConfig: PlaybackConfig = {
+          isAutoplayEnabled: true,
+        };
+
+        await startPlayerTest(
+          { playbackConfig, advertisingConfig },
+          async () => {
+            await callPlayerAndExpectEvent(
+              (player) => {
+                player.load(Sources.artOfMotionHls);
+              },
+              FilteredEvent<TimeChangedEvent>(
+                EventType.TimeChanged,
+                (event) => event.currentTime > 0.25
+              )
+            );
+
+            expect(callbackInvocationCount).toBeGreaterThan(0);
+            await callPlayer(async (player) => {
+              expect(await player.isAd()).toBeFalsy();
+            });
+          }
+        );
+      }
+    );
+  });
+
   type AdErrorScenario = {
     adItem: AdItem;
     label: string;

--- a/src/advertising.ts
+++ b/src/advertising.ts
@@ -125,6 +125,11 @@ export interface AdvertisingConfig {
    * - `true` → the ad break will start playback.
    * - `false` → the ad break will be skipped.
    *
+   * @remarks
+   * If the callback does not return within the platform's internal timeout,
+   * the ad break will play.
+   * The callback must be synchronous.
+   *
    * @platform Android
    */
   shouldPlayAdBreak?: (adBreak: AdBreak) => boolean;

--- a/src/advertising.ts
+++ b/src/advertising.ts
@@ -114,6 +114,21 @@ export interface AdvertisingConfig {
    */
   shouldLoadAdItem?: (adItem: AdItem) => boolean;
   /**
+   * Called right before a scheduled ad break starts playback.
+   *
+   * Use this callback to conditionally allow or skip ad breaks at runtime
+   * (e.g., when starting playback from a time offset and discarding past breaks).
+   *
+   * @param adBreak - The ad break that is about to start.
+   *
+   * @returns
+   * - `true` → the ad break will start playback.
+   * - `false` → the ad break will be skipped.
+   *
+   * @platform Android
+   */
+  shouldPlayAdBreak?: (adBreak: AdBreak) => boolean;
+  /**
    * Configuration to customize Google IMA SDK integration.
    */
   ima?: ImaAdvertisingConfig;

--- a/src/modules/PlayerModule.ts
+++ b/src/modules/PlayerModule.ts
@@ -1,5 +1,5 @@
 import { NativeModule, requireNativeModule } from 'expo-modules-core';
-import { AdItem, ImaSettings } from '../advertising';
+import { AdBreak, AdItem, ImaSettings } from '../advertising';
 
 export type PlayerModuleEvents = {
   onShouldLoadAdItem: ({
@@ -10,6 +10,15 @@ export type PlayerModuleEvents = {
     nativeId: string;
     id: number;
     adItem: AdItem;
+  }) => void;
+  onShouldPlayAdBreak: ({
+    nativeId,
+    id,
+    adBreak,
+  }: {
+    nativeId: string;
+    id: number;
+    adBreak: AdBreak;
   }) => void;
   onImaBeforeInitialization: ({
     nativeId,
@@ -172,6 +181,11 @@ declare class PlayerModule extends NativeModule<PlayerModuleEvents> {
    * Applies the JS decision for an ad item load callback.
    */
   setShouldLoadAdItem(id: number, shouldLoad: boolean): Promise<void>;
+
+  /**
+   * Applies the JS decision for an ad break playback callback.
+   */
+  setShouldPlayAdBreak(id: number, shouldPlay: boolean): Promise<void>;
 
   /**
    * Applies the JS-updated IMA settings for a before-initialization callback.

--- a/src/player.ts
+++ b/src/player.ts
@@ -9,7 +9,7 @@ import { OfflineContentManager, OfflineSourceOptions } from './offline';
 import { Thumbnail } from './thumbnail';
 import { AnalyticsApi } from './analytics/player';
 import { PlayerConfig } from './playerConfig';
-import { AdItem, ImaSettings } from './advertising';
+import { AdBreak, AdItem, ImaSettings } from './advertising';
 import { BufferApi } from './bufferApi';
 import { VideoQuality } from './media';
 import { Network } from './network';
@@ -52,6 +52,7 @@ export class Player extends NativeInstance<PlayerConfig> {
 
   private decoderConfig?: DecoderConfigBridge;
   private onShouldLoadAdItemSubscription?: EventSubscription;
+  private onShouldPlayAdBreakSubscription?: EventSubscription;
   private onImaBeforeInitializationSubscription?: EventSubscription;
   /**
    * Allocates the native `Player` instance and its resources natively.
@@ -59,6 +60,7 @@ export class Player extends NativeInstance<PlayerConfig> {
   initialize = async (): Promise<void> => {
     if (!this.isInitialized) {
       this.ensureShouldLoadAdItemListener();
+      this.ensureShouldPlayAdBreakListener();
       this.ensureImaBeforeInitializationListener();
       if (this.config?.networkConfig) {
         this.network = new Network(this.config.networkConfig);
@@ -99,8 +101,10 @@ export class Player extends NativeInstance<PlayerConfig> {
       void this.network?.destroy();
       void this.decoderConfig?.destroy();
       this.onShouldLoadAdItemSubscription?.remove();
+      this.onShouldPlayAdBreakSubscription?.remove();
       this.onImaBeforeInitializationSubscription?.remove();
       this.onShouldLoadAdItemSubscription = undefined;
+      this.onShouldPlayAdBreakSubscription = undefined;
       this.onImaBeforeInitializationSubscription = undefined;
       this.isDestroyed = true;
     }
@@ -236,6 +240,43 @@ export class Player extends NativeInstance<PlayerConfig> {
    */
   setVolume = (volume: number) => {
     void PlayerModule.setVolume(this.nativeId, volume);
+  };
+
+  private ensureShouldPlayAdBreakListener = () => {
+    if (Platform.OS !== 'android') {
+      return;
+    }
+    const callback = this.config?.advertisingConfig?.shouldPlayAdBreak;
+    if (!callback) {
+      return;
+    }
+    if (this.onShouldPlayAdBreakSubscription) {
+      return;
+    }
+    this.onShouldPlayAdBreakSubscription = PlayerModule.addListener(
+      'onShouldPlayAdBreak',
+      ({ nativeId, id, adBreak }) => {
+        if (nativeId !== this.nativeId) {
+          return;
+        }
+        const cloned: AdBreak = {
+          ...adBreak,
+          ads: adBreak.ads.map((ad) => ({
+            ...ad,
+            data: ad.data ? { ...ad.data } : undefined,
+          })),
+        };
+        let shouldPlay = true;
+        try {
+          const shouldPlayResult = callback(cloned);
+          shouldPlay =
+            typeof shouldPlayResult === 'boolean' ? shouldPlayResult : true;
+        } catch {
+          shouldPlay = true;
+        }
+        void PlayerModule.setShouldPlayAdBreak(id, shouldPlay);
+      }
+    );
   };
 
   private ensureImaBeforeInitializationListener = () => {


### PR DESCRIPTION
## Description
This change exposes the Android `AdvertisingConfig.shouldPlayAdBreak` callback through the React Native bridge.

Previously, React Native integrations could filter ad items before loading (`shouldLoadAdItem`), but could not decide at ad-break playback time whether a scheduled break should still play. This prevented runtime discard logic for already-scheduled breaks (for example when playback starts from an offset).

## Changes
- Added `AdvertisingConfig.shouldPlayAdBreak?: (adBreak: AdBreak) => boolean` in `src/advertising.ts` (Android-only API surface).
- Extended the JS/native module contract in `src/modules/PlayerModule.ts`:
  - new event: `onShouldPlayAdBreak`
  - new bridge method: `setShouldPlayAdBreak(id, shouldPlay)`
- Updated `src/player.ts`:
  - added Android-only listener wiring for `onShouldPlayAdBreak`
  - clones callback payload before invoking user callback
  - defaults to `true` on callback errors/non-boolean return, matching existing callback behavior
  - ensures listener lifecycle cleanup on player destroy
- Updated Android native bridge in `android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt`:
  - added `ResultWaiter<Boolean>` for should-play responses
  - added `onShouldPlayAdBreak` event registration
  - added `setShouldPlayAdBreak` async function
  - wired `setupShouldPlayAdBreak(...)` into player initialization and mapped callback to `AdvertisingConfig.shouldPlayAdBreak`
- Added Android integration test coverage in `integration_test/tests/advertisingTest.ts`:
  - verifies preroll ad break is skipped when `shouldPlayAdBreak` returns `false`
  - verifies callback invocation and non-ad playback state
- Added changelog entry under `## [Unreleased]`.

### API validation
- Verified Android API availability/signature against the official Bitmovin Android API docs (`ShouldPlayAdBreakCallback.shouldPlayAdBreak(adBreak: AdBreak): Boolean` and `AdvertisingConfig.shouldPlayAdBreak`).

### Testing
Executed in this environment:
- `corepack yarn typecheck` ✅
- `corepack yarn lint` ✅
- `corepack yarn lint:android` ✅
- `corepack yarn build` ✅
- `corepack yarn integration-test typecheck` ✅
- `corepack yarn --cwd integration_test eslint tests/advertisingTest.ts --ext .ts --quiet` ✅

Android instrumentation attempts (`yarn integration-test test:android`):
-  ✅ suite executed end-to-end on emulator
  - Result: `50 examples, 7 failures` (existing unrelated failures)
  - **New test passed**: `filtering ad breaks via shouldPlayAdBreak: skips preroll ad break on Android when callback returns false`

## Checklist
- [x] 🗒 `CHANGELOG` entry
