### PR TITLE
Fix NSLocalNetworkUsageDescription dropped from Info.plist when googleCastSDK.ios is configured as an object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- iOS: Expo config plugin no longer drops `NSLocalNetworkUsageDescription` from `Info.plist` when `features.googleCastSDK.ios` is configured as an object without an explicit `localNetworkUsageDescription`. The default description is now applied as a fallback, restoring local-network access required for Cast device discovery
+
 ## [1.19.0] - 2026-05-08
 
 ### Added

--- a/plugin/src/withBitmovinIosConfig.ts
+++ b/plugin/src/withBitmovinIosConfig.ts
@@ -61,10 +61,12 @@ const withBitmovinIosConfig: ConfigPlugin<BitmovinConfigOptions> = (
         delete config.modResults['BitmovinPlayerOfflineSupportEnabled'];
       }
       if (googleCastConfig?.ios != null) {
+        const defaultLocalNetworkUsageDescription =
+          '${PRODUCT_NAME} uses the local network to discover Cast-enabled devices on your WiFi network.';
         const localNetworkUsageDescription =
-          typeof googleCastConfig?.ios === 'object'
+          (typeof googleCastConfig?.ios === 'object'
             ? googleCastConfig?.ios?.localNetworkUsageDescription
-            : '${PRODUCT_NAME} uses the local network to discover Cast-enabled devices on your WiFi network.';
+            : undefined) ?? defaultLocalNetworkUsageDescription;
 
         config.modResults['BitmovinPlayerGoogleCastApplicationId'] =
           googleCastAppId;


### PR DESCRIPTION


## Description
When the Expo config plugin is configured with `features.googleCastSDK.ios` as an
object — the documented and most common form, e.g.:

```ts
googleCastSDK: {
  android: { version: '21.3.0' },
  ios: { version: '4.8.4' },
}
```
…and localNetworkUsageDescription is omitted (it is optional per
Features.ts), the plugin assigned undefined to
config.modResults['NSLocalNetworkUsageDescription']. Expo's plist serializer
drops keys whose values are undefined, so the produced Info.plist shipped
without the usage description.

Without NSLocalNetworkUsageDescription, iOS does not prompt the user for
local-network access and silently denies it, which prevents the Google Cast SDK
from discovering Cast-enabled devices. Customers reported intermittent /
missing Cast device discovery; manually setting
localNetworkUsageDescription in their app config worked around the issue.

The fallback default string in the plugin was only applied when the ios
field was provided as a string (version-only form), never when it was an
object — so it never triggered for the normal usage path. Bug has been
present since the initial Expo plugin support commit (b69afef0) and is
still reproducible on v1.19.0.

Internal ticket: PRN-247

## Changes
- plugin/src/withBitmovinIosConfig.ts: extract the default usage-description string and apply it via ?? so the fallback kicks in for both the string and the object form of googleCastSDK.ios. Behavior when the user does provide localNetworkUsageDescription is unchanged.
- CHANGELOG.md: added entry under [Unreleased] → Fixed.

## Checklist
- [x] 🗒 `CHANGELOG` entry
