### PR TITLE
Android: Fix PiP handling for Android <15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Android: Fix known limitation of `PictureInPictureEntered` and `PictureInPictureExited` events on Android <15
+
 ## [1.20.0] - 2026-05-29
 
 ### Added

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -331,6 +331,9 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
                     currentActivity,
                     player,
                     pictureInPictureConfig,
+                    onPictureInPictureExited = {
+                        playerView?.onPictureInPictureModeChanged(false, null)
+                    },
                 )
             } else {
                 null
@@ -442,20 +445,25 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
             if (!reparentHelper.isActive) {
                 reparentHelper.reparent()
             }
+
+            // We must "delay" the onPictureInPictureModeChanged callback via posting a runnable.
+            // This will force the callback to be called at the end of the current pending UI transactions.
+            // This is necessary as the `PlayerView.onPictureInPictureModeChanged` call will immediately send a
+            // PiP-transition ended event.
+            post {
+                playerView.onPictureInPictureModeChanged(true, newConfig)
+            }
         } else {
             if (playerView.isPictureInPicture) {
                 playerView.exitPictureInPicture()
             }
 
             reparentHelper.tryRestore()
-        }
 
-        // We must "delay" the onPictureInPictureModeChanged callback via posting a runnable.
-        // This will force the callback to be called at the end of the current pending UI transactions.
-        // This is necessary as the `PlayerView.onPictureInPictureModeChanged` call will immediately send a
-        // PiP-transition ended event.
-        post {
-            playerView.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+            // No need to call playerView.onPictureInPictureModeChanged,
+            // as this is done via the RNPictureInPictureHandler callback.
+            // The PiP-exit handling is different compared to PiP-enter, due to the nature of PiP handling:
+            // Enter via `activity.enterPictureInPictureMode`, Exit via `activity.startActivity(restoreIntent)`.
         }
     }
 
@@ -644,7 +652,14 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
         if (isEnabled && pictureInPictureHandler == null) {
             val currentActivity = appContext.activityProvider?.currentActivity ?: return
             val player = playerView?.player ?: return
-            pictureInPictureHandler = RNPictureInPictureHandler(currentActivity, player, pictureInPictureConfig)
+            pictureInPictureHandler = RNPictureInPictureHandler(
+                currentActivity,
+                player,
+                pictureInPictureConfig,
+                onPictureInPictureExited = {
+                    playerView?.onPictureInPictureModeChanged(false, null)
+                },
+            )
             playerView?.setPictureInPictureHandler(pictureInPictureHandler)
         } else if (!isEnabled && pictureInPictureHandler != null) {
             pictureInPictureHandler?.dispose()

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -328,9 +328,9 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
             val isPictureInPictureEnabled = isPictureInPictureEnabledOnPlayer || pictureInPictureConfig.isEnabled
             pictureInPictureHandler = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && isPictureInPictureEnabled) {
                 RNPictureInPictureHandler(
-                    currentActivity,
-                    player,
-                    pictureInPictureConfig,
+                    activity = currentActivity,
+                    player = player,
+                    pictureInPictureConfig = pictureInPictureConfig,
                     onPictureInPictureExited = {
                         playerView?.onPictureInPictureModeChanged(false, null)
                     },
@@ -653,9 +653,9 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
             val currentActivity = appContext.activityProvider?.currentActivity ?: return
             val player = playerView?.player ?: return
             pictureInPictureHandler = RNPictureInPictureHandler(
-                currentActivity,
-                player,
-                pictureInPictureConfig,
+                activity = currentActivity,
+                player = player,
+                pictureInPictureConfig = pictureInPictureConfig,
                 onPictureInPictureExited = {
                     playerView?.onPictureInPictureModeChanged(false, null)
                 },

--- a/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/RNPlayerView.kt
@@ -332,7 +332,11 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
                     player = player,
                     pictureInPictureConfig = pictureInPictureConfig,
                     onPictureInPictureExited = {
-                        playerView?.onPictureInPictureModeChanged(false, null)
+                        // It is safe to call this function with `newConfig = null`
+                        playerView?.onPictureInPictureModeChanged(
+                            isInPictureInPictureMode = false,
+                            newConfig = null,
+                        )
                     },
                 )
             } else {
@@ -657,7 +661,11 @@ class RNPlayerView(context: Context, appContext: AppContext) : ExpoView(context,
                 player = player,
                 pictureInPictureConfig = pictureInPictureConfig,
                 onPictureInPictureExited = {
-                    playerView?.onPictureInPictureModeChanged(false, null)
+                    // It is safe to call this function with `newConfig = null`
+                    playerView?.onPictureInPictureModeChanged(
+                        isInPictureInPictureMode = false,
+                        newConfig = null,
+                    )
                 },
             )
             playerView?.setPictureInPictureHandler(pictureInPictureHandler)

--- a/android/src/main/java/com/bitmovin/player/reactnative/ui/RNPictureInPictureHandler.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/ui/RNPictureInPictureHandler.kt
@@ -60,6 +60,8 @@ class RNPictureInPictureHandler(
         updatePictureInPictureParams()
     }
 
+    private var pipTransactionEndedCallback: PipTransactionEndedActivityLifecycleCallback? = null
+
     init {
         playerIsPlaying = player.isPlaying
         subscribeToPlayerPlaybackEvents()
@@ -110,7 +112,9 @@ class RNPictureInPictureHandler(
             return
         }
 
-        activity.application.registerActivityLifecycleCallbacks(PipTransactionEndedActivityLifecycleCallback())
+        val callback = PipTransactionEndedActivityLifecycleCallback()
+        activity.application.registerActivityLifecycleCallbacks(callback)
+        pipTransactionEndedCallback = callback
 
         activity.enterPictureInPictureMode(buildPictureInPictureParams())
         _isPictureInPicture = true
@@ -149,6 +153,10 @@ class RNPictureInPictureHandler(
                     .build(),
             )
         }
+        pipTransactionEndedCallback?.let { callback ->
+            activity.application.unregisterActivityLifecycleCallbacks(callback)
+        }
+        pipTransactionEndedCallback = null
     }
 
     private inner class PipTransactionEndedActivityLifecycleCallback : Application.ActivityLifecycleCallbacks {
@@ -180,6 +188,9 @@ class RNPictureInPictureHandler(
                 }
             } finally {
                 activity.application.unregisterActivityLifecycleCallbacks(this)
+                if (pipTransactionEndedCallback == this) {
+                    pipTransactionEndedCallback = null
+                }
             }
         }
 
