### PR TITLE
Expose video dynamic range changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Android and iOS/tvOS: Expose `VideoQuality.colorInfo.dynamicRange` (`sdr`, `hdr`, `unknown`) via the new `DynamicRange` enum
+
 ### Changed
 
 - Update Bitmovin's native iOS SDK version to [`3.118.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#31180)

--- a/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
+++ b/android/src/main/java/com/bitmovin/player/reactnative/converter/JsonConverter.kt
@@ -46,6 +46,7 @@ import com.bitmovin.player.api.media.subtitle.Cue
 import com.bitmovin.player.api.media.subtitle.SubtitleTrack
 import com.bitmovin.player.api.media.thumbnail.Thumbnail
 import com.bitmovin.player.api.media.thumbnail.ThumbnailTrack
+import com.bitmovin.player.api.media.video.quality.DynamicRange
 import com.bitmovin.player.api.media.video.quality.VideoQuality
 import com.bitmovin.player.api.metadata.Metadata
 import com.bitmovin.player.api.metadata.daterange.DateRangeMetadata
@@ -699,7 +700,16 @@ fun VideoQuality.toJson(): Map<String, Any> = mapOf<String, Any?>(
     "frameRate" to frameRate.toDouble(),
     "height" to height,
     "width" to width,
+    "colorInfo" to mapOf(
+        "dynamicRange" to dynamicRange.toJson(),
+    ),
 ).filterNotNullValues()
