### PR TITLE
Add PlayerView readiness callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `PlayerView.onPlayerViewReady` callback fired once after the player is initialized and the native view is mounted
+- `PlayerViewProps.onPlayerViewReady` callback fired once after the player is initialized and the native view is mounted
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `PlayerView.onPlayerViewReady` callback fired once after the player is initialized and the native view is mounted
+
 ### Changed
 
 - Update Bitmovin's native Android SDK version to [`3.159.0+jason`](https://developer.bitmovin.com/playback/docs/release-notes-android#31590)

--- a/src/components/PlayerView/index.tsx
+++ b/src/components/PlayerView/index.tsx
@@ -36,6 +36,7 @@ export function PlayerView({
   isPictureInPictureRequested = false,
   pictureInPictureActions,
   isPictureInPictureEnabled,
+  onPlayerViewReady,
   ...props
 }: PlayerViewProps) {
   // Keep the device awake while the PlayerView is mounted
@@ -81,6 +82,7 @@ export function PlayerView({
   };
 
   const [isPlayerInitialized, setIsPlayerInitialized] = useState(false);
+  const didNotifyPlayerViewReady = useRef(false);
 
   useEffect(() => {
     void player.initialize().then(() => {
@@ -97,10 +99,19 @@ export function PlayerView({
   }, [player, fullscreenBridge, customMessageHandlerBridge]);
 
   useEffect(() => {
-    if (isPlayerInitialized && viewRef) {
+    if (!isPlayerInitialized || !nativeView.current) {
+      return;
+    }
+
+    if (viewRef) {
       viewRef.current = nativeView.current;
     }
-  }, [isPlayerInitialized, viewRef, nativeView]);
+
+    if (!didNotifyPlayerViewReady.current) {
+      didNotifyPlayerViewReady.current = true;
+      onPlayerViewReady?.();
+    }
+  }, [isPlayerInitialized, viewRef, nativeView, onPlayerViewReady]);
 
   useEffect(() => {
     if (isPlayerInitialized && pictureInPictureActions != null) {

--- a/src/components/PlayerView/properties.ts
+++ b/src/components/PlayerView/properties.ts
@@ -83,7 +83,11 @@ export interface BasePlayerViewProps {
   isPictureInPictureEnabled?: boolean;
 
   /**
-   * Called once after the {@link PlayerView} has initialized its player and mounted the native view.
+   * Event-style callback called once after the {@link PlayerView} has initialized its player and mounted the
+   * native view.
+   *
+   * Like other event callbacks, this is only invoked if provided when readiness happens; it is not replayed if
+   * assigned later.
    */
   onPlayerViewReady?: () => void;
 }

--- a/src/components/PlayerView/properties.ts
+++ b/src/components/PlayerView/properties.ts
@@ -81,6 +81,11 @@ export interface BasePlayerViewProps {
    * Can be changed dynamically after the player is initialized.
    */
   isPictureInPictureEnabled?: boolean;
+
+  /**
+   * Called once after the {@link PlayerView} has initialized its player and mounted the native view.
+   */
+  onPlayerViewReady?: () => void;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `PlayerViewProps.onPlayerViewReady` as an event-style, one-shot callback.
- Invoke it after `PlayerView` has initialized the `Player` and the native view ref is available.
- Keep the existing `viewRef` behavior intact while providing an explicit readiness notification for integrations that need an attached native `PlayerView` before loading a source.
- As with other event callbacks, it is not replayed if the prop is provided after readiness.

## Motivation
Some integrations, such as Google DAI/SSAI, require the native `PlayerView`/ad UI container to exist before loading a source. Without an explicit readiness callback, consumers have to poll `viewRef.current` or rely on unrelated playback events.
