### PR TITLE
Remove updatesNowPlayingInfoCenter removed from iOS SDK 3.115.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Removed
 
-- iOS: `TweaksConfig.updatesNowPlayingInfoCenter`, which was removed from the native iOS SDK in `3.115.0`. Use `MediaControlConfig.isEnabled` to control the Now Playing information instead
+- iOS: `TweaksConfig.updatesNowPlayingInfoCenter`. Use `MediaControlConfig.isEnabled` to control the Now Playing information instead
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+- iOS: `TweaksConfig.updatesNowPlayingInfoCenter`, which was removed from the native iOS SDK in `3.115.0`. Use `MediaControlConfig.isEnabled` to control the Now Playing information instead
+
 ### Changed
 
 - Update Bitmovin's native iOS SDK version to `3.115.0`

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -146,11 +146,6 @@ extension RCTConvert {
                 break
             }
         }
-#if !os(tvOS)
-        if let updatesNowPlayingInfoCenter = json["updatesNowPlayingInfoCenter"] as? Bool {
-            tweaksConfig.updatesNowPlayingInfoCenter = updatesNowPlayingInfoCenter
-        }
-#endif
         return tweaksConfig
     }
 

--- a/src/mediaControlConfig.ts
+++ b/src/mediaControlConfig.ts
@@ -13,8 +13,6 @@ export interface MediaControlConfig {
    * For a detailed list of the supported features in the **default behavior**,
    * check the **Default Supported Features** section.
    *
-   * @remarks Enabling this flag will automatically treat {@link TweaksConfig.updatesNowPlayingInfoCenter} as `false`.
-   *
    * ## Limitations
    * ---
    * - Android: If an app creates multiple player instances, the player shown in media controls is the latest one created having media controls enabled.

--- a/src/tweaksConfig.ts
+++ b/src/tweaksConfig.ts
@@ -174,19 +174,6 @@ export interface TweaksConfig {
    * @platform Android
    */
   enableDrmLicenseRenewRetry?: boolean;
-  /**
-   * Determines whether `AVKit` should update Now Playing information automatically when using System UI.
-   *
-   * - If set to `false`, the automatic updates of Now Playing Info sent by `AVKit` are disabled.
-   *   This prevents interference with manual updates you may want to perform.
-   * - If set to `true`, the default behaviour is maintained, allowing `AVKit` to handle Now Playing updates.
-   *
-   * Default is `true`.
-   *
-   * @deprecated To enable the Now Playing information use {@link MediaControlConfig.isEnabled}
-   * @platform iOS
-   */
-  updatesNowPlayingInfoCenter?: boolean;
 
   /**
    * When switching between video formats (eg: adapting between video qualities)


### PR DESCRIPTION
## Description

The native iOS SDK removed `TweaksConfig.updatesNowPlayingInfoCenter` in `3.115.0`. The bridge in `RCTConvert+BitmovinPlayer.swift` still set that property, so building against the bumped SDK fails to compile.

This stacks on top of the `3.115.0` bump and removes the now-unbuildable API so the version update compiles.

## Changes

- Remove the native mapping of `updatesNowPlayingInfoCenter` in `ios/RCTConvert+BitmovinPlayer.swift`
- Remove the already-deprecated `updatesNowPlayingInfoCenter` field from `src/tweaksConfig.ts`
- Remove the dangling doc reference to it in `src/mediaControlConfig.ts`
- Add a `Removed` changelog entry pointing users to `MediaControlConfig.isEnabled`

The replacement is already wired end to end: `MediaControlConfig.isEnabled` maps to the iOS `NowPlayingConfig.isNowPlayingInfoEnabled` and the Android `MediaControlConfig`, so no new capability is needed, only removal of the dead path.

## Checklist
- [x] 🗒 `CHANGELOG` entry
