### PR TITLE
Expose `Player.showAirPlayTargetPicker()` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- iOS: `Player.showAirPlayTargetPicker()` to display the system AirPlay route selection menu
+
 ### Fixed
 
 - Android: Expo config plugin now enables core library desugaring independently from Cast and offline features

--- a/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/PlayerModule.kt
@@ -181,6 +181,10 @@ class PlayerModule : Module() {
             false
         }
 
+        AsyncFunction("showAirPlayTargetPicker") { _: String ->
+            // AirPlay is iOS-only, no-op on Android
+        }
+
         AsyncFunction("isCastAvailable") { nativeId: NativeId ->
             val player = PlayerRegistry.getPlayer(nativeId)
             return@AsyncFunction player?.isCastAvailable

--- a/ios/PlayerModule.swift
+++ b/ios/PlayerModule.swift
@@ -162,6 +162,11 @@ public class PlayerModule: Module {
             nil
             #endif
         }.runOnQueue(.main)
+        AsyncFunction("showAirPlayTargetPicker") { (nativeId: NativeId) in
+            #if os(iOS)
+            PlayerRegistry.getPlayer(nativeId: nativeId)?.showAirPlayTargetPicker()
+            #endif
+        }.runOnQueue(.main)
         AsyncFunction("isCastAvailable") { (nativeId: NativeId) -> Bool? in
             PlayerRegistry.getPlayer(nativeId: nativeId)?.isCastAvailable
         }.runOnQueue(.main)

--- a/src/modules/PlayerModule.ts
+++ b/src/modules/PlayerModule.ts
@@ -153,6 +153,11 @@ declare class PlayerModule extends NativeModule<PlayerModuleEvents> {
   isAirPlayAvailable(nativeId: string): Promise<boolean | null>;
 
   /**
+   * Display the AirPlay route selection menu for nativeId's player (iOS only).
+   */
+  showAirPlayTargetPicker(nativeId: string): Promise<void>;
+
+  /**
    * Resolve nativeId's cast availability state.
    */
   isCastAvailable(nativeId: string): Promise<boolean | null>;

--- a/src/player.ts
+++ b/src/player.ts
@@ -402,9 +402,9 @@ export class Player extends NativeInstance<PlayerConfig> {
    * @platform iOS
    */
   showAirPlayTargetPicker = () => {
-    if (Platform.OS === 'android') {
+    if (Platform.OS !== 'ios' || Platform.isTV) {
       console.warn(
-        `[Player ${this.nativeId}] Method showAirPlayTargetPicker is not available for Android. Only iOS devices.`
+        `[Player ${this.nativeId}] Method showAirPlayTargetPicker is only available on iOS (not Android/tvOS).`
       );
       return;
     }

--- a/src/player.ts
+++ b/src/player.ts
@@ -396,6 +396,22 @@ export class Player extends NativeInstance<PlayerConfig> {
   };
 
   /**
+   * Displays the system AirPlay route selection menu, allowing the user to pick
+   * an AirPlay target for the current playback.
+   *
+   * @platform iOS
+   */
+  showAirPlayTargetPicker = () => {
+    if (Platform.OS === 'android') {
+      console.warn(
+        `[Player ${this.nativeId}] Method showAirPlayTargetPicker is not available for Android. Only iOS devices.`
+      );
+      return;
+    }
+    void PlayerModule.showAirPlayTargetPicker(this.nativeId);
+  };
+
+  /**
    * @returns The currently selected audio track or `null`.
    */
   getAudioTrack = async (): Promise<AudioTrack | null> => {


### PR DESCRIPTION
## Description
<!-- Describe the problem as detailed as possible -->
<!-- Include any information that may help to review the PR -->
`showAirPlayTargetPicker` (iOS API) was not exposed in React Native. This feature exposes it in order to allow users to programmatically show the target picker. 

## Changes
<!-- Describe your changes as detailed as possible  -->
<!-- Include any information that may help to review the PR -->
Map the showAirplayTargetPicker API in the relevant files, only for iOS platforms


## Checklist
- [x] 🗒 `CHANGELOG` entry
