### PR TITLE
chore(deps): bump actions/setup-node from 6 to 7

### DIFF
--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup node and npm registry
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org/'
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup node and npm registry
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org/'

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -52,11 +52,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup node and npm registry
+      - name: Setup Node
         uses: actions/setup-node@v7
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org/'
           cache: 'yarn'
 
       - name: Install node_modules
@@ -78,11 +77,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup node and npm registry
+      - name: Setup Node
         uses: actions/setup-node@v7
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org/'
           cache: 'yarn'
 
       - name: Install node_modules

--- a/.github/workflows/expo-auto-doctor.yml
+++ b/.github/workflows/expo-auto-doctor.yml
@@ -29,11 +29,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup node and npm registry
+      - name: Setup Node
         uses: actions/setup-node@v7
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org/'
           cache: 'yarn'
           cache-dependency-path: |
             yarn.lock

--- a/.github/workflows/expo-auto-doctor.yml
+++ b/.github/workflows/expo-auto-doctor.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup node and npm registry
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org/'

--- a/.github/workflows/expo-doctor.yml
+++ b/.github/workflows/expo-doctor.yml
@@ -68,11 +68,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup node and npm registry
+      - name: Setup Node
         uses: actions/setup-node@v7
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org/'
           cache: 'yarn'
           cache-dependency-path: ${{ matrix.lockfile }}
 

--- a/.github/workflows/expo-doctor.yml
+++ b/.github/workflows/expo-doctor.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup node and npm registry
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org/'


### PR DESCRIPTION
## Description

Upgrade `actions/setup-node` from v6 to v7. Version 7 no longer exports a dummy `NODE_AUTH_TOKEN`; the existing npm registry configuration therefore caused Yarn cache discovery to fail before CI jobs could install dependencies.

This replaces #1005, which GitHub cannot reopen after its Dependabot branch was force-pushed.

## Changes

- Upgrade the four direct workflow usages to `actions/setup-node@v7`.
- Remove unnecessary npm registry configuration from non-publishing workflows.
- Keep Yarn dependency caching enabled.

## Validation

- Workflow validation passes for the touched files, excluding one pre-existing shellcheck warning in the nightly Expo workflow.
- Formatting and whitespace validation pass.
- Tokenless Yarn cache discovery succeeds.

## Checklist

- [ ] 🗒 `CHANGELOG` entry (not required for this CI-only change)
