### PR TITLE
Fix Android build could miss necessary desugaring plugin

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -100,8 +100,8 @@ jobs:
       - name: Build TypeScript (Module)
         run: yarn build:module
 
-      - name: Build TypeScript (Plugin)
-        run: yarn build:plugin
+      - name: Build and test TypeScript (Plugin)
+        run: yarn test:plugin
 
   test-build-docs:
     name: Build API docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Android: Expo config plugin now enables core library desugaring independently from Cast and offline features, fixing clean builds with the Google IMA SDK dependency
+- Android: Expo config plugin now enables core library desugaring independently from Cast and offline features
 
 ## [1.20.1] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Android: Expo config plugin now enables core library desugaring independently from Cast and offline features, fixing clean builds with the Google IMA SDK dependency
+
 ## [1.20.1] - 2026-06-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "setup-hooks": "./scripts/setup-hooks.sh",
     "lint:ios": "swiftlint ios --strict --quiet",
     "lint:android": "cd android && ./gradlew -b ktlint.gradle ktlintCheck --quiet --console=plain",
+    "test:plugin": "yarn build:plugin && node scripts/test-with-app-gradle-dependencies.js",
     "prepare": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
     "module": "expo-module",

--- a/plugin/src/withAppGradleDependencies.ts
+++ b/plugin/src/withAppGradleDependencies.ts
@@ -18,6 +18,8 @@ const defaultProps: PluginProps = {
 
 const CORE_LIBRARY_DESUGARING_DEPENDENCY =
   "coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'";
+const CORE_LIBRARY_DESUGARING_COORDINATES =
+  'com.android.tools:desugar_jdk_libs:2.1.5';
 
 const stripBlockComments = (contents: string) =>
   contents.replace(/\/\*[\s\S]*?\*\//g, '');
@@ -27,19 +29,20 @@ const hasCoreLibraryDesugaringEnabled = (contents: string) =>
     stripBlockComments(contents)
   );
 
-const hasCoreLibraryDesugaringDependency = (contents: string) =>
-  /^\s*coreLibraryDesugaring\b/m.test(stripBlockComments(contents));
-
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const hasGradleDependencyDeclaration = (
   contents: string,
-  dependency: string
+  dependency: string,
+  configuration?: string
 ) => {
   const dependencyPattern = escapeRegExp(dependency);
+  const configurationPattern = configuration
+    ? escapeRegExp(configuration)
+    : '[A-Za-z_][\\w.-]*';
   const declarationPattern = new RegExp(
-    `^[A-Za-z_][\\w.-]*\\s*(?:\\(\\s*)?['"]${dependencyPattern}['"]`
+    `^${configurationPattern}\\s*(?:\\(\\s*)?['"]${dependencyPattern}['"]`
   );
   let nestedBlockDepth = 0;
 
@@ -65,7 +68,16 @@ const hasGradleDependencyDeclaration = (
     });
 };
 
-const replaceDisabledCoreLibraryDesugaringSettings = (contents: string) =>
+const hasCoreLibraryDesugaringDependency = (contents: string) =>
+  hasGradleDependencyDeclaration(
+    contents,
+    CORE_LIBRARY_DESUGARING_COORDINATES,
+    'coreLibraryDesugaring'
+  );
+
+const replaceDisabledCoreLibraryDesugaringSettingsInGradle = (
+  contents: string
+) =>
   contents
     .replace(
       /^(\s*)setCoreLibraryDesugaringEnabled\s*\(\s*false\s*\)/gm,
@@ -79,6 +91,16 @@ const replaceDisabledCoreLibraryDesugaringSettings = (contents: string) =>
       /^(\s*)coreLibraryDesugaringEnabled(\s+)false\b/gm,
       '$1coreLibraryDesugaringEnabled$2true'
     );
