### PR TITLE
Isolate Android CI Gradle caches

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           path: |
             example/android
-          key: ${{ runner.os }}-android-prebuild-${{ hashFiles('example/yarn.lock', 'example/app.config.*', 'plugin/**', 'android/**') }}
+          key: ${{ runner.os }}-android-prebuild-${{ hashFiles('package.json', 'yarn.lock', 'expo-module.config.json', 'example/package.json', 'example/yarn.lock', 'example/app.config.*', 'plugin/**', 'android/**') }}
           restore-keys: |
             ${{ runner.os }}-android-prebuild-
 
@@ -101,9 +101,9 @@ jobs:
             example/android/.gradle
             example/android/app/build
             example/android/build
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'example/yarn.lock') }}
+          key: ${{ runner.os }}-gradle-example-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'example/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
+            ${{ runner.os }}-gradle-example-
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -155,7 +155,7 @@ jobs:
         with:
           path: |
             integration_test/android
-          key: ${{ runner.os }}-android-integration-prebuild-${{ hashFiles('integration_test/yarn.lock', 'integration_test/app.config.*', 'plugin/**', 'android/**') }}
+          key: ${{ runner.os }}-android-integration-prebuild-${{ hashFiles('package.json', 'yarn.lock', 'expo-module.config.json', 'integration_test/package.json', 'integration_test/yarn.lock', 'integration_test/app.config.*', 'plugin/**', 'android/**') }}
           restore-keys: |
             ${{ runner.os }}-android-integration-prebuild-
 
@@ -172,7 +172,6 @@ jobs:
           key: ${{ runner.os }}-gradle-integration-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'integration_test/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-gradle-integration-
-            ${{ runner.os }}-gradle-
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -224,7 +223,7 @@ jobs:
         with:
           path: |
             example/android
-          key: ${{ runner.os }}-android-tv-prebuild-${{ hashFiles('example/yarn.lock', 'example/app.config.*', 'plugin/**', 'android/**') }}
+          key: ${{ runner.os }}-android-tv-prebuild-${{ hashFiles('package.json', 'yarn.lock', 'expo-module.config.json', 'example/package.json', 'example/yarn.lock', 'example/app.config.*', 'plugin/**', 'android/**') }}
           restore-keys: |
             ${{ runner.os }}-android-tv-prebuild-
 
@@ -241,7 +240,6 @@ jobs:
           key: ${{ runner.os }}-gradle-tv-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'example/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-gradle-tv-
-            ${{ runner.os }}-gradle-
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment


### PR DESCRIPTION
## Description
Android CI jobs currently share a broad Gradle cache fallback. The regular Android example job can restore Android TV or integration test build intermediates, which can leave incompatible generated build outputs in `example/android/app/build`. See [example](https://github.com/bitmovin/bitmovin-player-react-native/actions/runs/30373195998/job/90338549509), [another](https://github.com/bitmovin/bitmovin-player-react-native/actions/runs/29741449012/job/88348906398?pr=1004)

## Changes
- Give the Android example Gradle cache its own `gradle-example` namespace
- Remove broad Gradle cache fallbacks from Android integration and TV jobs
- Include package and Expo module config inputs in Android prebuild cache keys

