### PR TITLE
Enable trusted npm publishing

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Setup node and install root node modules
     default: false
     required: false
+  node-version:
+    description: Node.js version to use when setting up node
+    default: '20'
+    required: false
   subprojects:
     description: Setup node and install root and subproject node modules (overrides `node` input)
     default: false
@@ -51,7 +55,7 @@ runs:
       if: ${{ inputs.node == 'true' || inputs.subprojects == 'true' }}
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: ${{ inputs['node-version'] }}
         registry-url: 'https://registry.npmjs.org/'
         cache: 'yarn'
 

--- a/.github/workflows/finish-release-train.yml
+++ b/.github/workflows/finish-release-train.yml
@@ -111,6 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -135,14 +136,13 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           node: true
+          node-version: '24'
 
       - name: Build TypeScript files
         run: yarn build
 
       - name: Publish npm package
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Extract changelog
         id: changelog


### PR DESCRIPTION
## Description
Enable npm trusted publishing for the stable release workflow.

npm package settings still need the trusted publisher configured for:
- owner/repo: `bitmovin/bitmovin-player-react-native`
- workflow: `finish-release-train.yml`

Alpha publishing is intentionally unchanged/out of scope.

## Changes
- Grant `id-token: write` to the stable publish job.
- Use Node 24 for the stable publish job so npm OIDC publishing is supported.
- Remove `NODE_AUTH_TOKEN` from stable `npm publish`.
- Add a `node-version` input to the shared setup action, defaulting to Node 20 for existing jobs.

## Checklist
- [x] 🗒 `CHANGELOG` entry not needed (CI-only change)