+
+const replaceDisabledCoreLibraryDesugaringSettings = (contents: string) =>
+  contents
+    .split(/(\/\*[\s\S]*?\*\/)/g)
+    .map((part) =>
+      part.startsWith('/*')
+        ? part
+        : replaceDisabledCoreLibraryDesugaringSettingsInGradle(part)
+    )
+    .join('');
 
 const ensureCoreLibraryDesugaringCompileOptions = (
   contents: string,

--- a/plugin/src/withAppGradleDependencies.ts
+++ b/plugin/src/withAppGradleDependencies.ts
@@ -19,13 +19,16 @@ const defaultProps: PluginProps = {
 const CORE_LIBRARY_DESUGARING_DEPENDENCY =
   "coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'";
 
+const stripBlockComments = (contents: string) =>
+  contents.replace(/\/\*[\s\S]*?\*\//g, '');
+
 const hasCoreLibraryDesugaringEnabled = (contents: string) =>
   /^\s*(?:setCoreLibraryDesugaringEnabled\s*\(\s*true\s*\)|coreLibraryDesugaringEnabled(?:\s*=\s*|\s+)true\b)/m.test(
-    contents
+    stripBlockComments(contents)
   );
 
 const hasCoreLibraryDesugaringDependency = (contents: string) =>
-  /^\s*coreLibraryDesugaring\b/m.test(contents);
+  /^\s*coreLibraryDesugaring\b/m.test(stripBlockComments(contents));
 
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -40,24 +43,26 @@ const hasGradleDependencyDeclaration = (
   );
   let nestedBlockDepth = 0;
 
-  return contents.split('\n').some((line) => {
-    const trimmedLine = line.trim();
-    if (trimmedLine.startsWith('//')) {
-      return false;
-    }
+  return stripBlockComments(contents)
+    .split('\n')
+    .some((line) => {
+      const trimmedLine = line.trim();
+      if (trimmedLine.startsWith('//')) {
+        return false;
+      }
 
-    if (/^dependencies\s*\{$/.test(trimmedLine)) {
-      return false;
-    }
+      if (/^dependencies\s*\{$/.test(trimmedLine)) {
+        return false;
+      }
 
-    const isTopLevelDependency =
-      nestedBlockDepth === 0 && declarationPattern.test(trimmedLine);
-    const openBlockCount = (trimmedLine.match(/\{/g) || []).length;
-    const closeBlockCount = (trimmedLine.match(/\}/g) || []).length;
-    nestedBlockDepth += openBlockCount - closeBlockCount;
+      const isTopLevelDependency =
+        nestedBlockDepth === 0 && declarationPattern.test(trimmedLine);
+      const openBlockCount = (trimmedLine.match(/\{/g) || []).length;
+      const closeBlockCount = (trimmedLine.match(/\}/g) || []).length;
+      nestedBlockDepth += openBlockCount - closeBlockCount;
 
-    return isTopLevelDependency;
-  });
+      return isTopLevelDependency;
+    });
 };
 
 const replaceDisabledCoreLibraryDesugaringSettings = (contents: string) =>
@@ -78,18 +83,28 @@ const replaceDisabledCoreLibraryDesugaringSettings = (contents: string) =>
 const ensureCoreLibraryDesugaringCompileOptions = (
   contents: string,
   spacing: string,
+  androidBlockStart: number,
   androidPosition: number
 ) => {
-  const updatedContents =
-    replaceDisabledCoreLibraryDesugaringSettings(contents);
-  if (hasCoreLibraryDesugaringEnabled(updatedContents)) {
+  const androidBlock = contents.slice(androidBlockStart, androidPosition);
+  const updatedAndroidBlock =
+    replaceDisabledCoreLibraryDesugaringSettings(androidBlock);
+  const updatedContents = [
+    contents.slice(0, androidBlockStart),
+    updatedAndroidBlock,
+    contents.slice(androidPosition),
+  ].join('');
+  const updatedAndroidPosition =
+    androidPosition + updatedAndroidBlock.length - androidBlock.length;
+
+  if (hasCoreLibraryDesugaringEnabled(updatedAndroidBlock)) {
     return updatedContents;
   }
 
-  const compileOptionsStart = updatedContents.search(
+  const compileOptionsRelativeStart = updatedAndroidBlock.search(
     /^\s*compileOptions\s*\{$/m
   );
-  if (compileOptionsStart === -1) {
+  if (compileOptionsRelativeStart === -1) {
     const compileOptions = [];
     compileOptions.push(`${spacing}compileOptions {`);
     compileOptions.push('\n');
@@ -100,12 +115,13 @@ const ensureCoreLibraryDesugaringCompileOptions = (
     compileOptions.push(`${spacing}}`);
     compileOptions.push('\n');
     return [
-      updatedContents.slice(0, androidPosition),
+      updatedContents.slice(0, updatedAndroidPosition),
       ...compileOptions,
-      updatedContents.slice(androidPosition),
+      updatedContents.slice(updatedAndroidPosition),
     ].join('');
   }
 
+  const compileOptionsStart = androidBlockStart + compileOptionsRelativeStart;
   const compileOptionsLineEnd =
     updatedContents.indexOf('\n', compileOptionsStart) + 1;
   return [
@@ -184,6 +200,7 @@ const withAppGradleDependencies: ConfigPlugin<PluginProps> = (
     config.modResults.contents = ensureCoreLibraryDesugaringCompileOptions(
       config.modResults.contents,
       spacing,
+      androidBlockStart,
       androidPosition
     );
 

--- a/plugin/src/withAppGradleDependencies.ts
+++ b/plugin/src/withAppGradleDependencies.ts
@@ -20,22 +20,42 @@ const CORE_LIBRARY_DESUGARING_DEPENDENCY =
   "coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'";
 
 const hasCoreLibraryDesugaringEnabled = (contents: string) =>
-  contents.includes('coreLibraryDesugaringEnabled') ||
-  contents.includes('setCoreLibraryDesugaringEnabled');
+  /^\s*(?:setCoreLibraryDesugaringEnabled\s*\(\s*true\s*\)|coreLibraryDesugaringEnabled(?:\s*=\s*|\s+)true\b)/m.test(
+    contents
+  );
 
 const hasCoreLibraryDesugaringDependency = (contents: string) =>
-  /\bcoreLibraryDesugaring\b/.test(contents);
+  /^\s*coreLibraryDesugaring\b/m.test(contents);
+
+const replaceDisabledCoreLibraryDesugaringSettings = (contents: string) =>
+  contents
+    .replace(
+      /^(\s*)setCoreLibraryDesugaringEnabled\s*\(\s*false\s*\)/gm,
+      '$1setCoreLibraryDesugaringEnabled(true)'
+    )
+    .replace(
+      /^(\s*)coreLibraryDesugaringEnabled(\s*=\s*)false\b/gm,
+      '$1coreLibraryDesugaringEnabled$2true'
+    )
+    .replace(
+      /^(\s*)coreLibraryDesugaringEnabled(\s+)false\b/gm,
+      '$1coreLibraryDesugaringEnabled$2true'
+    );
 
 const ensureCoreLibraryDesugaringCompileOptions = (
   contents: string,
   spacing: string,
   androidPosition: number
 ) => {
-  if (hasCoreLibraryDesugaringEnabled(contents)) {
-    return contents;
+  const updatedContents =
+    replaceDisabledCoreLibraryDesugaringSettings(contents);
+  if (hasCoreLibraryDesugaringEnabled(updatedContents)) {
+    return updatedContents;
   }
 
-  const compileOptionsStart = contents.search(/^\s*compileOptions\s*\{$/m);
+  const compileOptionsStart = updatedContents.search(
+    /^\s*compileOptions\s*\{$/m
+  );
   if (compileOptionsStart === -1) {
     const compileOptions = [];
     compileOptions.push(`${spacing}compileOptions {`);
@@ -47,17 +67,18 @@ const ensureCoreLibraryDesugaringCompileOptions = (
     compileOptions.push(`${spacing}}`);
     compileOptions.push('\n');
     return [
-      contents.slice(0, androidPosition),
+      updatedContents.slice(0, androidPosition),
       ...compileOptions,
-      contents.slice(androidPosition),
+      updatedContents.slice(androidPosition),
     ].join('');
   }
 
-  const compileOptionsLineEnd = contents.indexOf('\n', compileOptionsStart) + 1;
+  const compileOptionsLineEnd =
+    updatedContents.indexOf('\n', compileOptionsStart) + 1;
   return [
-    contents.slice(0, compileOptionsLineEnd),
+    updatedContents.slice(0, compileOptionsLineEnd),
     `${spacing}${spacing}setCoreLibraryDesugaringEnabled(true)\n`,
-    contents.slice(compileOptionsLineEnd),
+    updatedContents.slice(compileOptionsLineEnd),
   ].join('');
 };
 
@@ -112,12 +133,6 @@ const withAppGradleDependencies: ConfigPlugin<PluginProps> = (
       );
       return config;
     }
-    const androidPosition = androidBlockStart + androidBlockEnd;
-    config.modResults.contents = ensureCoreLibraryDesugaringCompileOptions(
-      config.modResults.contents,
-      spacing,
-      androidPosition
-    );
 
     const dependenciesBlockStart =
       config.modResults.contents.search(/^dependencies \{$/m);
@@ -139,9 +154,27 @@ const withAppGradleDependencies: ConfigPlugin<PluginProps> = (
       );
       return config;
     }
-    const position = dependenciesBlockStart + dependenciesBlockEnd;
-    const insertedDependencies = getCoreLibraryDesugaringDependencyLines(
+    const androidPosition = androidBlockStart + androidBlockEnd;
+    config.modResults.contents = ensureCoreLibraryDesugaringCompileOptions(
       config.modResults.contents,
+      spacing,
+      androidPosition
+    );
+
+    const updatedDependenciesBlockStart =
+      config.modResults.contents.search(/^dependencies \{$/m);
+    const updatedFromDependencies = config.modResults.contents.substring(
+      updatedDependenciesBlockStart
+    );
+    const updatedDependenciesBlockEnd = updatedFromDependencies.search(/^\}$/m);
+    const position =
+      updatedDependenciesBlockStart + updatedDependenciesBlockEnd;
+    const dependenciesBlock = config.modResults.contents.slice(
+      updatedDependenciesBlockStart,
+      position
+    );
+    const insertedDependencies = getCoreLibraryDesugaringDependencyLines(
+      dependenciesBlock,
       spacing
     );
     filteredDependencies.forEach((dependency) => {

--- a/plugin/src/withAppGradleDependencies.ts
+++ b/plugin/src/withAppGradleDependencies.ts
@@ -21,9 +21,7 @@ const CORE_LIBRARY_DESUGARING_DEPENDENCY =
 const CORE_LIBRARY_DESUGARING_ARTIFACT = 'com.android.tools:desugar_jdk_libs';
 
 const hasCoreLibraryDesugaringEnabled = (contents: string) =>
-  /^\s*(?:setCoreLibraryDesugaringEnabled\s*\(\s*true\s*\)|coreLibraryDesugaringEnabled(?:\s*=\s*|\s+)true\b)/m.test(
-    contents
-  );
+  /^\s*(?:set)?CoreLibraryDesugaringEnabled\b.*?\btrue\b/m.test(contents);
 
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/plugin/src/withAppGradleDependencies.ts
+++ b/plugin/src/withAppGradleDependencies.ts
@@ -27,6 +27,39 @@ const hasCoreLibraryDesugaringEnabled = (contents: string) =>
 const hasCoreLibraryDesugaringDependency = (contents: string) =>
   /^\s*coreLibraryDesugaring\b/m.test(contents);
 
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const hasGradleDependencyDeclaration = (
+  contents: string,
+  dependency: string
+) => {
+  const dependencyPattern = escapeRegExp(dependency);
+  const declarationPattern = new RegExp(
+    `^[A-Za-z_][\\w.-]*\\s*(?:\\(\\s*)?['"]${dependencyPattern}['"]`
+  );
+  let nestedBlockDepth = 0;
+
+  return contents.split('\n').some((line) => {
+    const trimmedLine = line.trim();
+    if (trimmedLine.startsWith('//')) {
+      return false;
+    }
+
+    if (/^dependencies\s*\{$/.test(trimmedLine)) {
+      return false;
+    }
+
+    const isTopLevelDependency =
+      nestedBlockDepth === 0 && declarationPattern.test(trimmedLine);
+    const openBlockCount = (trimmedLine.match(/\{/g) || []).length;
+    const closeBlockCount = (trimmedLine.match(/\}/g) || []).length;
+    nestedBlockDepth += openBlockCount - closeBlockCount;
+
+    return isTopLevelDependency;
+  });
+};
+
 const replaceDisabledCoreLibraryDesugaringSettings = (contents: string) =>
   contents
     .replace(
@@ -108,13 +141,6 @@ const withAppGradleDependencies: ConfigPlugin<PluginProps> = (
       return config;
     }
 
-    const deduplicatedDependencies = Array.from(
-      new Set(combinedProps.dependencies)
-    );
-    const filteredDependencies = deduplicatedDependencies.filter((dep) => {
-      return config.modResults.contents.indexOf(dep) === -1;
-    });
-
     const androidBlockStart =
       config.modResults.contents.search(/^android \{$/m);
     if (androidBlockStart === -1) {
@@ -176,6 +202,13 @@ const withAppGradleDependencies: ConfigPlugin<PluginProps> = (
     const insertedDependencies = getCoreLibraryDesugaringDependencyLines(
       dependenciesBlock,
       spacing
+    );
+    const deduplicatedDependencies = Array.from(
+      new Set(combinedProps.dependencies)
+    );
+    const filteredDependencies = deduplicatedDependencies.filter(
+      (dependency) =>
+        !hasGradleDependencyDeclaration(dependenciesBlock, dependency)
     );
     filteredDependencies.forEach((dependency) => {
       insertedDependencies.push(`${spacing}implementation '${dependency}'\n`);

--- a/plugin/src/withAppGradleDependencies.ts
+++ b/plugin/src/withAppGradleDependencies.ts
@@ -18,27 +18,15 @@ const defaultProps: PluginProps = {
 
 const CORE_LIBRARY_DESUGARING_DEPENDENCY =
   "coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'";
-const CORE_LIBRARY_DESUGARING_ARTIFACT =
-  'com.android.tools:desugar_jdk_libs';
-
-const stripBlockComments = (contents: string) =>
-  contents.replace(/\/\*[\s\S]*?\*\//g, '');
+const CORE_LIBRARY_DESUGARING_ARTIFACT = 'com.android.tools:desugar_jdk_libs';
 
 const hasCoreLibraryDesugaringEnabled = (contents: string) =>
   /^\s*(?:setCoreLibraryDesugaringEnabled\s*\(\s*true\s*\)|coreLibraryDesugaringEnabled(?:\s*=\s*|\s+)true\b)/m.test(
-    stripBlockComments(contents)
+    contents
   );
 
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-// Removes quoted strings and trailing line comments so that braces appearing
-// inside them do not throw off the nesting-depth tracking below.
-const stripLineNoise = (line: string) =>
-  line
-    .replace(/'(?:\\.|[^'\\])*'/g, "''")
-    .replace(/"(?:\\.|[^"\\])*"/g, '""')
-    .replace(/\/\/.*$/, '');
 
 const hasGradleDependencyDeclaration = (
   contents: string,
@@ -56,27 +44,24 @@ const hasGradleDependencyDeclaration = (
   );
   let nestedBlockDepth = 0;
 
-  return stripBlockComments(contents)
-    .split('\n')
-    .some((line) => {
-      const trimmedLine = line.trim();
-      if (trimmedLine.startsWith('//')) {
-        return false;
-      }
+  return contents.split('\n').some((line) => {
+    const trimmedLine = line.trim();
+    if (trimmedLine.startsWith('//')) {
+      return false;
+    }
 
-      if (/^dependencies\s*\{$/.test(trimmedLine)) {
-        return false;
-      }
+    if (/^dependencies\s*\{$/.test(trimmedLine)) {
+      return false;
+    }
 
-      const isTopLevelDependency =
-        nestedBlockDepth === 0 && declarationPattern.test(trimmedLine);
-      const sanitizedLine = stripLineNoise(trimmedLine);
-      const openBlockCount = (sanitizedLine.match(/\{/g) || []).length;
-      const closeBlockCount = (sanitizedLine.match(/\}/g) || []).length;
-      nestedBlockDepth += openBlockCount - closeBlockCount;
+    const isTopLevelDependency =
+      nestedBlockDepth === 0 && declarationPattern.test(trimmedLine);
+    const openBlockCount = (trimmedLine.match(/\{/g) || []).length;
+    const closeBlockCount = (trimmedLine.match(/\}/g) || []).length;
+    nestedBlockDepth += openBlockCount - closeBlockCount;
 
-      return isTopLevelDependency;
-    });
+    return isTopLevelDependency;
+  });
 };
 
 // Matches any pinned version of the desugaring artifact so an existing
@@ -89,9 +74,7 @@ const hasCoreLibraryDesugaringDependency = (contents: string) =>
     true
   );
 
-const replaceDisabledCoreLibraryDesugaringSettingsInGradle = (
-  contents: string
-) =>
+const replaceDisabledCoreLibraryDesugaringSettings = (contents: string) =>
   contents
     .replace(
       /^(\s*)setCoreLibraryDesugaringEnabled\s*\(\s*false\s*\)/gm,
@@ -105,16 +88,6 @@ const replaceDisabledCoreLibraryDesugaringSettingsInGradle = (
       /^(\s*)coreLibraryDesugaringEnabled(\s+)false\b/gm,
       '$1coreLibraryDesugaringEnabled$2true'
     );
-
-const replaceDisabledCoreLibraryDesugaringSettings = (contents: string) =>
-  contents
-    .split(/(\/\*[\s\S]*?\*\/)/g)
-    .map((part) =>
-      part.startsWith('/*')
-        ? part
-        : replaceDisabledCoreLibraryDesugaringSettingsInGradle(part)
-    )
-    .join('');
 
 const ensureCoreLibraryDesugaringCompileOptions = (
   contents: string,
@@ -141,18 +114,15 @@ const ensureCoreLibraryDesugaringCompileOptions = (
     /^[^\S\r\n]*compileOptions\s*\{$/m
   );
   if (compileOptionsRelativeStart === -1) {
-    const compileOptions = [];
-    compileOptions.push(`${spacing}compileOptions {`);
-    compileOptions.push('\n');
-    compileOptions.push(
-      `${spacing}${spacing}setCoreLibraryDesugaringEnabled(true)`
-    );
-    compileOptions.push('\n');
-    compileOptions.push(`${spacing}}`);
-    compileOptions.push('\n');
+    const compileOptions = [
+      `${spacing}compileOptions {`,
+      `${spacing}${spacing}setCoreLibraryDesugaringEnabled(true)`,
+      `${spacing}}`,
+      '',
+    ].join('\n');
     return [
       updatedContents.slice(0, updatedAndroidPosition),
-      ...compileOptions,
+      compileOptions,
       updatedContents.slice(updatedAndroidPosition),
     ].join('');
   }
@@ -241,23 +211,17 @@ const withAppGradleDependencies: ConfigPlugin<PluginProps> = (
       updatedDependenciesBlockStart,
       position
     );
-    const dependencyDeclarations: string[] = [];
-    if (!hasCoreLibraryDesugaringDependency(dependenciesBlock)) {
-      dependencyDeclarations.push(
-        `${spacing}${CORE_LIBRARY_DESUGARING_DEPENDENCY}`
-      );
-    }
-    const deduplicatedDependencies = Array.from(
-      new Set(combinedProps.dependencies)
-    );
-    deduplicatedDependencies
-      .filter(
-        (dependency) =>
-          !hasGradleDependencyDeclaration(dependenciesBlock, dependency)
-      )
-      .forEach((dependency) => {
-        dependencyDeclarations.push(`${spacing}implementation '${dependency}'`);
-      });
+    const dependencyDeclarations = [
+      ...(!hasCoreLibraryDesugaringDependency(dependenciesBlock)
+        ? [`${spacing}${CORE_LIBRARY_DESUGARING_DEPENDENCY}`]
+        : []),
+      ...Array.from(new Set(combinedProps.dependencies))
+        .filter(
+          (dependency) =>
+            !hasGradleDependencyDeclaration(dependenciesBlock, dependency)
+        )
+        .map((dependency) => `${spacing}implementation '${dependency}'`),
+    ];
     if (dependencyDeclarations.length === 0) {
       return config;
     }

--- a/plugin/src/withAppGradleDependencies.ts
+++ b/plugin/src/withAppGradleDependencies.ts
@@ -18,8 +18,8 @@ const defaultProps: PluginProps = {
 
 const CORE_LIBRARY_DESUGARING_DEPENDENCY =
   "coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'";
-const CORE_LIBRARY_DESUGARING_COORDINATES =
-  'com.android.tools:desugar_jdk_libs:2.1.5';
+const CORE_LIBRARY_DESUGARING_ARTIFACT =
+  'com.android.tools:desugar_jdk_libs';
 
 const stripBlockComments = (contents: string) =>
   contents.replace(/\/\*[\s\S]*?\*\//g, '');
@@ -32,17 +32,27 @@ const hasCoreLibraryDesugaringEnabled = (contents: string) =>
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
+// Removes quoted strings and trailing line comments so that braces appearing
+// inside them do not throw off the nesting-depth tracking below.
+const stripLineNoise = (line: string) =>
+  line
+    .replace(/'(?:\\.|[^'\\])*'/g, "''")
+    .replace(/"(?:\\.|[^"\\])*"/g, '""')
+    .replace(/\/\/.*$/, '');
+
 const hasGradleDependencyDeclaration = (
   contents: string,
   dependency: string,
-  configuration?: string
+  configuration?: string,
+  allowVersionSuffix = false
 ) => {
   const dependencyPattern = escapeRegExp(dependency);
   const configurationPattern = configuration
     ? escapeRegExp(configuration)
     : '[A-Za-z_][\\w.-]*';
+  const versionSuffixPattern = allowVersionSuffix ? `(?::[^'"]*)?` : '';
   const declarationPattern = new RegExp(
-    `^${configurationPattern}\\s*(?:\\(\\s*)?['"]${dependencyPattern}['"]`
+    `^${configurationPattern}\\s*(?:\\(\\s*)?['"]${dependencyPattern}${versionSuffixPattern}['"]`
   );
   let nestedBlockDepth = 0;
 
@@ -60,19 +70,23 @@ const hasGradleDependencyDeclaration = (
 
       const isTopLevelDependency =
         nestedBlockDepth === 0 && declarationPattern.test(trimmedLine);
-      const openBlockCount = (trimmedLine.match(/\{/g) || []).length;
-      const closeBlockCount = (trimmedLine.match(/\}/g) || []).length;
+      const sanitizedLine = stripLineNoise(trimmedLine);
+      const openBlockCount = (sanitizedLine.match(/\{/g) || []).length;
+      const closeBlockCount = (sanitizedLine.match(/\}/g) || []).length;
       nestedBlockDepth += openBlockCount - closeBlockCount;
 
       return isTopLevelDependency;
     });
 };
 
+// Matches any pinned version of the desugaring artifact so an existing
+// declaration is never duplicated, even when it pins a different version.
 const hasCoreLibraryDesugaringDependency = (contents: string) =>
   hasGradleDependencyDeclaration(
     contents,
-    CORE_LIBRARY_DESUGARING_COORDINATES,
-    'coreLibraryDesugaring'
+    CORE_LIBRARY_DESUGARING_ARTIFACT,
+    'coreLibraryDesugaring',
+    true
   );
 
 const replaceDisabledCoreLibraryDesugaringSettingsInGradle = (
@@ -124,7 +138,7 @@ const ensureCoreLibraryDesugaringCompileOptions = (
   }
 
   const compileOptionsRelativeStart = updatedAndroidBlock.search(
-    /^\s*compileOptions\s*\{$/m
+    /^[^\S\r\n]*compileOptions\s*\{$/m
   );
   if (compileOptionsRelativeStart === -1) {
     const compileOptions = [];
@@ -151,17 +165,6 @@ const ensureCoreLibraryDesugaringCompileOptions = (
     `${spacing}${spacing}setCoreLibraryDesugaringEnabled(true)\n`,
     updatedContents.slice(compileOptionsLineEnd),
   ].join('');
-};
-
-const getCoreLibraryDesugaringDependencyLines = (
-  contents: string,
-  spacing: string
-) => {
-  if (hasCoreLibraryDesugaringDependency(contents)) {
-    return [];
-  }
-
-  return ['\n', `${spacing}${CORE_LIBRARY_DESUGARING_DEPENDENCY}`, '\n'];
 };
 
 const withAppGradleDependencies: ConfigPlugin<PluginProps> = (
@@ -238,27 +241,29 @@ const withAppGradleDependencies: ConfigPlugin<PluginProps> = (
       updatedDependenciesBlockStart,
       position
     );
-    const insertedDependencies = getCoreLibraryDesugaringDependencyLines(
-      dependenciesBlock,
-      spacing
-    );
+    const dependencyDeclarations: string[] = [];
+    if (!hasCoreLibraryDesugaringDependency(dependenciesBlock)) {
+      dependencyDeclarations.push(
+        `${spacing}${CORE_LIBRARY_DESUGARING_DEPENDENCY}`
+      );
+    }
     const deduplicatedDependencies = Array.from(
       new Set(combinedProps.dependencies)
     );
-    const filteredDependencies = deduplicatedDependencies.filter(
-      (dependency) =>
-        !hasGradleDependencyDeclaration(dependenciesBlock, dependency)
-    );
-    filteredDependencies.forEach((dependency) => {
-      insertedDependencies.push(`${spacing}implementation '${dependency}'\n`);
-    });
-    if (insertedDependencies.length === 0) {
+    deduplicatedDependencies
+      .filter(
+        (dependency) =>
+          !hasGradleDependencyDeclaration(dependenciesBlock, dependency)
+      )
+      .forEach((dependency) => {
+        dependencyDeclarations.push(`${spacing}implementation '${dependency}'`);
+      });
+    if (dependencyDeclarations.length === 0) {
       return config;
     }
-    insertedDependencies.push('\n');
     config.modResults.contents = [
       config.modResults.contents.slice(0, position),
-      ...insertedDependencies,
+      `\n${dependencyDeclarations.join('\n')}\n`,
       config.modResults.contents.slice(position),
     ].join('');
     return config;

--- a/plugin/src/withAppGradleDependencies.ts
+++ b/plugin/src/withAppGradleDependencies.ts
@@ -9,9 +9,67 @@ export type PluginProps = {
   dependencies?: string[];
 };
 
+const DEFAULT_SPACING = '    ';
+
 const defaultProps: PluginProps = {
-  spacing: '    ',
+  spacing: DEFAULT_SPACING,
   dependencies: [],
+};
+
+const CORE_LIBRARY_DESUGARING_DEPENDENCY =
+  "coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'";
+
+const hasCoreLibraryDesugaringEnabled = (contents: string) =>
+  contents.includes('coreLibraryDesugaringEnabled') ||
+  contents.includes('setCoreLibraryDesugaringEnabled');
+
+const hasCoreLibraryDesugaringDependency = (contents: string) =>
+  /\bcoreLibraryDesugaring\b/.test(contents);
+
+const ensureCoreLibraryDesugaringCompileOptions = (
+  contents: string,
+  spacing: string,
+  androidPosition: number
+) => {
+  if (hasCoreLibraryDesugaringEnabled(contents)) {
+    return contents;
+  }
+
+  const compileOptionsStart = contents.search(/^\s*compileOptions\s*\{$/m);
+  if (compileOptionsStart === -1) {
+    const compileOptions = [];
+    compileOptions.push(`${spacing}compileOptions {`);
+    compileOptions.push('\n');
+    compileOptions.push(
+      `${spacing}${spacing}setCoreLibraryDesugaringEnabled(true)`
+    );
+    compileOptions.push('\n');
+    compileOptions.push(`${spacing}}`);
+    compileOptions.push('\n');
+    return [
+      contents.slice(0, androidPosition),
+      ...compileOptions,
+      contents.slice(androidPosition),
+    ].join('');
+  }
+
+  const compileOptionsLineEnd = contents.indexOf('\n', compileOptionsStart) + 1;
+  return [
+    contents.slice(0, compileOptionsLineEnd),
+    `${spacing}${spacing}setCoreLibraryDesugaringEnabled(true)\n`,
+    contents.slice(compileOptionsLineEnd),
+  ].join('');
+};
+
+const getCoreLibraryDesugaringDependencyLines = (
+  contents: string,
+  spacing: string
+) => {
+  if (hasCoreLibraryDesugaringDependency(contents)) {
+    return [];
+  }
+
+  return ['\n', `${spacing}${CORE_LIBRARY_DESUGARING_DEPENDENCY}`, '\n'];
 };
 
 const withAppGradleDependencies: ConfigPlugin<PluginProps> = (
@@ -19,6 +77,7 @@ const withAppGradleDependencies: ConfigPlugin<PluginProps> = (
   props: PluginProps
 ) => {
   const combinedProps = { ...defaultProps, ...(props || {}) };
+  const spacing = combinedProps.spacing || DEFAULT_SPACING;
   config = withAppBuildGradle(config, (config) => {
     if (config.modResults.language !== 'groovy') {
       WarningAggregator.addWarningAndroid(
@@ -34,9 +93,6 @@ const withAppGradleDependencies: ConfigPlugin<PluginProps> = (
     const filteredDependencies = deduplicatedDependencies.filter((dep) => {
       return config.modResults.contents.indexOf(dep) === -1;
     });
-    if (filteredDependencies.length === 0) {
-      return config;
-    }
 
     const androidBlockStart =
       config.modResults.contents.search(/^android \{$/m);
@@ -57,20 +113,11 @@ const withAppGradleDependencies: ConfigPlugin<PluginProps> = (
       return config;
     }
     const androidPosition = androidBlockStart + androidBlockEnd;
-    const compileOptions = [];
-    compileOptions.push(`${combinedProps.spacing}compileOptions {`);
-    compileOptions.push('\n');
-    compileOptions.push(
-      `${combinedProps.spacing}setCoreLibraryDesugaringEnabled(true)`
+    config.modResults.contents = ensureCoreLibraryDesugaringCompileOptions(
+      config.modResults.contents,
+      spacing,
+      androidPosition
     );
-    compileOptions.push('\n');
-    compileOptions.push(`${combinedProps.spacing}}`);
-    compileOptions.push('\n');
-    config.modResults.contents = [
-      config.modResults.contents.slice(0, androidPosition),
-      ...compileOptions,
-      config.modResults.contents.slice(androidPosition),
-    ].join('');
 
     const dependenciesBlockStart =
       config.modResults.contents.search(/^dependencies \{$/m);
@@ -93,17 +140,16 @@ const withAppGradleDependencies: ConfigPlugin<PluginProps> = (
       return config;
     }
     const position = dependenciesBlockStart + dependenciesBlockEnd;
-    let insertedDependencies: string[] = [];
-    insertedDependencies.push('\n');
-    insertedDependencies.push(
-      `${combinedProps.spacing}coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'`
+    const insertedDependencies = getCoreLibraryDesugaringDependencyLines(
+      config.modResults.contents,
+      spacing
     );
-    insertedDependencies.push('\n');
     filteredDependencies.forEach((dependency) => {
-      insertedDependencies.push(
-        `${combinedProps.spacing}implementation '${dependency}'\n`
-      );
+      insertedDependencies.push(`${spacing}implementation '${dependency}'\n`);
     });
+    if (insertedDependencies.length === 0) {
+      return config;
+    }
     insertedDependencies.push('\n');
     config.modResults.contents = [
       config.modResults.contents.slice(0, position),

--- a/scripts/test-with-app-gradle-dependencies.js
+++ b/scripts/test-with-app-gradle-dependencies.js
@@ -88,6 +88,39 @@ dependencies {
   );
 });
 
+test('ignores compileOptions blocks outside android', async () => {
+  const gradleWithExternalCompileOptions = `plugins {
+    id 'com.android.application'
+}
+
+subprojects {
+    compileOptions {
+        setCoreLibraryDesugaringEnabled(false)
+        sourceCompatibility JavaVersion.VERSION_17
+    }
+}
+
+android {
+    namespace 'com.example'
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+}
+`;
+
+  const result = await applyPlugin(gradleWithExternalCompileOptions);
+
+  assert.match(
+    result,
+    /subprojects \{\n    compileOptions \{\n        setCoreLibraryDesugaringEnabled\(false\)\n        sourceCompatibility JavaVersion\.VERSION_17/
+  );
+  assert.match(
+    result,
+    /android \{\n    namespace 'com\.example'\n    compileOptions \{\n        setCoreLibraryDesugaringEnabled\(true\)\n    }\n}/
+  );
+});
+
 test('does not duplicate existing core library desugaring settings', async () => {
   const gradleWithDesugaring = `plugins {
     id 'com.android.application'
@@ -202,6 +235,28 @@ dependencies {
   assert.ok(result.includes(coreLibraryDesugaringDependency));
 });
 
+test('does not treat block comments as existing core library desugaring dependency', async () => {
+  const gradleWithDependencyBlockComment = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+    /*
+    ${coreLibraryDesugaringDependency}
+    */
+}
+`;
+
+  const result = await applyPlugin(gradleWithDependencyBlockComment);
+
+  assert.equal(countOccurrences(result, coreLibraryDesugaringDependency), 2);
+});
+
 test('does not treat comments as existing feature dependencies', async () => {
   const featureDependency = 'com.example:feature:1.0';
   const gradleWithFeatureDependencyComment = `plugins {
@@ -223,6 +278,34 @@ dependencies {
   });
 
   assert.match(result, /implementation 'com\.example:feature:1\.0'/);
+});
+
+test('does not treat block comments as existing feature dependencies', async () => {
+  const featureDependency = 'com.example:feature:1.0';
+  const gradleWithFeatureDependencyBlockComment = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+    /*
+    implementation '${featureDependency}'
+    */
+}
+`;
+
+  const result = await applyPlugin(gradleWithFeatureDependencyBlockComment, {
+    dependencies: [featureDependency],
+  });
+
+  assert.equal(
+    countOccurrences(result, `implementation '${featureDependency}'`),
+    2
+  );
 });
 
 test('does not treat dependency constraints as existing feature dependencies', async () => {

--- a/scripts/test-with-app-gradle-dependencies.js
+++ b/scripts/test-with-app-gradle-dependencies.js
@@ -392,6 +392,118 @@ dependencies {
   );
 });
 
+test('enables desugaring inside a compileOptions block preceded by a blank line', async () => {
+  const gradleWithBlankLineBeforeCompileOptions = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+}
+`;
+
+  const result = await applyPlugin(gradleWithBlankLineBeforeCompileOptions);
+
+  assert.equal(countOccurrences(result, 'compileOptions {'), 1);
+  assert.match(
+    result,
+    /compileOptions \{\n        setCoreLibraryDesugaringEnabled\(true\)\n        sourceCompatibility/
+  );
+  assert.doesNotMatch(
+    result,
+    /namespace 'com\.example'\n\n        setCoreLibraryDesugaringEnabled/
+  );
+});
+
+test('enables desugaring inside a compileOptions block preceded by a comment line', async () => {
+  const gradleWithCommentBeforeCompileOptions = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+    // Java 17 toolchain
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+}
+`;
+
+  const result = await applyPlugin(gradleWithCommentBeforeCompileOptions);
+
+  assert.equal(countOccurrences(result, 'compileOptions {'), 1);
+  assert.match(
+    result,
+    /compileOptions \{\n        setCoreLibraryDesugaringEnabled\(true\)\n        sourceCompatibility/
+  );
+});
+
+test('does not duplicate an existing desugaring dependency pinned to another version', async () => {
+  const gradleWithOtherDesugaringVersion = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+    compileOptions {
+        setCoreLibraryDesugaringEnabled(true)
+    }
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
+}
+`;
+
+  const result = await applyPlugin(gradleWithOtherDesugaringVersion);
+
+  assert.equal(
+    countOccurrences(result, "coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs"),
+    1
+  );
+  assert.doesNotMatch(result, /desugar_jdk_libs:2\.1\.5/);
+  assert.match(result, /desugar_jdk_libs:2\.0\.4/);
+});
+
+test('does not desync nesting depth on braces inside trailing comments', async () => {
+  const featureDependency = 'com.example:feature:1.0';
+  const gradleWithTrailingBraceComment = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android' // TODO close this {
+    implementation '${featureDependency}'
+}
+`;
+
+  const result = await applyPlugin(gradleWithTrailingBraceComment, {
+    dependencies: [featureDependency],
+  });
+
+  assert.equal(
+    countOccurrences(result, `implementation '${featureDependency}'`),
+    1
+  );
+});
+
 const run = async () => {
   const failures = [];
 

--- a/scripts/test-with-app-gradle-dependencies.js
+++ b/scripts/test-with-app-gradle-dependencies.js
@@ -119,6 +119,89 @@ dependencies {
   assert.match(result, /implementation 'com.example:feature:1\.0'/);
 });
 
+test('replaces explicitly disabled core library desugaring property syntax', async () => {
+  const gradleWithDisabledDesugaring = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+    compileOptions {
+        coreLibraryDesugaringEnabled false
+    }
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+}
+`;
+
+  const result = await applyPlugin(gradleWithDisabledDesugaring);
+
+  assert.match(result, /coreLibraryDesugaringEnabled true/);
+  assert.doesNotMatch(result, /coreLibraryDesugaringEnabled false/);
+  assert.ok(result.includes(coreLibraryDesugaringDependency));
+});
+
+test('replaces explicitly disabled core library desugaring setter syntax', async () => {
+  const gradleWithDisabledDesugaring = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+    compileOptions {
+        setCoreLibraryDesugaringEnabled(false)
+    }
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+}
+`;
+
+  const result = await applyPlugin(gradleWithDisabledDesugaring);
+
+  assert.match(result, /setCoreLibraryDesugaringEnabled\(true\)/);
+  assert.doesNotMatch(result, /setCoreLibraryDesugaringEnabled\(false\)/);
+  assert.ok(result.includes(coreLibraryDesugaringDependency));
+});
+
+test('leaves gradle unchanged when dependencies block is missing', async () => {
+  const gradleWithoutDependencies = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+}
+`;
+
+  const result = await applyPlugin(gradleWithoutDependencies);
+
+  assert.equal(result, gradleWithoutDependencies);
+});
+
+test('does not treat comments as existing core library desugaring dependency', async () => {
+  const gradleWithDependencyComment = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+    // coreLibraryDesugaring is added by the Bitmovin plugin
+}
+`;
+
+  const result = await applyPlugin(gradleWithDependencyComment);
+
+  assert.ok(result.includes(coreLibraryDesugaringDependency));
+});
+
 const run = async () => {
   const failures = [];
 
@@ -138,4 +221,7 @@ const run = async () => {
   }
 };
 
-run();
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/test-with-app-gradle-dependencies.js
+++ b/scripts/test-with-app-gradle-dependencies.js
@@ -308,6 +308,34 @@ dependencies {
   );
 });
 
+test('does not treat dependency constraints as existing core library desugaring dependency', async () => {
+  const gradleWithCoreLibraryDependencyConstraint = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+    constraints {
+        coreLibraryDesugaring('com.android.tools:desugar_jdk_libs:2.1.5') {
+            because 'pins the version when another dependency requests it'
+        }
+    }
+}
+`;
+
+  const result = await applyPlugin(gradleWithCoreLibraryDependencyConstraint);
+
+  assert.equal(countOccurrences(result, coreLibraryDesugaringDependency), 1);
+  assert.match(
+    result,
+    /constraints \{\n        coreLibraryDesugaring\('com\.android\.tools:desugar_jdk_libs:2\.1\.5'\)/
+  );
+});
+
 test('does not treat dependency constraints as existing feature dependencies', async () => {
   const featureDependency = 'com.example:feature:1.0';
   const gradleWithFeatureDependencyConstraint = `plugins {
@@ -333,6 +361,35 @@ dependencies {
   });
 
   assert.match(result, /implementation 'com\.example:feature:1\.0'/);
+});
+
+test('does not rewrite disabled core library desugaring settings inside block comments', async () => {
+  const gradleWithDisabledDesugaringBlockComment = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+    /*
+    setCoreLibraryDesugaringEnabled(false)
+    */
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+}
+`;
+
+  const result = await applyPlugin(gradleWithDisabledDesugaringBlockComment);
+
+  assert.match(
+    result,
+    /\/\*\n    setCoreLibraryDesugaringEnabled\(false\)\n    \*\//
+  );
+  assert.match(
+    result,
+    /compileOptions \{\n        setCoreLibraryDesugaringEnabled\(true\)\n    }/
+  );
 });
 
 const run = async () => {

--- a/scripts/test-with-app-gradle-dependencies.js
+++ b/scripts/test-with-app-gradle-dependencies.js
@@ -202,6 +202,56 @@ dependencies {
   assert.ok(result.includes(coreLibraryDesugaringDependency));
 });
 
+test('does not treat comments as existing feature dependencies', async () => {
+  const featureDependency = 'com.example:feature:1.0';
+  const gradleWithFeatureDependencyComment = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+    // ${featureDependency} is added by the Bitmovin plugin
+}
+`;
+
+  const result = await applyPlugin(gradleWithFeatureDependencyComment, {
+    dependencies: [featureDependency],
+  });
+
+  assert.match(result, /implementation 'com\.example:feature:1\.0'/);
+});
+
+test('does not treat dependency constraints as existing feature dependencies', async () => {
+  const featureDependency = 'com.example:feature:1.0';
+  const gradleWithFeatureDependencyConstraint = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+    constraints {
+        implementation('${featureDependency}') {
+            because 'pins the version when another dependency requests it'
+        }
+    }
+}
+`;
+
+  const result = await applyPlugin(gradleWithFeatureDependencyConstraint, {
+    dependencies: [featureDependency],
+  });
+
+  assert.match(result, /implementation 'com\.example:feature:1\.0'/);
+});
+
 const run = async () => {
   const failures = [];
 

--- a/scripts/test-with-app-gradle-dependencies.js
+++ b/scripts/test-with-app-gradle-dependencies.js
@@ -3,21 +3,9 @@ const assert = require('node:assert/strict');
 const withAppGradleDependencies =
   require('../plugin/build/withAppGradleDependencies').default;
 
-const coreLibraryDesugaringDependency =
+const desugaringDependency =
   "coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'";
-
-const baseGradle = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-}
-`;
+const featureDependency = 'com.example:feature:1.0';
 
 const countOccurrences = (contents, needle) =>
   contents.split(needle).length - 1;
@@ -47,370 +35,46 @@ const applyPlugin = async (contents, props = {}) => {
   return result.modResults.contents;
 };
 
+const gradle = ({
+  android = "    namespace 'com.example'",
+  dependencies = '',
+}) => `plugins {
+    id 'com.android.application'
+}
+
+android {
+${android}
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+${dependencies}
+}
+`;
+
 const tests = [];
 
 const test = (name, run) => {
   tests.push({ name, run });
 };
 
-test('adds core library desugaring when no feature dependencies are requested', async () => {
-  const result = await applyPlugin(baseGradle);
+test('adds desugaring when no feature dependencies are requested', async () => {
+  const result = await applyPlugin(gradle({}));
 
   assert.match(result, /setCoreLibraryDesugaringEnabled\(true\)/);
-  assert.ok(result.includes(coreLibraryDesugaringDependency));
+  assert.ok(result.includes(desugaringDependency));
 });
 
-test('enables desugaring inside an existing compileOptions block', async () => {
-  const gradleWithCompileOptions = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-    }
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-}
-`;
-
-  const result = await applyPlugin(gradleWithCompileOptions, {
-    dependencies: ['com.example:feature:1.0'],
-  });
-
-  assert.equal(countOccurrences(result, 'compileOptions {'), 1);
-  assert.match(
-    result,
-    /compileOptions \{\n        setCoreLibraryDesugaringEnabled\(true\)\n        sourceCompatibility/
-  );
-});
-
-test('ignores compileOptions blocks outside android', async () => {
-  const gradleWithExternalCompileOptions = `plugins {
-    id 'com.android.application'
-}
-
-subprojects {
-    compileOptions {
-        setCoreLibraryDesugaringEnabled(false)
-        sourceCompatibility JavaVersion.VERSION_17
-    }
-}
-
-android {
-    namespace 'com.example'
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-}
-`;
-
-  const result = await applyPlugin(gradleWithExternalCompileOptions);
-
-  assert.match(
-    result,
-    /subprojects \{\n    compileOptions \{\n        setCoreLibraryDesugaringEnabled\(false\)\n        sourceCompatibility JavaVersion\.VERSION_17/
-  );
-  assert.match(
-    result,
-    /android \{\n    namespace 'com\.example'\n    compileOptions \{\n        setCoreLibraryDesugaringEnabled\(true\)\n    }\n}/
-  );
-});
-
-test('does not duplicate existing core library desugaring settings', async () => {
-  const gradleWithDesugaring = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
-    compileOptions {
-        setCoreLibraryDesugaringEnabled(true)
-        sourceCompatibility JavaVersion.VERSION_17
-    }
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-    ${coreLibraryDesugaringDependency}
-}
-`;
-
-  const result = await applyPlugin(gradleWithDesugaring, {
-    dependencies: ['com.example:feature:1.0'],
-  });
-
-  assert.equal(
-    countOccurrences(result, 'setCoreLibraryDesugaringEnabled(true)'),
-    1
-  );
-  assert.equal(countOccurrences(result, coreLibraryDesugaringDependency), 1);
-  assert.match(result, /implementation 'com.example:feature:1\.0'/);
-});
-
-test('replaces explicitly disabled core library desugaring property syntax', async () => {
-  const gradleWithDisabledDesugaring = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
-    compileOptions {
-        coreLibraryDesugaringEnabled false
-    }
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-}
-`;
-
-  const result = await applyPlugin(gradleWithDisabledDesugaring);
-
-  assert.match(result, /coreLibraryDesugaringEnabled true/);
-  assert.doesNotMatch(result, /coreLibraryDesugaringEnabled false/);
-  assert.ok(result.includes(coreLibraryDesugaringDependency));
-});
-
-test('replaces explicitly disabled core library desugaring setter syntax', async () => {
-  const gradleWithDisabledDesugaring = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
-    compileOptions {
-        setCoreLibraryDesugaringEnabled(false)
-    }
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-}
-`;
-
-  const result = await applyPlugin(gradleWithDisabledDesugaring);
-
-  assert.match(result, /setCoreLibraryDesugaringEnabled\(true\)/);
-  assert.doesNotMatch(result, /setCoreLibraryDesugaringEnabled\(false\)/);
-  assert.ok(result.includes(coreLibraryDesugaringDependency));
-});
-
-test('leaves gradle unchanged when dependencies block is missing', async () => {
-  const gradleWithoutDependencies = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
-}
-`;
-
-  const result = await applyPlugin(gradleWithoutDependencies);
-
-  assert.equal(result, gradleWithoutDependencies);
-});
-
-test('does not treat comments as existing core library desugaring dependency', async () => {
-  const gradleWithDependencyComment = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-    // coreLibraryDesugaring is added by the Bitmovin plugin
-}
-`;
-
-  const result = await applyPlugin(gradleWithDependencyComment);
-
-  assert.ok(result.includes(coreLibraryDesugaringDependency));
-});
-
-test('does not treat block comments as existing core library desugaring dependency', async () => {
-  const gradleWithDependencyBlockComment = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-    /*
-    ${coreLibraryDesugaringDependency}
-    */
-}
-`;
-
-  const result = await applyPlugin(gradleWithDependencyBlockComment);
-
-  assert.equal(countOccurrences(result, coreLibraryDesugaringDependency), 2);
-});
-
-test('does not treat comments as existing feature dependencies', async () => {
-  const featureDependency = 'com.example:feature:1.0';
-  const gradleWithFeatureDependencyComment = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-    // ${featureDependency} is added by the Bitmovin plugin
-}
-`;
-
-  const result = await applyPlugin(gradleWithFeatureDependencyComment, {
-    dependencies: [featureDependency],
-  });
-
-  assert.match(result, /implementation 'com\.example:feature:1\.0'/);
-});
-
-test('does not treat block comments as existing feature dependencies', async () => {
-  const featureDependency = 'com.example:feature:1.0';
-  const gradleWithFeatureDependencyBlockComment = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-    /*
-    implementation '${featureDependency}'
-    */
-}
-`;
-
-  const result = await applyPlugin(gradleWithFeatureDependencyBlockComment, {
-    dependencies: [featureDependency],
-  });
-
-  assert.equal(
-    countOccurrences(result, `implementation '${featureDependency}'`),
-    2
-  );
-});
-
-test('does not treat dependency constraints as existing core library desugaring dependency', async () => {
-  const gradleWithCoreLibraryDependencyConstraint = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-    constraints {
-        coreLibraryDesugaring('com.android.tools:desugar_jdk_libs:2.1.5') {
-            because 'pins the version when another dependency requests it'
-        }
-    }
-}
-`;
-
-  const result = await applyPlugin(gradleWithCoreLibraryDependencyConstraint);
-
-  assert.equal(countOccurrences(result, coreLibraryDesugaringDependency), 1);
-  assert.match(
-    result,
-    /constraints \{\n        coreLibraryDesugaring\('com\.android\.tools:desugar_jdk_libs:2\.1\.5'\)/
-  );
-});
-
-test('does not treat dependency constraints as existing feature dependencies', async () => {
-  const featureDependency = 'com.example:feature:1.0';
-  const gradleWithFeatureDependencyConstraint = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-    constraints {
-        implementation('${featureDependency}') {
-            because 'pins the version when another dependency requests it'
-        }
-    }
-}
-`;
-
-  const result = await applyPlugin(gradleWithFeatureDependencyConstraint, {
-    dependencies: [featureDependency],
-  });
-
-  assert.match(result, /implementation 'com\.example:feature:1\.0'/);
-});
-
-test('does not rewrite disabled core library desugaring settings inside block comments', async () => {
-  const gradleWithDisabledDesugaringBlockComment = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
-    /*
-    setCoreLibraryDesugaringEnabled(false)
-    */
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-}
-`;
-
-  const result = await applyPlugin(gradleWithDisabledDesugaringBlockComment);
-
-  assert.match(
-    result,
-    /\/\*\n    setCoreLibraryDesugaringEnabled\(false\)\n    \*\//
-  );
-  assert.match(
-    result,
-    /compileOptions \{\n        setCoreLibraryDesugaringEnabled\(true\)\n    }/
-  );
-});
-
-test('enables desugaring inside a compileOptions block preceded by a blank line', async () => {
-  const gradleWithBlankLineBeforeCompileOptions = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
+test('inserts desugaring inside existing compileOptions with surrounding whitespace', async () => {
+  const result = await applyPlugin(
+    gradle({
+      android: `    namespace 'com.example'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
-    }
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-}
-`;
-
-  const result = await applyPlugin(gradleWithBlankLineBeforeCompileOptions);
+    }`,
+    })
+  );
 
   assert.equal(countOccurrences(result, 'compileOptions {'), 1);
   assert.match(
@@ -423,85 +87,42 @@ dependencies {
   );
 });
 
-test('enables desugaring inside a compileOptions block preceded by a comment line', async () => {
-  const gradleWithCommentBeforeCompileOptions = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
-    // Java 17 toolchain
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-    }
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-}
-`;
-
-  const result = await applyPlugin(gradleWithCommentBeforeCompileOptions);
-
-  assert.equal(countOccurrences(result, 'compileOptions {'), 1);
-  assert.match(
-    result,
-    /compileOptions \{\n        setCoreLibraryDesugaringEnabled\(true\)\n        sourceCompatibility/
-  );
-});
-
-test('does not duplicate an existing desugaring dependency pinned to another version', async () => {
-  const gradleWithOtherDesugaringVersion = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
+test('does not duplicate existing desugaring dependency', async () => {
+  const result = await applyPlugin(
+    gradle({
+      android: `    namespace 'com.example'
     compileOptions {
         setCoreLibraryDesugaringEnabled(true)
-    }
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android'
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
-}
-`;
-
-  const result = await applyPlugin(gradleWithOtherDesugaringVersion);
+    }`,
+      dependencies:
+        "    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'",
+    })
+  );
 
   assert.equal(
-    countOccurrences(result, "coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs"),
+    countOccurrences(
+      result,
+      "coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs"
+    ),
     1
   );
   assert.doesNotMatch(result, /desugar_jdk_libs:2\.1\.5/);
-  assert.match(result, /desugar_jdk_libs:2\.0\.4/);
 });
 
-test('does not desync nesting depth on braces inside trailing comments', async () => {
-  const featureDependency = 'com.example:feature:1.0';
-  const gradleWithTrailingBraceComment = `plugins {
-    id 'com.android.application'
-}
-
-android {
-    namespace 'com.example'
-}
-
-dependencies {
-    implementation 'com.facebook.react:react-android' // TODO close this {
-    implementation '${featureDependency}'
-}
-`;
-
-  const result = await applyPlugin(gradleWithTrailingBraceComment, {
-    dependencies: [featureDependency],
-  });
-
-  assert.equal(
-    countOccurrences(result, `implementation '${featureDependency}'`),
-    1
+test('ignores comments and constraints when checking feature dependencies', async () => {
+  const result = await applyPlugin(
+    gradle({
+      dependencies: `    // ${featureDependency} is added by the plugin
+    constraints {
+        implementation('${featureDependency}') {
+            because 'pins the version when another dependency requests it'
+        }
+    }`,
+    }),
+    { dependencies: [featureDependency] }
   );
+
+  assert.match(result, /implementation 'com\.example:feature:1\.0'/);
 });
 
 const run = async () => {

--- a/scripts/test-with-app-gradle-dependencies.js
+++ b/scripts/test-with-app-gradle-dependencies.js
@@ -1,0 +1,141 @@
+const assert = require('node:assert/strict');
+
+const withAppGradleDependencies =
+  require('../plugin/build/withAppGradleDependencies').default;
+
+const coreLibraryDesugaringDependency =
+  "coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'";
+
+const baseGradle = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+}
+`;
+
+const countOccurrences = (contents, needle) =>
+  contents.split(needle).length - 1;
+
+const applyPlugin = async (contents, props = {}) => {
+  const config = withAppGradleDependencies(
+    { name: 'test-app', slug: 'test-app' },
+    props
+  );
+  const appBuildGradleMod = config.mods?.android?.appBuildGradle;
+  assert.equal(typeof appBuildGradleMod, 'function');
+
+  const result = await appBuildGradleMod({
+    ...config,
+    modResults: {
+      language: 'groovy',
+      contents,
+    },
+    modRequest: {
+      projectRoot: process.cwd(),
+      platform: 'android',
+      modName: 'appBuildGradle',
+      introspect: true,
+    },
+  });
+
+  return result.modResults.contents;
+};
+
+const tests = [];
+
+const test = (name, run) => {
+  tests.push({ name, run });
+};
+
+test('adds core library desugaring when no feature dependencies are requested', async () => {
+  const result = await applyPlugin(baseGradle);
+
+  assert.match(result, /setCoreLibraryDesugaringEnabled\(true\)/);
+  assert.ok(result.includes(coreLibraryDesugaringDependency));
+});
+
+test('enables desugaring inside an existing compileOptions block', async () => {
+  const gradleWithCompileOptions = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+}
+`;
+
+  const result = await applyPlugin(gradleWithCompileOptions, {
+    dependencies: ['com.example:feature:1.0'],
+  });
+
+  assert.equal(countOccurrences(result, 'compileOptions {'), 1);
+  assert.match(
+    result,
+    /compileOptions \{\n        setCoreLibraryDesugaringEnabled\(true\)\n        sourceCompatibility/
+  );
+});
+
+test('does not duplicate existing core library desugaring settings', async () => {
+  const gradleWithDesugaring = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example'
+    compileOptions {
+        setCoreLibraryDesugaringEnabled(true)
+        sourceCompatibility JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-android'
+    ${coreLibraryDesugaringDependency}
+}
+`;
+
+  const result = await applyPlugin(gradleWithDesugaring, {
+    dependencies: ['com.example:feature:1.0'],
+  });
+
+  assert.equal(
+    countOccurrences(result, 'setCoreLibraryDesugaringEnabled(true)'),
+    1
+  );
+  assert.equal(countOccurrences(result, coreLibraryDesugaringDependency), 1);
+  assert.match(result, /implementation 'com.example:feature:1\.0'/);
+});
+
+const run = async () => {
+  const failures = [];
+
+  for (const { name, run } of tests) {
+    try {
+      await run();
+      console.log(`PASS ${name}`);
+    } catch (error) {
+      failures.push({ name, error });
+      console.error(`FAIL ${name}`);
+      console.error(error);
+    }
+  }
+
+  if (failures.length > 0) {
+    process.exitCode = 1;
+  }
+};
+
+run();


### PR DESCRIPTION
## Description

Android app builds can fail when a dependency requires Java library desugaring because the config plugin only enabled desugaring while adding optional Cast or offline dependencies.

## Changes

- Enable core library desugaring independently from optional feature dependencies
- Update existing disabled desugaring settings instead of duplicating Gradle entries
- Add plugin regression coverage and run it in TypeScript CI

## Manual testing

Before the fix:

- Check out `development`
- In the example app, configure Android without `features.offline` and without `features.googleCastSDK.android`
- Build the android app, it should fail because Java library desugaring is not enabled while a dependency requires it
<!--
- Specifically:
- Run Expo prebuild for that app
- Open `android/app/build.gradle`
- Confirm `setCoreLibraryDesugaringEnabled(true)` and `coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'` are missing
- Run the Android build, for example `./gradlew assembleDebug` from the generated `android` directory
- Confirm the build fails because Java library desugaring is not enabled while a dependency requires it
-->

After the fix:

- Check out this branch
- In the example app, configure Android without `features.offline` and without `features.googleCastSDK.android`
- Build the android app, it should work
<!--
- Specifically:
- Repeat the same prebuild with the same plugin config
- Open `android/app/build.gradle`
- Confirm `setCoreLibraryDesugaringEnabled(true)` is present in `android.compileOptions`
- Confirm `coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'` is present in `dependencies`
- Confirm existing disabled desugaring settings are rewritten to true and existing desugaring entries are not duplicated
- Run the Android build again
- Confirm the build succeeds past the desugaring configuration step
-->

Additional check:

- Run `yarn test:plugin`

## Checklist
- [x] 🗒 `CHANGELOG` entry
