### PR TITLE
Restore unreleased changelog after release

### DIFF
--- a/.github/scripts/ensure_unreleased_changelog.py
+++ b/.github/scripts/ensure_unreleased_changelog.py
@@ -1,0 +1,53 @@
+"""Ensure CHANGELOG.md contains a top-level [Unreleased] section."""
+from __future__ import annotations
+
+import re
+import sys
+
+
+CHANGELOG_FILE = "CHANGELOG.md"
+HEADER_CHANGELOG = "# Changelog"
+HEADER_UNRELEASED = "## [Unreleased]"
+
+
+def normalize_newlines(text: str) -> str:
+    return text.replace("\r\n", "\n")
+
+
+def ensure_unreleased_section(content: str) -> str:
+    if re.search(rf"^{re.escape(HEADER_UNRELEASED)}(?:\s|$)", content, flags=re.MULTILINE):
+        return content
+
+    release_heading_match = re.search(r"^## \[[^\]]+\]", content, flags=re.MULTILINE)
+    if release_heading_match:
+        prefix = content[: release_heading_match.start()]
+        suffix = content[release_heading_match.start() :]
+        prefix = prefix.rstrip("\n") + "\n\n"
+        return prefix + HEADER_UNRELEASED + "\n\n" + suffix
+
+    changelog_header_match = re.search(
+        rf"^{re.escape(HEADER_CHANGELOG)}[^\n]*\n?",
+        content,
+        flags=re.MULTILINE,
+    )
+    if changelog_header_match:
+        prefix = content[: changelog_header_match.end()].rstrip("\n") + "\n\n"
+        suffix = content[changelog_header_match.end() :].lstrip("\n")
+        return prefix + HEADER_UNRELEASED + "\n\n" + suffix
+
+    return HEADER_CHANGELOG + "\n\n" + HEADER_UNRELEASED + "\n\n" + content
+
+
+def main() -> None:
+    path = sys.argv[1] if len(sys.argv) > 1 else CHANGELOG_FILE
+    with open(path, "r", encoding="utf-8") as changelog:
+        content = normalize_newlines(changelog.read())
+
+    updated = ensure_unreleased_section(content)
+
+    with open(path, "w", encoding="utf-8", newline="\n") as changelog:
+        changelog.write(updated)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_ensure_unreleased_changelog.py
+++ b/.github/scripts/test_ensure_unreleased_changelog.py
@@ -1,4 +1,8 @@
+import sys
 import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from ensure_unreleased_changelog import ensure_unreleased_section
 

--- a/.github/scripts/test_ensure_unreleased_changelog.py
+++ b/.github/scripts/test_ensure_unreleased_changelog.py
@@ -1,0 +1,43 @@
+import unittest
+
+from ensure_unreleased_changelog import ensure_unreleased_section
+
+
+class EnsureUnreleasedSectionTests(unittest.TestCase):
+    def test_inserts_unreleased_above_first_release(self) -> None:
+        content = "# Changelog\n\n## [1.20.1] - 2026-06-12\n\n### Fixed\n\n- Fix\n"
+
+        updated = ensure_unreleased_section(content)
+
+        self.assertEqual(
+            "# Changelog\n\n## [Unreleased]\n\n## [1.20.1] - 2026-06-12\n\n### Fixed\n\n- Fix\n",
+            updated,
+        )
+
+    def test_does_not_duplicate_existing_unreleased(self) -> None:
+        content = "# Changelog\n\n## [Unreleased]\n\n## [1.20.1] - 2026-06-12\n"
+
+        updated = ensure_unreleased_section(content)
+
+        self.assertEqual(content, updated)
+
+    def test_preserves_intro_text(self) -> None:
+        content = (
+            "# Changelog\n"
+            "All notable changes to this project will be documented in this file.\n\n"
+            "## [1.20.1] - 2026-06-12\n"
+        )
+
+        updated = ensure_unreleased_section(content)
+
+        self.assertEqual(
+            "# Changelog\n"
+            "All notable changes to this project will be documented in this file.\n\n"
+            "## [Unreleased]\n\n"
+            "## [1.20.1] - 2026-06-12\n",
+            updated,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/finish-release-train.yml
+++ b/.github/workflows/finish-release-train.yml
@@ -85,23 +85,21 @@ jobs:
           echo "branch_name=$branch_name" >> "$GITHUB_OUTPUT"
 
       - name: Create sync branch
-        id: sync_branch
         run: |
           git checkout -B "${{ steps.sync.outputs.branch_name }}"
           python3 .github/scripts/ensure_unreleased_changelog.py
 
           if git diff --quiet -- CHANGELOG.md; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "CHANGELOG.md already contains an Unreleased section"
           else
             git add CHANGELOG.md
             git commit --no-verify -m "restore unreleased changelog section"
-            git fetch origin "${{ steps.sync.outputs.branch_name }}:refs/remotes/origin/${{ steps.sync.outputs.branch_name }}" || true
-            git push --force-with-lease origin "${{ steps.sync.outputs.branch_name }}"
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
+          git fetch origin "${{ steps.sync.outputs.branch_name }}:refs/remotes/origin/${{ steps.sync.outputs.branch_name }}" || true
+          git push --force-with-lease origin "${{ steps.sync.outputs.branch_name }}"
+
       - name: Create PR
-        if: steps.sync_branch.outputs.has_changes == 'true'
         run: |
           existing_pr_number="$(gh pr list \
             --state open \

--- a/.github/workflows/finish-release-train.yml
+++ b/.github/workflows/finish-release-train.yml
@@ -57,28 +57,69 @@ jobs:
     needs: [prepare]
     name: Create Finish Release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
+
+      - name: Setup Git User
+        run: |
+          git config --global user.name "Bitmovin Release Automation"
+          git config --global user.email "support@bitmovin.com"
+
+      - name: Set sync branch
+        id: sync
+        run: |
+          if [ "${{ github.event.pull_request.base.ref }}" = "support/v0" ]; then
+            target_base="development-v0"
+          else
+            target_base="development"
+          fi
+
+          branch_name="release/v${{ needs.prepare.outputs.version_number }}-sync-${target_base}"
+          echo "target_base=$target_base" >> "$GITHUB_OUTPUT"
+          echo "branch_name=$branch_name" >> "$GITHUB_OUTPUT"
+
+      - name: Create sync branch
+        id: sync_branch
+        run: |
+          git checkout -B "${{ steps.sync.outputs.branch_name }}"
+          python3 .github/scripts/ensure_unreleased_changelog.py
+
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            git add CHANGELOG.md
+            git commit --no-verify -m "restore unreleased changelog section"
+            git push --force-with-lease origin "${{ steps.sync.outputs.branch_name }}"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create PR
-        if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'support/v0') }}
+        if: steps.sync_branch.outputs.has_changes == 'true'
         run: |
