### PR TITLE
Automatically close superseded SDK update PRs

### DIFF
--- a/.github/scripts/close_superseded_sdk_update_prs.py
+++ b/.github/scripts/close_superseded_sdk_update_prs.py
@@ -4,6 +4,9 @@ Usage:
     gh pr list --state open --json number,headRefName,baseRefName \
       | python3 .github/scripts/close_superseded_sdk_update_prs.py <android|ios> <version> [base-ref]
 
+    gh api graphql --paginate --slurp ... \
+      | python3 .github/scripts/close_superseded_sdk_update_prs.py <android|ios> <version> [base-ref]
+
 The script prints TSV rows:
     <pr-number>\t<head-branch>\t<old-version>
 """
@@ -25,6 +28,10 @@ SEMVER_RE = re.compile(
     r"(?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
 )
 VALID_SDK_NAMES = {"android", "ios"}
+USAGE = (
+    "Usage: python3 .github/scripts/close_superseded_sdk_update_prs.py "
+    "<android|ios> <version> [base-ref]"
+)
 
 
 @total_ordering
@@ -80,11 +87,18 @@ def parse_semver(version: str) -> SemVer | None:
         return None
 
     prerelease = match.group("prerelease")
+    prerelease_identifiers = tuple(prerelease.split(".")) if prerelease else ()
+    if any(
+        identifier.isdigit() and len(identifier) > 1 and identifier.startswith("0")
+        for identifier in prerelease_identifiers
+    ):
+        return None
+
     return SemVer(
         major=int(match.group("major")),
         minor=int(match.group("minor")),
         patch=int(match.group("patch")),
-        prerelease=tuple(prerelease.split(".")) if prerelease else (),
+        prerelease=prerelease_identifiers,
     )
 
 
@@ -131,21 +145,48 @@ def find_superseded_prs(
     return superseded_prs
 
 
+def normalize_prs_payload(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        raise ValueError("PR JSON must be a list")
+
+    if all(isinstance(pr, dict) and "headRefName" in pr for pr in payload):
+        return payload
+
+    prs = []
+    for page in payload:
+        if not isinstance(page, dict):
+            raise ValueError("PR JSON must be a list")
+
+        nodes = (
+            page.get("data", {})
+            .get("repository", {})
+            .get("pullRequests", {})
+            .get("nodes")
+        )
+        if not isinstance(nodes, list):
+            raise ValueError("PR JSON must be a list")
+
+        for pr in nodes:
+            if not isinstance(pr, dict):
+                raise ValueError("PR JSON must be a list")
+            prs.append(pr)
+
+    return prs
+
+
 def load_prs_from_stdin() -> list[dict[str, Any]]:
     try:
-        prs = json.load(sys.stdin)
+        payload = json.load(sys.stdin)
     except json.JSONDecodeError as error:
         raise ValueError(f"Invalid PR JSON: {error}") from error
 
-    if not isinstance(prs, list):
-        raise ValueError("PR JSON must be a list")
-    return prs
+    return normalize_prs_payload(payload)
 
 
 def main() -> None:
     if len(sys.argv) not in (3, 4):
         print(
-            "Usage: python3 close_superseded_sdk_update_prs.py <android|ios> <version> [base-ref]",
+            USAGE,
             file=sys.stderr,
         )
         sys.exit(1)

--- a/.github/scripts/close_superseded_sdk_update_prs.py
+++ b/.github/scripts/close_superseded_sdk_update_prs.py
@@ -157,12 +157,19 @@ def normalize_prs_payload(payload: Any) -> list[dict[str, Any]]:
         if not isinstance(page, dict):
             raise ValueError("PR JSON must be a list")
 
-        nodes = (
-            page.get("data", {})
-            .get("repository", {})
-            .get("pullRequests", {})
-            .get("nodes")
-        )
+        data = page.get("data")
+        if not isinstance(data, dict):
+            raise ValueError("PR JSON must be a list")
+
+        repository = data.get("repository")
+        if not isinstance(repository, dict):
+            raise ValueError("PR JSON must be a list")
+
+        pull_requests = repository.get("pullRequests")
+        if not isinstance(pull_requests, dict):
+            raise ValueError("PR JSON must be a list")
+
+        nodes = pull_requests.get("nodes")
         if not isinstance(nodes, list):
             raise ValueError("PR JSON must be a list")
 

--- a/.github/scripts/close_superseded_sdk_update_prs.py
+++ b/.github/scripts/close_superseded_sdk_update_prs.py
@@ -1,0 +1,169 @@
+"""Select open SDK update PRs superseded by a newer SDK update.
+
+Usage:
+    gh pr list --state open --json number,headRefName \
+      | python3 .github/scripts/close_superseded_sdk_update_prs.py <android|ios> <version>
+
+The script prints TSV rows:
+    <pr-number>\t<head-branch>\t<old-version>
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from functools import total_ordering
+from typing import Any
+
+
+SEMVER_RE = re.compile(
+    r"^(?P<major>0|[1-9]\d*)\."
+    r"(?P<minor>0|[1-9]\d*)\."
+    r"(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+    r"(?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+VALID_SDK_NAMES = {"android", "ios"}
+
+
+@total_ordering
+@dataclass(frozen=True)
+class SemVer:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[str, ...]
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, SemVer):
+            return NotImplemented
+
+        own_core = (self.major, self.minor, self.patch)
+        other_core = (other.major, other.minor, other.patch)
+        if own_core != other_core:
+            return own_core < other_core
+
+        return compare_prerelease(self.prerelease, other.prerelease) < 0
+
+
+def compare_prerelease(left: tuple[str, ...], right: tuple[str, ...]) -> int:
+    if not left and not right:
+        return 0
+    if not left:
+        return 1
+    if not right:
+        return -1
+
+    for left_identifier, right_identifier in zip(left, right):
+        left_is_numeric = left_identifier.isdigit()
+        right_is_numeric = right_identifier.isdigit()
+
+        if left_is_numeric and right_is_numeric:
+            left_value = int(left_identifier)
+            right_value = int(right_identifier)
+            if left_value != right_value:
+                return -1 if left_value < right_value else 1
+        elif left_is_numeric != right_is_numeric:
+            return -1 if left_is_numeric else 1
+        elif left_identifier != right_identifier:
+            return -1 if left_identifier < right_identifier else 1
+
+    if len(left) == len(right):
+        return 0
+    return -1 if len(left) < len(right) else 1
+
+
+def parse_semver(version: str) -> SemVer | None:
+    match = SEMVER_RE.fullmatch(version)
+    if match is None:
+        return None
+
+    prerelease = match.group("prerelease")
+    return SemVer(
+        major=int(match.group("major")),
+        minor=int(match.group("minor")),
+        patch=int(match.group("patch")),
+        prerelease=tuple(prerelease.split(".")) if prerelease else (),
+    )
+
+
+def find_superseded_prs(
+    sdk_name: str,
+    new_version: str,
+    prs: list[dict[str, Any]],
+    expected_base_ref: str | None = None,
+) -> list[dict[str, Any]]:
+    if sdk_name not in VALID_SDK_NAMES:
+        raise ValueError("SDK name must be 'android' or 'ios'")
+
+    parsed_new_version = parse_semver(new_version)
+    if parsed_new_version is None:
+        raise ValueError(f"Invalid SemVer version: {new_version}")
+
+    branch_prefix = f"update_{sdk_name}_player_to_"
+    superseded_prs = []
+
+    for pr in prs:
+        if expected_base_ref is not None and pr.get("baseRefName") != expected_base_ref:
+            continue
+
+        head_ref_name = pr.get("headRefName")
+        if not isinstance(head_ref_name, str):
+            continue
+        if not head_ref_name.startswith(branch_prefix):
+            continue
+
+        old_version = head_ref_name.removeprefix(branch_prefix)
+        parsed_old_version = parse_semver(old_version)
+        if parsed_old_version is None:
+            continue
+
+        if parsed_old_version < parsed_new_version:
+            superseded_prs.append(
+                {
+                    "number": pr.get("number"),
+                    "headRefName": head_ref_name,
+                    "version": old_version,
+                }
+            )
+
+    return superseded_prs
+
+
+def load_prs_from_stdin() -> list[dict[str, Any]]:
+    try:
+        prs = json.load(sys.stdin)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"Invalid PR JSON: {error}") from error
+
+    if not isinstance(prs, list):
+        raise ValueError("PR JSON must be a list")
+    return prs
+
+
+def main() -> None:
+    if len(sys.argv) not in (3, 4):
+        print(
+            "Usage: python3 close_superseded_sdk_update_prs.py <android|ios> <version> [base-ref]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        superseded_prs = find_superseded_prs(
+            sdk_name=sys.argv[1],
+            new_version=sys.argv[2],
+            prs=load_prs_from_stdin(),
+            expected_base_ref=sys.argv[3] if len(sys.argv) == 4 else None,
+        )
+    except ValueError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)
+
+    for pr in superseded_prs:
+        print(f"{pr['number']}\t{pr['headRefName']}\t{pr['version']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/close_superseded_sdk_update_prs.py
+++ b/.github/scripts/close_superseded_sdk_update_prs.py
@@ -1,11 +1,11 @@
 """Select open SDK update PRs superseded by a newer SDK update.
 
 Usage:
-    gh pr list --state open --json number,headRefName,baseRefName \
-      | python3 .github/scripts/close_superseded_sdk_update_prs.py <android|ios> <version> [base-ref]
+    gh pr list --state open --json number,headRefName,baseRefName,headRepository \
+      | python3 .github/scripts/close_superseded_sdk_update_prs.py <android|ios> <version> [base-ref] [head-repository]
 
     gh api graphql --paginate --slurp ... \
-      | python3 .github/scripts/close_superseded_sdk_update_prs.py <android|ios> <version> [base-ref]
+      | python3 .github/scripts/close_superseded_sdk_update_prs.py <android|ios> <version> [base-ref] [head-repository]
 
 The script prints TSV rows:
     <pr-number>\t<head-branch>\t<old-version>
@@ -30,7 +30,7 @@ SEMVER_RE = re.compile(
 VALID_SDK_NAMES = {"android", "ios"}
 USAGE = (
     "Usage: python3 .github/scripts/close_superseded_sdk_update_prs.py "
-    "<android|ios> <version> [base-ref]"
+    "<android|ios> <version> [base-ref] [head-repository]"
 )
 
 
@@ -107,6 +107,7 @@ def find_superseded_prs(
     new_version: str,
     prs: list[dict[str, Any]],
     expected_base_ref: str | None = None,
+    expected_head_repository: str | None = None,
 ) -> list[dict[str, Any]]:
     if sdk_name not in VALID_SDK_NAMES:
         raise ValueError("SDK name must be 'android' or 'ios'")
@@ -121,6 +122,12 @@ def find_superseded_prs(
     for pr in prs:
         if expected_base_ref is not None and pr.get("baseRefName") != expected_base_ref:
             continue
+        if expected_head_repository is not None:
+            head_repository = pr.get("headRepository")
+            if not isinstance(head_repository, dict):
+                continue
+            if head_repository.get("nameWithOwner") != expected_head_repository:
+                continue
 
         head_ref_name = pr.get("headRefName")
         if not isinstance(head_ref_name, str):
@@ -191,7 +198,7 @@ def load_prs_from_stdin() -> list[dict[str, Any]]:
 
 
 def main() -> None:
-    if len(sys.argv) not in (3, 4):
+    if len(sys.argv) not in (3, 4, 5):
         print(
             USAGE,
             file=sys.stderr,
@@ -203,7 +210,8 @@ def main() -> None:
             sdk_name=sys.argv[1],
             new_version=sys.argv[2],
             prs=load_prs_from_stdin(),
-            expected_base_ref=sys.argv[3] if len(sys.argv) == 4 else None,
+            expected_base_ref=sys.argv[3] if len(sys.argv) >= 4 else None,
+            expected_head_repository=sys.argv[4] if len(sys.argv) == 5 else None,
         )
     except ValueError as error:
         print(f"Error: {error}", file=sys.stderr)

--- a/.github/scripts/close_superseded_sdk_update_prs.py
+++ b/.github/scripts/close_superseded_sdk_update_prs.py
@@ -1,8 +1,8 @@
 """Select open SDK update PRs superseded by a newer SDK update.
 
 Usage:
-    gh pr list --state open --json number,headRefName \
-      | python3 .github/scripts/close_superseded_sdk_update_prs.py <android|ios> <version>
+    gh pr list --state open --json number,headRefName,baseRefName \
+      | python3 .github/scripts/close_superseded_sdk_update_prs.py <android|ios> <version> [base-ref]
 
 The script prints TSV rows:
     <pr-number>\t<head-branch>\t<old-version>

--- a/.github/scripts/test_close_superseded_sdk_update_prs.py
+++ b/.github/scripts/test_close_superseded_sdk_update_prs.py
@@ -83,6 +83,41 @@ class FindSupersededPrsTests(unittest.TestCase):
             superseded,
         )
 
