### PR TITLE
Migrate iOS SDK dependencies to Swift Package Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 
 - Update Bitmovin's native iOS SDK version to [`3.119.0`](https://developer.bitmovin.com/playback/docs/release-notes-ios#31190)
+- iOS/tvOS: Resolve the Bitmovin Player and Google IMA SDKs through Swift Package Manager instead of CocoaPods
+- Update Google IMA to `3.31.0` on iOS and `4.16.0` on tvOS
 
 ## [1.24.0] - 2026-07-31
 

--- a/ios/RNBitmovinPlayer.podspec
+++ b/ios/RNBitmovinPlayer.podspec
@@ -28,9 +28,34 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency "BitmovinPlayer", "3.119.0"
-  s.ios.dependency "GoogleAds-IMA-iOS-SDK", "3.26.1"
-  s.tvos.dependency "GoogleAds-IMA-tvOS-SDK", "4.15.1"
+
+  unless respond_to?(:spm_dependency, true)
+    raise 'RNBitmovinPlayer requires React Native >=0.75.0 because it uses Swift Package Manager dependencies.'
+  end
+
+  spm_dependency(
+    s,
+    url: 'https://github.com/bitmovin/player-ios.git',
+    requirement: { kind: 'exactVersion', version: '3.119.0' },
+    products: ['BitmovinPlayer']
+  )
+
+  is_tvos = podfile_properties['BITMOVIN_APPLE_PLATFORM'] == 'tvos'
+  if is_tvos
+    spm_dependency(
+      s,
+      url: 'https://github.com/googleads/swift-package-manager-google-interactive-media-ads-tvos',
+      requirement: { kind: 'exactVersion', version: '4.16.0' },
+      products: ['GoogleInteractiveMediaAdsTvOS']
+    )
+  else
+    spm_dependency(
+      s,
+      url: 'https://github.com/googleads/swift-package-manager-google-interactive-media-ads-ios',
+      requirement: { kind: 'exactVersion', version: '3.31.0' },
+      products: ['GoogleInteractiveMediaAds']
+    )
+  end
 
   if podfile_properties['BITMOVIN_GOOGLE_CAST_SDK_VERSION'].to_s != ''
     s.ios.dependency "google-cast-sdk", podfile_properties['BITMOVIN_GOOGLE_CAST_SDK_VERSION'].to_s

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmovin-player-react-native",
-  "version": "1.24.0",
+  "version": "1.25.0-alpha.0",
   "description": "Official React Native bindings for Bitmovin's mobile Player SDKs.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/plugin/src/withBitmovinIosConfig.ts
+++ b/plugin/src/withBitmovinIosConfig.ts
@@ -91,17 +91,16 @@ const withBitmovinIosConfig: ConfigPlugin<BitmovinConfigOptions> = (
     return config;
   });
 
-  if (!isTV) {
-    config = withPodfileProperties(config, (config) => {
-      if (googleCastVersion != null) {
-        config.modResults['BITMOVIN_GOOGLE_CAST_SDK_VERSION'] =
-          googleCastVersion;
-      } else {
-        delete config.modResults['BITMOVIN_GOOGLE_CAST_SDK_VERSION'];
-      }
-      return config;
-    });
-  }
+  config = withPodfileProperties(config, (config) => {
+    config.modResults['BITMOVIN_APPLE_PLATFORM'] = isTV ? 'tvos' : 'ios';
+    if (!isTV && googleCastVersion != null) {
+      config.modResults['BITMOVIN_GOOGLE_CAST_SDK_VERSION'] =
+        googleCastVersion;
+    } else {
+      delete config.modResults['BITMOVIN_GOOGLE_CAST_SDK_VERSION'];
+    }
+    return config;
+  });
 
   return config;
 };


### PR DESCRIPTION
## Description

Cocoapods is sunsetting by the end of this year and we (and Google) will stop publishing our frameworks for cocoapods. Therefore we need to migrate to SPM.

## Changes

- Resolve Bitmovin Player `3.119.0` through React Native's Swift Package Manager integration.
- Resolve Google IMA `3.31.0` on iOS and `4.16.0` on tvOS through Swift Package Manager.
- Pass the generated Apple platform through `Podfile.properties.json` so the podspec selects the correct IMA package and product.
- Keep Expo, React Native, the React Native bridges, and Google Cast on CocoaPods.
- Align the IMA versions with the native Google DAI integration so SwiftPM resolves one Player and IMA dependency graph.

## Checklist
- [x] 🗒 `CHANGELOG` entry