-          gh pr create \
-          --base "development-v0" \
-          --head "support/v0" \
-          --title "Finish release ${{ needs.prepare.outputs.version_number }}" \
-          --body "Finish release ${{ needs.prepare.outputs.version_number }}"
-        env:
-          GH_TOKEN: ${{ github.token }}
+          existing_pr_number="$(gh pr list \
+            --state open \
+            --head "${{ steps.sync.outputs.branch_name }}" \
+            --base "${{ steps.sync.outputs.target_base }}" \
+            --json number \
+            --jq '.[0].number // empty')"
 
-      - name: Create PR
-        if: ${{ github.event.pull_request.merged == true && !startsWith(github.head_ref, 'support/v0') }}
-        run: |
-          gh pr create \
-          --base "development" \
-          --head "main" \
-          --title "Finish release ${{ needs.prepare.outputs.version_number }}" \
-          --body "Finish release ${{ needs.prepare.outputs.version_number }}"
+          if [ -n "$existing_pr_number" ]; then
+            gh pr edit "$existing_pr_number" \
+              --title "Finish release ${{ needs.prepare.outputs.version_number }}" \
+              --body "Finish release ${{ needs.prepare.outputs.version_number }}"
+          else
+            gh pr create \
+              --base "${{ steps.sync.outputs.target_base }}" \
+              --head "${{ steps.sync.outputs.branch_name }}" \
+              --title "Finish release ${{ needs.prepare.outputs.version_number }}" \
+              --body "Finish release ${{ needs.prepare.outputs.version_number }}"
+          fi
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/finish-release-train.yml
+++ b/.github/workflows/finish-release-train.yml
@@ -80,7 +80,7 @@ jobs:
             target_base="development"
           fi
 
-          branch_name="release/v${{ needs.prepare.outputs.version_number }}-sync-${target_base}"
+          branch_name="finish-release/v${{ needs.prepare.outputs.version_number }}-sync-${target_base}"
           echo "target_base=$target_base" >> "$GITHUB_OUTPUT"
           echo "branch_name=$branch_name" >> "$GITHUB_OUTPUT"
 
@@ -95,6 +95,7 @@ jobs:
           else
             git add CHANGELOG.md
             git commit --no-verify -m "restore unreleased changelog section"
+            git fetch origin "${{ steps.sync.outputs.branch_name }}:refs/remotes/origin/${{ steps.sync.outputs.branch_name }}" || true
             git push --force-with-lease origin "${{ steps.sync.outputs.branch_name }}"
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Description
Automates the release cleanup step that restores the top-level `## [Unreleased]` section after a release is finished.

## Changes
- Creates the finish-release sync branch from the released base branch
- Restores `## [Unreleased]` before opening the sync PR to development
- Adds a tested changelog helper for idempotent placeholder insertion

## Checklist
- [x] 🗒 `CHANGELOG` entry - n/a, release automation