+    def test_ignores_prs_from_different_head_repository(self) -> None:
+        prs = [
+            {
+                "number": 52,
+                "headRefName": "update_ios_player_to_3.113.0",
+                "baseRefName": "development",
+                "headRepository": {"nameWithOwner": "external/fork"},
+            },
+            {
+                "number": 53,
+                "headRefName": "update_ios_player_to_3.112.0",
+                "baseRefName": "development",
+                "headRepository": {"nameWithOwner": "bitmovin/bitmovin-player-react-native"},
+            },
+        ]
+
+        superseded = find_superseded_prs(
+            "ios",
+            "3.114.0",
+            prs,
+            "development",
+            "bitmovin/bitmovin-player-react-native",
+        )
+
+        self.assertEqual(
+            [
+                {
+                    "number": 53,
+                    "headRefName": "update_ios_player_to_3.112.0",
+                    "version": "3.112.0",
+                }
+            ],
+            superseded,
+        )
+
     def test_keeps_same_core_version_with_different_build_metadata(self) -> None:
         prs = [
             {"number": 60, "headRefName": "update_android_player_to_3.152.0+preview"},
@@ -112,6 +147,9 @@ class FindSupersededPrsTests(unittest.TestCase):
                                     "number": 80,
                                     "headRefName": "update_ios_player_to_3.113.0",
                                     "baseRefName": "development",
+                                    "headRepository": {
+                                        "nameWithOwner": "bitmovin/bitmovin-player-react-native"
+                                    },
                                 }
                             ]
                         }
