### PR TITLE
Update Apple CI to Xcode 26.6 and Swift 6.3.3

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -108,7 +108,14 @@ runs:
     - uses: maxim-lobanov/setup-xcode@v1
       if: ${{ inputs.ios == 'true' }}
       with:
-        xcode-version: '16.4'
+        xcode-version: '26.6' # Includes the Swift 6.3.3 compiler.
+
+    - name: Show Apple toolchain versions
+      if: ${{ inputs.ios == 'true' }}
+      shell: bash
+      run: |
+        xcodebuild -version
+        xcrun swift --version
 
     - name: Install dependencies
       if: ${{ inputs.ios == 'true' || inputs.brew == 'true' }}

--- a/.github/workflows/ci-ios-tvos.yml
+++ b/.github/workflows/ci-ios-tvos.yml
@@ -84,7 +84,7 @@ jobs:
 
   ios-example-build:
     name: Build iOS Example App
-    runs-on: macOS-15
+    runs-on: macos-26
     timeout-minutes: 25
     steps:
       - name: Checkout
@@ -138,7 +138,7 @@ jobs:
 
   ios-integration-build:
     name: Build iOS Integration Tests
-    runs-on: macOS-15
+    runs-on: macos-26
     timeout-minutes: 25
     steps:
       - name: Checkout
@@ -192,7 +192,7 @@ jobs:
 
   tvos-example-build:
     name: Build tvOS Example App
-    runs-on: macOS-15
+    runs-on: macos-26
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ Before creating a pull request, please
 
 If this is your first React Native project, setup your React Native development environment for both Android and iOS as described [here](https://reactnative.dev/docs/set-up-your-environment).
 
+For iOS and tvOS development, use Xcode 26.6, which includes the Swift 6.3.3 compiler, to match CI. Xcode 26.6 requires macOS Tahoe 26.2 or later. The native bridge remains in Swift 5 language mode (`s.swift_version = '5.10'`); this toolchain update does not enable Swift 6 language mode.
+
 To get started with the project, run `yarn bootstrap` in the root directory to install the required dependencies for each package and cocoapods dependencies for the example app:
 
 ```sh


### PR DESCRIPTION
## Description

This PR aligns Apple CI with Xcode 26.6 and its bundled Swift 6.3.3 compiler. 

## Changes
- Pin the shared Apple setup action to Xcode 26.6 and print the selected Xcode and Swift versions.
- Move the iOS example, iOS integration-test build, and tvOS example jobs to macOS 26 runners, which provide Xcode 26.6.
- Document the development toolchain and its macOS requirement.
- Keep the native bridge in Swift 5 language mode; this does not enable Swift 6 language mode or change deployment targets.