@@ -206,6 +217,9 @@ class RNPictureInPictureHandler(
                 onPictureInPictureExited()
             } finally {
                 activity.application.unregisterActivityLifecycleCallbacks(this)
+                if (pipTransactionEndedCallback == this) {
+                    pipTransactionEndedCallback = null
+                }
             }
         }
     }

--- a/android/src/main/java/com/bitmovin/player/reactnative/ui/RNPictureInPictureHandler.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/ui/RNPictureInPictureHandler.kt
@@ -1,8 +1,10 @@
 package com.bitmovin.player.reactnative.ui
 
 import android.app.Activity
+import android.app.Application
 import android.app.PictureInPictureParams
 import android.os.Build
+import android.os.Bundle
 import android.util.Log
 import android.util.Rational
 import androidx.annotation.RequiresApi
@@ -10,8 +12,8 @@ import com.bitmovin.player.api.Player
 import com.bitmovin.player.api.event.PlayerEvent
 import com.bitmovin.player.api.event.on
 import com.bitmovin.player.reactnative.PictureInPictureAction
-import com.bitmovin.player.ui.DefaultPictureInPictureHandler
 import com.bitmovin.player.reactnative.PictureInPictureConfig
+import com.bitmovin.player.ui.DefaultPictureInPictureHandler
 
 private const val TAG = "RNPiPHandler"
 
