### PR TITLE
Run GitHub script tests in CI

### DIFF
--- a/.github/workflows/ci-github-scripts.yml
+++ b/.github/workflows/ci-github-scripts.yml
@@ -1,0 +1,38 @@
+name: CI (GitHub scripts)
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/ci-github-scripts.yml'
+      - '.github/scripts/**'
+
+  push:
+    branches: [development, development-v0]
+    paths:
+      - '.github/workflows/ci-github-scripts.yml'
+      - '.github/scripts/**'
+
+concurrency:
+  group: ci-github-scripts-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  python-script-tests:
+    name: Python script tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Run Python script tests
+        run: |
+          test_file="$(find .github/scripts -name 'test_*.py' -print -quit)"
+          if [ -z "$test_file" ]; then
+            echo "No Python script tests found."
+            exit 0
+          fi
+
+          python3 -m unittest discover -s .github/scripts -p 'test_*.py'


### PR DESCRIPTION
## Description
Adds a lightweight CI workflow for Python tests under `.github/scripts` so release automation helper tests run automatically when those files change.

## Changes
- Add CI (GitHub scripts) workflow
- Run unittest discovery for `.github/scripts/test_*.py`
- Skip cleanly while no script tests exist on the base branch

## Checklist
- [x] CHANGELOG entry - no need, internal process