### PR TITLE
Simplify Android Gradle caching

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -43,7 +43,7 @@ runs:
 
     - name: Set up Gradle cache
       if: ${{ inputs.java == 'true' }}
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v6
       with:
         cache-read-only: ${{ github.ref != 'refs/heads/development' }}
 

--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -81,16 +81,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Cache Android Prebuild
-        id: android-prebuild-cache
-        uses: actions/cache@v6
-        with:
-          path: |
-            example/android
-          key: ${{ runner.os }}-android-prebuild-${{ hashFiles('package.json', 'yarn.lock', 'expo-module.config.json', 'example/package.json', 'example/yarn.lock', 'example/app.config.*', 'plugin/**', 'android/**') }}
-          restore-keys: |
-            ${{ runner.os }}-android-prebuild-
-
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -99,9 +89,8 @@ jobs:
           subprojects: true
           skip-prebuild: true
 
-      - name: Prebuild Android Example (on cache miss)
-        if: ${{ steps.android-prebuild-cache.outputs.cache-hit != 'true' }}
-        run: .github/scripts/smart-prebuild.sh example
+      - name: Prebuild Android Example
+        run: yarn example prebuild --clean --platform android
 
       - name: Build Android example
         id: build
@@ -118,32 +107,12 @@ jobs:
       - name: Report build time
         run: echo "✅ Build completed in ${{ steps.build.outputs.duration }} seconds"
 
-      - name: Upload build cache artifacts
-        if: success()
-        uses: actions/upload-artifact@v7
-        with:
-          name: android-example-build-cache
-          path: |
-            ~/.gradle/caches/build-cache-*
-            example/android/app/build/intermediates
-          retention-days: 1
-
   test-build-android-integration-tests:
     name: Build Android Integration Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
-      - name: Cache Android Integration Prebuild
-        id: android-integration-prebuild-cache
-        uses: actions/cache@v6
-        with:
-          path: |
-            integration_test/android
-          key: ${{ runner.os }}-android-integration-prebuild-${{ hashFiles('package.json', 'yarn.lock', 'expo-module.config.json', 'integration_test/package.json', 'integration_test/yarn.lock', 'integration_test/app.config.*', 'plugin/**', 'android/**') }}
-          restore-keys: |
-            ${{ runner.os }}-android-integration-prebuild-
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -153,9 +122,8 @@ jobs:
           subprojects: true
           skip-prebuild: true
 
-      - name: Prebuild Android Integration (on cache miss)
-        if: ${{ steps.android-integration-prebuild-cache.outputs.cache-hit != 'true' }}
-        run: .github/scripts/smart-prebuild.sh integration-test
+      - name: Prebuild Android Integration
+        run: yarn integration-test prebuild --clean --platform android
 
       - name: Build Android integration test host app
         id: build
@@ -172,32 +140,12 @@ jobs:
       - name: Report build time
         run: echo "✅ Build completed in ${{ steps.build.outputs.duration }} seconds"
 
-      - name: Upload build cache artifacts
-        if: success()
-        uses: actions/upload-artifact@v7
-        with:
-          name: android-integration-build-cache
-          path: |
-            ~/.gradle/caches/build-cache-*
-            integration_test/android/app/build/intermediates
-          retention-days: 1
-
   test-build-android-tv:
     name: Build Android TV Example App
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-
-      - name: Cache Android TV Prebuild
-        id: android-tv-prebuild-cache
-        uses: actions/cache@v6
-        with:
-          path: |
-            example/android
-          key: ${{ runner.os }}-android-tv-prebuild-${{ hashFiles('package.json', 'yarn.lock', 'expo-module.config.json', 'example/package.json', 'example/yarn.lock', 'example/app.config.*', 'plugin/**', 'android/**') }}
-          restore-keys: |
-            ${{ runner.os }}-android-tv-prebuild-
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -208,9 +156,8 @@ jobs:
           tv: true
           skip-prebuild: true
 
-      - name: Prebuild Android TV Example (on cache miss)
-        if: ${{ steps.android-tv-prebuild-cache.outputs.cache-hit != 'true' }}
-        run: .github/scripts/smart-prebuild.sh example tv
+      - name: Prebuild Android TV Example
+        run: yarn example prebuild:tv --clean --platform android
 
       - name: Build Android TV example
         id: build
@@ -226,13 +173,3 @@ jobs:
 
       - name: Report build time
         run: echo "✅ Build completed in ${{ steps.build.outputs.duration }} seconds"