@@ -127,6 +165,9 @@ class FindSupersededPrsTests(unittest.TestCase):
                                     "number": 81,
                                     "headRefName": "update_ios_player_to_3.112.0",
                                     "baseRefName": "support/v0",
+                                    "headRepository": {
+                                        "nameWithOwner": "bitmovin/bitmovin-player-react-native"
+                                    },
                                 }
                             ]
                         }
@@ -141,11 +182,17 @@ class FindSupersededPrsTests(unittest.TestCase):
                     "number": 80,
                     "headRefName": "update_ios_player_to_3.113.0",
                     "baseRefName": "development",
+                    "headRepository": {
+                        "nameWithOwner": "bitmovin/bitmovin-player-react-native"
+                    },
                 },
                 {
                     "number": 81,
                     "headRefName": "update_ios_player_to_3.112.0",
                     "baseRefName": "support/v0",
+                    "headRepository": {
+                        "nameWithOwner": "bitmovin/bitmovin-player-react-native"
+                    },
                 },
             ],
             normalize_prs_payload(payload),

--- a/.github/scripts/test_close_superseded_sdk_update_prs.py
+++ b/.github/scripts/test_close_superseded_sdk_update_prs.py
@@ -1,0 +1,97 @@
+import unittest
+
+from close_superseded_sdk_update_prs import find_superseded_prs
+
+
+class FindSupersededPrsTests(unittest.TestCase):
+    def test_closes_only_older_prs_for_same_sdk(self) -> None:
+        prs = [
+            {"number": 10, "headRefName": "update_ios_player_to_3.113.0"},
+            {"number": 11, "headRefName": "update_ios_player_to_3.114.0"},
+            {"number": 12, "headRefName": "update_ios_player_to_3.115.0"},
+            {"number": 13, "headRefName": "update_android_player_to_3.153.0+jason"},
+            {"number": 14, "headRefName": "feature/manual-sdk-update"},
+        ]
+
+        superseded = find_superseded_prs("ios", "3.114.0", prs)
+
+        self.assertEqual(
+            [{"number": 10, "headRefName": "update_ios_player_to_3.113.0", "version": "3.113.0"}],
+            superseded,
+        )
+
+    def test_handles_android_build_metadata(self) -> None:
+        prs = [
+            {"number": 20, "headRefName": "update_android_player_to_3.151.0+jason"},
+            {"number": 21, "headRefName": "update_android_player_to_3.152.0+preview"},
+            {"number": 22, "headRefName": "update_android_player_to_3.153.0+jason"},
+        ]
+
+        superseded = find_superseded_prs("android", "3.152.0+jason", prs)
+
+        self.assertEqual(
+            [{"number": 20, "headRefName": "update_android_player_to_3.151.0+jason", "version": "3.151.0+jason"}],
+            superseded,
+        )
+
+    def test_closes_prerelease_when_stable_version_arrives(self) -> None:
+        prs = [
+            {"number": 30, "headRefName": "update_ios_player_to_3.114.0-beta.1"},
+        ]
+
+        superseded = find_superseded_prs("ios", "3.114.0", prs)
+
+        self.assertEqual(
+            [{"number": 30, "headRefName": "update_ios_player_to_3.114.0-beta.1", "version": "3.114.0-beta.1"}],
+            superseded,
+        )
+
+    def test_ignores_malformed_versions(self) -> None:
+        prs = [
+            {"number": 40, "headRefName": "update_ios_player_to_not-a-version"},
+            {"number": 41, "headRefName": "update_ios_player_to_3.113"},
+        ]
+
+        superseded = find_superseded_prs("ios", "3.114.0", prs)
+
+        self.assertEqual([], superseded)
+
+    def test_ignores_prs_targeting_different_base_branch(self) -> None:
+        prs = [
+            {
+                "number": 50,
+                "headRefName": "update_ios_player_to_3.113.0",
+                "baseRefName": "support/v0",
+            },
+            {
+                "number": 51,
+                "headRefName": "update_ios_player_to_3.112.0",
+                "baseRefName": "development",
+            },
+        ]
+
+        superseded = find_superseded_prs("ios", "3.114.0", prs, "development")
+
+        self.assertEqual(
+            [
+                {
+                    "number": 51,
+                    "headRefName": "update_ios_player_to_3.112.0",
+                    "version": "3.112.0",
+                }
+            ],
+            superseded,
+        )
+
+    def test_keeps_same_core_version_with_different_build_metadata(self) -> None:
+        prs = [
+            {"number": 60, "headRefName": "update_android_player_to_3.152.0+preview"},
+        ]
+
+        superseded = find_superseded_prs("android", "3.152.0+jason", prs)
+
+        self.assertEqual([], superseded)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_close_superseded_sdk_update_prs.py
+++ b/.github/scripts/test_close_superseded_sdk_update_prs.py
@@ -151,6 +151,10 @@ class FindSupersededPrsTests(unittest.TestCase):
             normalize_prs_payload(payload),
         )
 