+
+fun DynamicRange.toJson(): String = when (this) {
+    DynamicRange.SDR -> "sdr"
+    DynamicRange.HDR -> "hdr"
+    DynamicRange.Unknown -> "unknown"
+}
 
 fun AudioQuality.toJson(): Map<String, Any> = mapOf<String, Any?>(
     "id" to id,

--- a/integration_test/tests/index.ts
+++ b/integration_test/tests/index.ts
@@ -6,6 +6,7 @@ import LoadingTest from './loadingTest';
 import metadataId3Test from './metadataId3Test';
 import PlaybackTest from './playbackTest';
 import UnloadingTest from './unloadingTest';
+import videoQualityTest from './videoQualityTest';
 
 export default [
   AdvertisingTest,
@@ -16,4 +17,5 @@ export default [
   PlaybackTest,
   UnloadingTest,
   audioTrackTest,
+  videoQualityTest,
 ];

--- a/integration_test/tests/videoQualityTest.ts
+++ b/integration_test/tests/videoQualityTest.ts
@@ -1,0 +1,120 @@
+import { TestScope } from 'cavy';
+import {
+  DynamicRange,
+  VideoPlaybackQualityChangedEvent,
+  type VideoColorInfo,
+} from 'bitmovin-player-react-native';
+import {
+  callPlayer,
+  EventType,
+  expectEvent,
+  loadSourceConfig,
+  playFor,
+  startPlayerTest,
+} from '../playertesting';
+import { Sources } from './helper/Sources';
+
+const dynamicRangeValues = Object.values(DynamicRange);
+
+const expectDefined = <T>(value: T | null | undefined, message: string): T => {
+  if (value == null) {
+    throw new Error(message);
+  }
+  return value;
+};
+
+const expectValidDynamicRange = (
+  dynamicRange: DynamicRange | undefined,
+  message: string
+): void => {
+  const definedDynamicRange = expectDefined(
+    dynamicRange,
+    `${message}: dynamicRange is missing`
+  );
+  if (!dynamicRangeValues.includes(definedDynamicRange)) {
+    throw new Error(
+      `${message}: unexpected dynamicRange ${definedDynamicRange}`
+    );
+  }
+};
+
+const expectValidColorInfo = (
+  colorInfo: VideoColorInfo | undefined,
+  message: string
+): void => {
+  const definedColorInfo = expectDefined(
+    colorInfo,
+    `${message}: colorInfo is missing`
+  );
+  expectValidDynamicRange(
+    definedColorInfo.dynamicRange,
+    `${message}.dynamicRange`
+  );
+};
+
+export default (spec: TestScope) => {
+  spec.describe('loading a source with video qualities', () => {
+    spec.it(
+      'exposes colorInfo.dynamicRange on available video qualities',
+      async () => {
+        await startPlayerTest({}, async () => {
+          // This source may report `DynamicRange.Unknown` when no dynamic range
+          // metadata is available, which is still a valid exposed dynamic range.
+          // NOTE: The `HDR -> 'hdr'` mapping is not exercised here because no HDR
+          // test asset is currently available in the test suite.
+          await loadSourceConfig(Sources.artOfMotionHls);
+          await callPlayer(async (player) => {
+            const qualities = await player.getAvailableVideoQualities();
+            if (qualities.length === 0) {
+              throw new Error('Expected at least one available video quality');
+            }
+            qualities.forEach((quality) => {
+              expectValidColorInfo(
+                quality.colorInfo,
+                `VideoQuality ${quality.id}.colorInfo`
+              );
+            });
+          });
+        });
+      }
+    );
+    spec.it(
+      'exposes colorInfo.dynamicRange on the active video quality',
+      async () => {
+        await startPlayerTest({}, async () => {
+          await loadSourceConfig(Sources.artOfMotionHls);
+          // Start playback so that an active video quality is guaranteed to be
+          // resolved before reading it.
+          await playFor(1);
+          await callPlayer(async (player) => {
+            const quality = expectDefined(
+              await player.getVideoQuality(),
+              'Expected an active video quality'
+            );
+            expectValidColorInfo(
+              quality.colorInfo,
+              'Active video quality.colorInfo'
+            );
+          });
+        });
+      }
+    );
+    spec.it(
+      'exposes colorInfo.dynamicRange on VideoPlaybackQualityChangedEvent',
+      async () => {
+        await startPlayerTest({}, async () => {
+          const eventPromise = expectEvent<VideoPlaybackQualityChangedEvent>(
+            EventType.VideoPlaybackQualityChanged,
+            20
+          );
+          await loadSourceConfig(Sources.artOfMotionHls);
+          const event = await eventPromise;
+          expectValidColorInfo(
+            event.newVideoQuality.colorInfo,
+            'VideoPlaybackQualityChangedEvent.newVideoQuality.colorInfo'
+          );
+        });
+      }
+    );
+  });
+};

--- a/ios/RCTConvert+BitmovinPlayer.swift
+++ b/ios/RCTConvert+BitmovinPlayer.swift
@@ -857,12 +857,32 @@ extension RCTConvert {
             "height": videoQuality.height,
             "width": videoQuality.width,
             "bitrate": videoQuality.bitrate,
+            "colorInfo": toJson(colorInfo: videoQuality.colorInfo),
         ]
         if let codec = videoQuality.codec {
             videoQualityDict["codec"] = codec
         }
 
         return videoQualityDict
+    }
+
+    static func toJson(colorInfo: VideoColorInfo) -> [String: Any] {
+        [
+            "dynamicRange": toJson(dynamicRange: colorInfo.dynamicRange),
+        ]
+    }
+
+    static func toJson(dynamicRange: DynamicRange) -> String {
+        switch dynamicRange {
+        case .sdr:
+            return "sdr"
+        case .hdr:
+            return "hdr"
+        case .unknown:
+            return "unknown"
+        @unknown default:
+            return "unknown"
+        }
     }
 
     static func userInterfaceType(_ json: Any?) -> UserInterfaceType? {

--- a/src/dynamicRange.ts
+++ b/src/dynamicRange.ts
@@ -1,0 +1,17 @@
+/**
+ * The dynamic range of a video quality.
+ */
+export enum DynamicRange {
+  /**
+   * Standard Dynamic Range.
+   */
+  SDR = 'sdr',
+  /**
+   * High Dynamic Range.
+   */
+  HDR = 'hdr',
+  /**
+   * The dynamic range could not be determined.
+   */
+  Unknown = 'unknown',
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,4 +31,5 @@ export * from './debug';
 export * from './decoder/decoderConfig';
 export * from './mediaTrackRole';
 export * from './subtitleFormat';
+export * from './dynamicRange';
 export * from './utils/temporal';

--- a/src/media.ts
+++ b/src/media.ts
@@ -1,3 +1,15 @@
+import { DynamicRange } from './dynamicRange';
+
+/**
+ * Color information of a video representation.
+ */
+export interface VideoColorInfo {
+  /**
+   * The dynamic range of the video quality.
+   */
+  dynamicRange: DynamicRange;
+}
+
 /**
  * Quality definition of a video representation.
  */
@@ -30,6 +42,10 @@ export interface VideoQuality {
    * The width of the video quality.
    */
   width?: number;
+  /**
+   * The color information of the video quality.
+   */
+  colorInfo: VideoColorInfo;
 }
 
 /**


### PR DESCRIPTION
## Description

`VideoQuality.colorInfo.dynamicRange` is available on the native players and should be surfaced through React Native.

## Changes

- Added a public `DynamicRange` enum and exported it from `src/index.ts`.
- Added `VideoQuality.colorInfo.dynamicRange` documentation.
- Added Android and iOS/tvOS JSON serialization from native dynamic range values to `colorInfo.dynamicRange` lowercase JS enum values.
- Added integration coverage for `colorInfo.dynamicRange` on available qualities, active quality, and `VideoPlaybackQualityChangedEvent` payloads.

## Notes

- The integration test source may report `DynamicRange.Unknown` when no dynamic range metadata is available, so runtime coverage asserts a defined valid `DynamicRange` enum value; the HDR mapping branch is covered by native mapping code but not by an HDR fixture.

## Checklist
- [x] 🗒 `CHANGELOG` entry