-
-      - name: Upload build cache artifacts
-        if: success()
-        uses: actions/upload-artifact@v7
-        with:
-          name: android-tv-build-cache
-          path: |
-            ~/.gradle/caches/build-cache-*
-            example/android/app/build/intermediates
-          retention-days: 1

--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -91,20 +91,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-android-prebuild-
 
-      - name: Setup Gradle Build Cache
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ${{ github.workspace }}/.gradle-ci
-            example/android/.gradle
-            example/android/app/build
-            example/android/build
-          key: ${{ runner.os }}-gradle-example-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'example/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-example-
-
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -159,20 +145,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-android-integration-prebuild-
 
-      - name: Setup Gradle Build Cache
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ${{ github.workspace }}/.gradle-ci
-            integration_test/android/.gradle
-            integration_test/android/app/build
-            integration_test/android/build
-          key: ${{ runner.os }}-gradle-integration-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'integration_test/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-integration-
-
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -226,20 +198,6 @@ jobs:
           key: ${{ runner.os }}-android-tv-prebuild-${{ hashFiles('package.json', 'yarn.lock', 'expo-module.config.json', 'example/package.json', 'example/yarn.lock', 'example/app.config.*', 'plugin/**', 'android/**') }}
           restore-keys: |
             ${{ runner.os }}-android-tv-prebuild-
-
-      - name: Setup Gradle Build Cache
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ${{ github.workspace }}/.gradle-ci
-            example/android/.gradle
-            example/android/app/build
-            example/android/build
-          key: ${{ runner.os }}-gradle-tv-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'example/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-tv-
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment

--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           path: |
             example/android
-          key: ${{ runner.os }}-android-prebuild-${{ hashFiles('example/yarn.lock', 'example/app.config.*', 'plugin/**', 'android/**') }}
+          key: ${{ runner.os }}-android-prebuild-${{ hashFiles('package.json', 'yarn.lock', 'expo-module.config.json', 'example/package.json', 'example/yarn.lock', 'example/app.config.*', 'plugin/**', 'android/**') }}
           restore-keys: |
             ${{ runner.os }}-android-prebuild-
 
@@ -101,9 +101,9 @@ jobs:
             example/android/.gradle
             example/android/app/build
             example/android/build
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'example/yarn.lock') }}
+          key: ${{ runner.os }}-gradle-example-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'example/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
+            ${{ runner.os }}-gradle-example-
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -155,7 +155,7 @@ jobs:
         with:
           path: |
             integration_test/android
-          key: ${{ runner.os }}-android-integration-prebuild-${{ hashFiles('integration_test/yarn.lock', 'integration_test/app.config.*', 'plugin/**', 'android/**') }}
+          key: ${{ runner.os }}-android-integration-prebuild-${{ hashFiles('package.json', 'yarn.lock', 'expo-module.config.json', 'integration_test/package.json', 'integration_test/yarn.lock', 'integration_test/app.config.*', 'plugin/**', 'android/**') }}
           restore-keys: |
             ${{ runner.os }}-android-integration-prebuild-
 
@@ -172,7 +172,6 @@ jobs:
           key: ${{ runner.os }}-gradle-integration-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'integration_test/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-gradle-integration-
-            ${{ runner.os }}-gradle-
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -224,7 +223,7 @@ jobs:
         with:
           path: |
             example/android
-          key: ${{ runner.os }}-android-tv-prebuild-${{ hashFiles('example/yarn.lock', 'example/app.config.*', 'plugin/**', 'android/**') }}
+          key: ${{ runner.os }}-android-tv-prebuild-${{ hashFiles('package.json', 'yarn.lock', 'expo-module.config.json', 'example/package.json', 'example/yarn.lock', 'example/app.config.*', 'plugin/**', 'android/**') }}
           restore-keys: |
             ${{ runner.os }}-android-tv-prebuild-
 
@@ -241,7 +240,6 @@ jobs:
           key: ${{ runner.os }}-gradle-tv-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'example/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-gradle-tv-
-            ${{ runner.os }}-gradle-
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment


### PR DESCRIPTION
## Description

Simplifies Android CI caching by using Gradle's supported cache integration and generating clean Android projects with Expo before each build.

## Changes

- Remove manual Gradle `actions/cache` steps from Android build jobs
- Remove Expo prebuild caches for generated native projects
- Generate only the required Android projects with `expo prebuild --clean --platform android`
- Remove unused build-cache artifact uploads
- Let `gradle/actions/setup-gradle` own Gradle cache handling
- Update `gradle/actions/setup-gradle` from v4 to v6

## Validation

- Verified the example, integration-test, and Android TV prebuild commands route to Expo CLI
- Checked the workflow with Prettier and YAML assertions