@@ -20,6 +22,7 @@ class RNPictureInPictureHandler(
     private val activity: Activity,
     private val player: Player,
     private val pictureInPictureConfig: PictureInPictureConfig,
+    private val onPictureInPictureExited: () -> Unit = {},
 ) : DefaultPictureInPictureHandler(activity, player) {
     private val pictureInPictureActionHandler = DefaultPictureInPictureActionHandler(
         activity,
@@ -107,6 +110,8 @@ class RNPictureInPictureHandler(
             return
         }
 
+        activity.application.registerActivityLifecycleCallbacks(PipTransactionEndedActivityLifecycleCallback())
+
         activity.enterPictureInPictureMode(buildPictureInPictureParams())
         _isPictureInPicture = true
     }
@@ -143,6 +148,65 @@ class RNPictureInPictureHandler(
                     .setAutoEnterEnabled(false)
                     .build(),
             )
+        }
+    }
+
+    private inner class PipTransactionEndedActivityLifecycleCallback : Application.ActivityLifecycleCallbacks {
+        private var callbackReceived = false
+        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+            // no-op
+        }
+
+        override fun onActivityDestroyed(activity: Activity) {
+            // no-op
+        }
+
+        override fun onActivityPaused(activity: Activity) {
+            // no-op
+        }
+
+        override fun onActivityResumed(activity: Activity) {
+            // Called when the PiP mode is exited via restoring to the "normal" activity
+            if (activity != this@RNPictureInPictureHandler.activity) {
+                return
+            }
+            if (callbackReceived) {
+                return
+            }
+            callbackReceived = true
+            try {
+                if (!isPictureInPicture) {
+                    onPictureInPictureExited()
+                }
+            } finally {
+                activity.application.unregisterActivityLifecycleCallbacks(this)
+            }
+        }
+
+        override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+            // no-op
+        }
+
+        override fun onActivityStarted(activity: Activity) {
+            // no-op
+        }
+
+        override fun onActivityStopped(activity: Activity) {
+            // Called when the PiP mode is exited via closing the PiP window
+            if (activity != this@RNPictureInPictureHandler.activity) {
+                return
+            }
+            if (callbackReceived) {
+                return
+            }
+            callbackReceived = true
+            // No need to check the `isPictureInPicture` value, as `onActivityStopped` is called
+            // when the activity gets destroyed from PiP mode
+            try {
+                onPictureInPictureExited()
+            } finally {
+                activity.application.unregisterActivityLifecycleCallbacks(this)
+            }
         }
     }
 }

--- a/android/src/main/java/com/bitmovin/player/reactnative/ui/RNPictureInPictureHandler.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/ui/RNPictureInPictureHandler.kt
@@ -161,6 +161,14 @@ class RNPictureInPictureHandler(
 
     private inner class PipTransactionEndedActivityLifecycleCallback : Application.ActivityLifecycleCallbacks {
         private var callbackReceived = false
+
+        private fun unregisterCallback(activity:Activity) {
+            activity.application.unregisterActivityLifecycleCallbacks(this)
+            if (pipTransactionEndedCallback == this) {
+                pipTransactionEndedCallback = null
+            }
+        }
+
         override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
             // no-op
         }
@@ -187,10 +195,7 @@ class RNPictureInPictureHandler(
                     onPictureInPictureExited()
                 }
             } finally {
-                activity.application.unregisterActivityLifecycleCallbacks(this)
-                if (pipTransactionEndedCallback == this) {
-                    pipTransactionEndedCallback = null
-                }
+                unregisterCallback(activity)
             }
         }
 
@@ -216,10 +221,7 @@ class RNPictureInPictureHandler(
             try {
                 onPictureInPictureExited()
             } finally {
-                activity.application.unregisterActivityLifecycleCallbacks(this)
-                if (pipTransactionEndedCallback == this) {
-                    pipTransactionEndedCallback = null
-                }
+                unregisterCallback(activity)
             }
         }
     }

--- a/android/src/main/java/com/bitmovin/player/reactnative/ui/RNPictureInPictureHandler.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/ui/RNPictureInPictureHandler.kt
@@ -162,7 +162,7 @@ class RNPictureInPictureHandler(
     private inner class PipTransactionEndedActivityLifecycleCallback : Application.ActivityLifecycleCallbacks {
         private var callbackReceived = false
 
-        private fun unregisterCallback(activity:Activity) {
+        private fun unregisterCallback(activity: Activity) {
             activity.application.unregisterActivityLifecycleCallbacks(this)
             if (pipTransactionEndedCallback == this) {
                 pipTransactionEndedCallback = null


### PR DESCRIPTION
## Description
In the current Android react-native PiP implementation there a limitation for devices running Android <15 that the timing of the `onPictureInPictureExited` call happened before the `AppState` change.

## Changes
- Make use of `ActivityLifecycleCallbacks` to notify about PiP exited transition
- Remove `playerView.onPictureInPictureModeChanged` in `onConfigurationChanged` for PiP exit

## Checklist
- [x] 🗒 `CHANGELOG` entry
