### PR TITLE
Stabilize Expo Doctor CI

### DIFF
--- a/.github/workflows/expo-doctor.yml
+++ b/.github/workflows/expo-doctor.yml
@@ -42,6 +42,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  EXPO_DOCTOR_VERSION: '1.20.1'
+
 jobs:
   expo-doctor:
     name: Expo Doctor (${{ matrix.name }})
@@ -87,4 +90,8 @@ jobs:
 
       - name: Run expo-doctor
         working-directory: ${{ matrix.cwd }}
-        run: EXPO_NONINTERACTIVE=1 npx --yes expo-doctor@latest
+        env:
+          EXPO_NONINTERACTIVE: '1'
+          # The dependency version check uses remote Expo metadata and can require new patch versions without repo changes.
+          EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK: '1'
+        run: npx --yes expo-doctor@${EXPO_DOCTOR_VERSION}


### PR DESCRIPTION
## Summary
- Pin the Expo Doctor version used by PR CI instead of using `expo-doctor@latest`.
- Skip Expo Doctor's dependency-version check in PR CI because it relies on remote Expo metadata and can require new patch versions without any repository changes.

## Motivation
Expo patch recommendations can change independently of this repository and make unrelated PRs fail. The nightly Expo Auto Doctor workflow remains responsible for applying and validating Expo dependency alignment updates.