+    def test_rejects_malformed_graphql_pr_payload(self) -> None:
+        with self.assertRaises(ValueError):
+            normalize_prs_payload([{"data": None}])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_close_superseded_sdk_update_prs.py
+++ b/.github/scripts/test_close_superseded_sdk_update_prs.py
@@ -1,6 +1,6 @@
 import unittest
 
-from close_superseded_sdk_update_prs import find_superseded_prs
+from close_superseded_sdk_update_prs import find_superseded_prs, normalize_prs_payload
 
 
 class FindSupersededPrsTests(unittest.TestCase):
@@ -91,6 +91,65 @@ class FindSupersededPrsTests(unittest.TestCase):
         superseded = find_superseded_prs("android", "3.152.0+jason", prs)
 
         self.assertEqual([], superseded)
+
+    def test_ignores_prerelease_numeric_identifiers_with_leading_zeroes(self) -> None:
+        prs = [
+            {"number": 70, "headRefName": "update_ios_player_to_3.114.0-01"},
+        ]
+
+        superseded = find_superseded_prs("ios", "3.114.0", prs)
+
+        self.assertEqual([], superseded)
+
+    def test_normalizes_paginated_graphql_pr_payload(self) -> None:
+        payload = [
+            {
+                "data": {
+                    "repository": {
+                        "pullRequests": {
+                            "nodes": [
+                                {
+                                    "number": 80,
+                                    "headRefName": "update_ios_player_to_3.113.0",
+                                    "baseRefName": "development",
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                "data": {
+                    "repository": {
+                        "pullRequests": {
+                            "nodes": [
+                                {
+                                    "number": 81,
+                                    "headRefName": "update_ios_player_to_3.112.0",
+                                    "baseRefName": "support/v0",
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+        ]
+
+        self.assertEqual(
+            [
+                {
+                    "number": 80,
+                    "headRefName": "update_ios_player_to_3.113.0",
+                    "baseRefName": "development",
+                },
+                {
+                    "number": 81,
+                    "headRefName": "update_ios_player_to_3.112.0",
+                    "baseRefName": "support/v0",
+                },
+            ],
+            normalize_prs_payload(payload),
+        )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -76,8 +76,8 @@ jobs:
             --state open \
             --head "${{ steps.branching.outputs.branch_name }}" \
             --base "${{ github.ref_name }}" \
-            --json number \
-            --jq '.[0].number // empty')"
+            --json number,headRepository \
+            --jq 'map(select(.headRepository.nameWithOwner == "${{ github.repository }}")) | .[0].number // empty')"
 
           if [ -n "$existing_pr_number" ]; then
             gh pr edit "$existing_pr_number" \

--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -17,10 +17,17 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.sdk_name }}
+  cancel-in-progress: true
+
 jobs:
   update:
     name: Update SDK version
     runs-on: macos-15
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
@@ -38,10 +45,25 @@ jobs:
           branch_name="update_${{ inputs.sdk_name }}_player_to_${{ inputs.version_number }}"
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
 
+      - name: Close superseded SDK update PRs
+        run: |
+          set -euo pipefail
+
+          gh pr list --state open --limit 100 --json number,headRefName,baseRefName \
+            | python3 .github/scripts/close_superseded_sdk_update_prs.py "${{ inputs.sdk_name }}" "${{ inputs.version_number }}" "${{ github.ref_name }}" \
+            | while IFS=$'\t' read -r pr_number head_ref_name old_version; do
+                if [ -z "$pr_number" ]; then
+                  continue
+                fi
+
+                gh pr close "$pr_number" \
+                  --delete-branch \
+                  --comment "Closing because ${{ inputs.sdk_name == 'ios' && 'iOS' || 'Android' }} Player SDK ${old_version} is superseded by ${{ inputs.version_number }}."
+              done
+
       - name: Create update branch
         run: |
-          git push origin --delete ${{ steps.branching.outputs.branch_name }} || true
-          git checkout -b ${{ steps.branching.outputs.branch_name }}
+          git checkout -B ${{ steps.branching.outputs.branch_name }}
 
       - name: Bump iOS player SDK version
         if: ${{ inputs.sdk_name == 'ios' }}
@@ -61,11 +83,25 @@ jobs:
         run: |
           git add ios/RNBitmovinPlayer.podspec android/build.gradle CHANGELOG.md
           git commit --no-verify -m "chore(${{ inputs.sdk_name }}): update ${{ inputs.sdk_name }} player version to ${{ inputs.version_number }}"
-          git push origin ${{ steps.branching.outputs.branch_name }}
+          git push --force-with-lease origin ${{ steps.branching.outputs.branch_name }}
 
       - name: Create PR
         run: |
-          gh pr create \
-          --base "${{ github.ref }}" \
-          --title "Update ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player to ${{ inputs.version_number }}" \
-          --body "Automated ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player version update to ${{ inputs.version_number }}"
+          existing_pr_number="$(gh pr list \
+            --state open \
+            --head "${{ steps.branching.outputs.branch_name }}" \
+            --base "${{ github.ref_name }}" \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          if [ -n "$existing_pr_number" ]; then
+            gh pr edit "$existing_pr_number" \
+              --title "Update ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player to ${{ inputs.version_number }}" \
+              --body "Automated ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player version update to ${{ inputs.version_number }}"
+          else
+            gh pr create \
+              --base "${{ github.ref_name }}" \
+              --head "${{ steps.branching.outputs.branch_name }}" \
+              --title "Update ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player to ${{ inputs.version_number }}" \
+              --body "Automated ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player version update to ${{ inputs.version_number }}"
+          fi

--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -83,6 +83,7 @@ jobs:
         run: |
           git add ios/RNBitmovinPlayer.podspec android/build.gradle CHANGELOG.md
           git commit --no-verify -m "chore(${{ inputs.sdk_name }}): update ${{ inputs.sdk_name }} player version to ${{ inputs.version_number }}"
+          git fetch origin "${{ steps.branching.outputs.branch_name }}:refs/remotes/origin/${{ steps.branching.outputs.branch_name }}" || true
           git push --force-with-lease origin ${{ steps.branching.outputs.branch_name }}
 
       - name: Create PR

--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -49,7 +49,26 @@ jobs:
         run: |
           set -euo pipefail
 
-          gh pr list --state open --limit 100 --json number,headRefName,baseRefName \
+          gh api graphql --paginate --slurp \
+            -F owner="${{ github.repository_owner }}" \
+            -F name="${{ github.event.repository.name }}" \
+            -f query='
+              query($owner: String!, $name: String!, $endCursor: String) {
+                repository(owner: $owner, name: $name) {
+                  pullRequests(states: OPEN, first: 100, after: $endCursor) {
+                    nodes {
+                      number
+                      headRefName
+                      baseRefName
+                    }
+                    pageInfo {
+                      hasNextPage
+                      endCursor
+                    }
+                  }
+                }
+              }
+            ' \
             | python3 .github/scripts/close_superseded_sdk_update_prs.py "${{ inputs.sdk_name }}" "${{ inputs.version_number }}" "${{ github.ref_name }}" \
             | while IFS=$'\t' read -r pr_number head_ref_name old_version; do
                 if [ -z "$pr_number" ]; then

--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -18,7 +18,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.sdk_name }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ inputs.sdk_name }}
   cancel-in-progress: true
 
 jobs:
@@ -29,7 +29,7 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -1,6 +1,6 @@
 name: Create SDK update PR
 
-run-name: Create SDK update PR for ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player to ${{ inputs.version_number }}
+run-name: Create SDK update PR for ${{ inputs.sdk_name == 'ios' && 'iOS' || 'Android' }} player to ${{ inputs.version_number }}
 
 on:
   workflow_dispatch:
@@ -81,14 +81,14 @@ jobs:
 
           if [ -n "$existing_pr_number" ]; then
             gh pr edit "$existing_pr_number" \
-              --title "Update ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player to ${{ inputs.version_number }}" \
-              --body "Automated ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player version update to ${{ inputs.version_number }}"
+              --title "Update ${{ inputs.sdk_name == 'ios' && 'iOS' || 'Android' }} player to ${{ inputs.version_number }}" \
+              --body "Automated ${{ inputs.sdk_name == 'ios' && 'iOS' || 'Android' }} player version update to ${{ inputs.version_number }}"
           else
             gh pr create \
               --base "${{ github.ref_name }}" \
               --head "${{ steps.branching.outputs.branch_name }}" \
-              --title "Update ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player to ${{ inputs.version_number }}" \
-              --body "Automated ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player version update to ${{ inputs.version_number }}"
+              --title "Update ${{ inputs.sdk_name == 'ios' && 'iOS' || 'Android' }} player to ${{ inputs.version_number }}" \
+              --body "Automated ${{ inputs.sdk_name == 'ios' && 'iOS' || 'Android' }} player version update to ${{ inputs.version_number }}"
           fi
 
       - name: Close superseded SDK update PRs

--- a/.github/workflows/create-sdk-update-pr.yml
+++ b/.github/workflows/create-sdk-update-pr.yml
@@ -45,41 +45,6 @@ jobs:
           branch_name="update_${{ inputs.sdk_name }}_player_to_${{ inputs.version_number }}"
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
 
-      - name: Close superseded SDK update PRs
-        run: |
-          set -euo pipefail
-
-          gh api graphql --paginate --slurp \
-            -F owner="${{ github.repository_owner }}" \
-            -F name="${{ github.event.repository.name }}" \
-            -f query='
-              query($owner: String!, $name: String!, $endCursor: String) {
-                repository(owner: $owner, name: $name) {
-                  pullRequests(states: OPEN, first: 100, after: $endCursor) {
-                    nodes {
-                      number
-                      headRefName
-                      baseRefName
-                    }
-                    pageInfo {
-                      hasNextPage
-                      endCursor
-                    }
-                  }
-                }
-              }
-            ' \
-            | python3 .github/scripts/close_superseded_sdk_update_prs.py "${{ inputs.sdk_name }}" "${{ inputs.version_number }}" "${{ github.ref_name }}" \
-            | while IFS=$'\t' read -r pr_number head_ref_name old_version; do
-                if [ -z "$pr_number" ]; then
-                  continue
-                fi
-
-                gh pr close "$pr_number" \
-                  --delete-branch \
-                  --comment "Closing because ${{ inputs.sdk_name == 'ios' && 'iOS' || 'Android' }} Player SDK ${old_version} is superseded by ${{ inputs.version_number }}."
-              done
-
       - name: Create update branch
         run: |
           git checkout -B ${{ steps.branching.outputs.branch_name }}
@@ -125,3 +90,41 @@ jobs:
               --title "Update ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player to ${{ inputs.version_number }}" \
               --body "Automated ${{ inputs.sdk_name == 'ios' && 'iOS' || inputs.sdk_name }} player version update to ${{ inputs.version_number }}"
           fi
+
+      - name: Close superseded SDK update PRs
+        run: |
+          set -euo pipefail
+
+          gh api graphql --paginate --slurp \
+            -F owner="${{ github.repository_owner }}" \
+            -F name="${{ github.event.repository.name }}" \
+            -f query='
+              query($owner: String!, $name: String!, $endCursor: String) {
+                repository(owner: $owner, name: $name) {
+                  pullRequests(states: OPEN, first: 100, after: $endCursor) {
+                    nodes {
+                      number
+                      headRefName
+                      baseRefName
+                      headRepository {
+                        nameWithOwner
+                      }
+                    }
+                    pageInfo {
+                      hasNextPage
+                      endCursor
+                    }
+                  }
+                }
+              }
+            ' \
+            | python3 .github/scripts/close_superseded_sdk_update_prs.py "${{ inputs.sdk_name }}" "${{ inputs.version_number }}" "${{ github.ref_name }}" "${{ github.repository }}" \
+            | while IFS=$'\t' read -r pr_number head_ref_name old_version; do
+                if [ -z "$pr_number" ]; then
+                  continue
+                fi
+
+                gh pr close "$pr_number" \
+                  --delete-branch \
+                  --comment "Closing because ${{ inputs.sdk_name == 'ios' && 'iOS' || 'Android' }} Player SDK ${old_version} is superseded by ${{ inputs.version_number }}."
+              done


### PR DESCRIPTION
## Description
Hardens the SDK update workflow so newer SDK update runs replace older open update PRs for the same platform and base branch.

## Changes
- Adds same-platform SemVer comparison for SDK update branch names
- Closes older open SDK update PRs on the same target branch
- Adds workflow concurrency for same-platform update runs
- Reuses an existing update PR on rerun instead of creating a duplicate

## Checklist
- [x] 🗒 `CHANGELOG` entry - n/a, release automation