### PR TITLE
Prevent iOS startup crash without Google Cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- iOS: Prevent startup crashes when Google Cast is not configured
+
 ## [1.24.0] - 2026-07-31
 
 ### Added

--- a/ios/AppLifecycleDelegate.swift
+++ b/ios/AppLifecycleDelegate.swift
@@ -17,12 +17,10 @@ public class AppLifecycleDelegate: ExpoAppDelegateSubscriber {
         }
 
         // Only initialize Cast when it is configured via the Expo plugin.
-        if infoDictionary["BitmovinPlayerGoogleCastApplicationId"] is String,
+        if let applicationId = infoDictionary["BitmovinPlayerGoogleCastApplicationId"] as? String,
            !BitmovinCastManager.isInitialized() {
             let options = BitmovinCastManagerOptions()
-            if let applicationId = infoDictionary["BitmovinPlayerGoogleCastApplicationId"] as? String {
-                options.applicationId = applicationId
-            }
+            options.applicationId = applicationId
             if let messageNamespace = infoDictionary["BitmovinPlayerGoogleCastMessageNamespace"] as? String {
                 options.messageNamespace = messageNamespace
             }

--- a/ios/AppLifecycleDelegate.swift
+++ b/ios/AppLifecycleDelegate.swift
@@ -16,7 +16,7 @@ public class AppLifecycleDelegate: ExpoAppDelegateSubscriber {
             OfflineManager.initializeOfflineManager()
         }
 
-        // Only initialize Cast when it is configured via the Expo plugin.
+        // The Cast SDK is optional; only attempt initialization when Cast configuration is present.
         if let applicationId = infoDictionary["BitmovinPlayerGoogleCastApplicationId"] as? String,
            !BitmovinCastManager.isInitialized() {
             let options = BitmovinCastManagerOptions()

--- a/ios/AppLifecycleDelegate.swift
+++ b/ios/AppLifecycleDelegate.swift
@@ -16,7 +16,9 @@ public class AppLifecycleDelegate: ExpoAppDelegateSubscriber {
             OfflineManager.initializeOfflineManager()
         }
 
-        if !BitmovinCastManager.isInitialized() {
+        // Only initialize Cast when it is configured via the Expo plugin.
+        if infoDictionary["BitmovinPlayerGoogleCastApplicationId"] is String,
+           !BitmovinCastManager.isInitialized() {
             let options = BitmovinCastManagerOptions()
             if let applicationId = infoDictionary["BitmovinPlayerGoogleCastApplicationId"] as? String {
                 options.applicationId = applicationId


### PR DESCRIPTION
## Description

Apps that do not configure Google Cast can crash during iOS startup because `AppLifecycleDelegate` invokes `BitmovinCastManager` even though the `google-cast-sdk` pod is optional.

## Changes

- Guard Cast manager initialization on the existing Google Cast application-ID Info.plist marker.
- Preserve Cast initialization and configured options when Google Cast is enabled.
- Add an unreleased changelog entry.

## Validation

- Podspec syntax and whitespace validation passed.
- SwiftLint could not complete because the environment could not save its temporary plist and reports unrelated existing violations.
- TypeScript checks were unavailable because dependencies are not installed in the checkout.
- No native XCTest or plugin test harness exists for this app-delegate startup path.

## Checklist

- [x] 🗒 `CHANGELOG` entry
